### PR TITLE
Fix file rights for ossec-remoted

### DIFF
--- a/ansible-wazuh-manager/tasks/main.yml
+++ b/ansible-wazuh-manager/tasks/main.yml
@@ -63,6 +63,19 @@
   tags:
     - config
 
+- name: Ensure file access for ossec-remoted
+  file:
+      path: "{{ item }}"
+      state: touch
+      owner: ossecr
+      group: ossec
+      mode: 0644
+  with_items:
+    - "/var/ossec/etc/shared/merged.mg"
+    - "/var/ossec/queue/rids/sender_counter"
+   tags:
+    - config
+    
 - name: Installing the local_rules.xml (default local_rules.xml)
   template: src=var-ossec-rules-local_rules.xml.j2
             dest=/var/ossec/etc/rules/local_rules.xml


### PR DESCRIPTION
ossec-remoted did not start due to following errors

~~~
ossec-remoted: ERROR: Unable to create merged file: '/etc/shared/merged.mg'

ossec-remoted: ERROR: Unable to open agent file. errno: 13
ossec-remoted: CRITICAL: (1103): Could not open file '/queue/rids/sender_counter' due to [(13)-(Permission denied)].
~~~