### PR TITLE
Fix "changed" result on the checking version task

### DIFF
--- a/ansible-role-kibana/tasks/main.yml
+++ b/ansible-role-kibana/tasks/main.yml
@@ -28,6 +28,7 @@
   args:
     removes: /usr/share/kibana/plugins/wazuh/package.json
   register: wazuh_app_verify
+  changed_when: False
   tags: install
 
 - name: Removing old Wazuh-APP


### PR DESCRIPTION
There's no need to produce a "changed" result on the "Checking Wazuh-APP version" task