### PR TITLE
Wrong example for Windows localfiles

### DIFF
--- a/ansible-wazuh-manager/defaults/main.yml
+++ b/ansible-wazuh-manager/defaults/main.yml
@@ -232,7 +232,7 @@ wazuh_agent_configs:
           arch: 'both'
         - key: 'HKEY_LOCAL_MACHINE\Software\Classes\Folder'
     localfiles:
-      - format: 'Security'
-        location: 'eventchannel'
-      - format: 'System'
-        location: 'eventlog'
+      - location: 'Security'
+        format: 'eventchannel'
+      - location: 'System'
+        format: 'eventlog'


### PR DESCRIPTION
`log_format` and `location` were inverted causing failure at startup

~~~
2018/03/01 16:57:41 ossec-agent: ERROR: (1235): Invalid value for element 'log_format': Security.
2018/03/01 16:57:41 ossec-agent: ERROR: (1202): Configuration error at 'shared/agent.conf'. Exiting.
~~~
