### PR TITLE
Implement Linux agent registration via restapi

### DIFF
--- a/ansible-wazuh-agent/README.md
+++ b/ansible-wazuh-agent/README.md
@@ -25,19 +25,23 @@ Playbook example
 
 The following is an example how this role can be used:
 
-    - hosts: all:!wazuh-manager
-      roles:
-        - ansible-wazuh-agent
-      vars:
-        wazuh_managers:
-          - address: 127.0.0.1
-            port: 1514
-            protocol: udp
-        wazuh_agent_authd:
-          enable: true
-          port: 1515
-          ssl_agent_ca: null
-          ssl_auto_negotiate: 'no'
+     - hosts: all:!wazuh-manager
+       roles:
+         - ansible-wazuh-agent
+       vars:
+         wazuh_managers:
+           - address: 127.0.0.1
+             port: 1514
+             protocol: udp
+             api_port: 55000
+             api_proto: 'http'
+             api_user: 'ansible'
+         wazuh_agent_authd:
+           enable: true
+           port: 1515
+           ssl_agent_ca: null
+           ssl_auto_negotiate: 'no'
+     
 
 License and copyright
 ---------------------

--- a/ansible-wazuh-agent/defaults/main.yml
+++ b/ansible-wazuh-agent/defaults/main.yml
@@ -3,6 +3,10 @@ wazuh_managers:
   - address: 127.0.0.1
     port: 1514
     protocol: tcp
+    api_port: 55000
+    api_proto: 'https'
+    api_user: null
+    api_password: null
 wazuh_profile: null
 wazuh_auto_restart: 'yes'
 wazuh_agent_authd:

--- a/ansible-wazuh-agent/defaults/main.yml
+++ b/ansible-wazuh-agent/defaults/main.yml
@@ -4,9 +4,8 @@ wazuh_managers:
     port: 1514
     protocol: tcp
     api_port: 55000
-    api_proto: 'https'
+    api_proto: 'http'
     api_user: null
-    api_password: null
 wazuh_profile: null
 wazuh_auto_restart: 'yes'
 wazuh_agent_authd:

--- a/ansible-wazuh-agent/tasks/Linux.yml
+++ b/ansible-wazuh-agent/tasks/Linux.yml
@@ -74,8 +74,8 @@
 - name: Linux | Agent registration via rest-API
   block:
 
-    - name: Retrieving authd Credentials
-      include_vars: authd_pass.yml
+    - name: Retrieving rest-API Credentials
+      include_vars: api_pass.yml
       tags:
         - config
         - api

--- a/ansible-wazuh-agent/tasks/Linux.yml
+++ b/ansible-wazuh-agent/tasks/Linux.yml
@@ -23,6 +23,7 @@
       include_vars: authd_pass.yml
       tags:
         - config
+        - authd
 
     - name: Copy CA, SSL key and cert for authd
       copy:
@@ -35,6 +36,7 @@
         - "{{ wazuh_agent_authd.ssl_agent_key }}"
       tags:
         - config
+        - authd
       when:
         - wazuh_agent_authd.ssl_agent_ca is not none
 
@@ -56,6 +58,7 @@
         - wazuh_managers.0.address is not none
       tags:
         - config
+        - authd
 
     - name: Linux | Verify agent registration
       shell: echo {{ agent_auth_output }} | grep "Valid key created"
@@ -64,11 +67,18 @@
         - wazuh_managers.0.address is not none
       tags:
         - config
+        - authd
 
   when: wazuh_agent_authd.enable == true
 
 - name: Linux | Agent registration via rest-API
   block:
+
+    - name: Retrieving authd Credentials
+      include_vars: authd_pass.yml
+      tags:
+        - config
+        - api
 
     - name: Linux | Create the agent key via rest-API
       uri:
@@ -81,7 +91,7 @@
         headers:
           Content-Type: "application/json"
         user: "{{ wazuh_managers.0.api_user }}"
-        password: "{{ wazuh_managers.0.api_password }}"
+        password: "{{ api_pass }}"
       register: newagent_api
       changed_when: newagent_api.json.error == 0
       when:
@@ -100,7 +110,7 @@
         method: GET
         return_content: yes
         user: "{{ wazuh_managers.0.api_user }}"
-        password: "{{ wazuh_managers.0.api_password }}"
+        password: "{{ api_pass }}"
       when:
         - check_keys.stat.size == 0
         - wazuh_managers.0.address is not none
@@ -128,9 +138,10 @@
         - newagent_api.changed
       tags:
         - config
+        - api
       notify: restart wazuh-agent
 
-  when: wazuh_agent_authd.enable == false
+  when: wazuh_agent_authd.enable == false and ( wazuh_managers.0.api_user is defined and api_pass is defined )
 
 - name: Linux | Vuls integration deploy (runs in background, can take a while)
   command: /var/ossec/wodles/vuls/deploy_vuls.sh {{ ansible_distribution|lower }} {{ ansible_distribution_major_version|int }}

--- a/ansible-wazuh-agent/tasks/Linux.yml
+++ b/ansible-wazuh-agent/tasks/Linux.yml
@@ -85,7 +85,7 @@
         url: "{{ wazuh_managers.0.api_proto }}://{{ wazuh_managers.0.address }}:{{ wazuh_managers.0.api_port }}/agents/"
         validate_certs: no
         method: POST
-        body: {"name":"{{ inventory_hostname }}","ip":"{{ ansible_default_ipv4.address }}"}
+        body: {"name":"{{ inventory_hostname }}"}
         body_format: json
         status_code: 200
         headers:
@@ -97,17 +97,14 @@
       when:
         - check_keys.stat.size == 0
         - wazuh_managers.0.address is not none
-        - wazuh_managers.0.api_user is not none
-        - api_pass is not none
-      delegate_to: localhost
       become: no
       tags:
         - config
         - api
 
-    - name: Linux | Retieve the client key via rest-API
+    - name: Linux | Retieve new agent data via rest-API
       uri:
-        url: "{{ wazuh_managers.0.api_proto }}://{{ wazuh_managers.0.address }}:{{ wazuh_managers.0.api_port }}/agents/{{ newagent_api.json.data.id }}/key"
+        url: "{{ wazuh_managers.0.api_proto }}://{{ wazuh_managers.0.address }}:{{ wazuh_managers.0.api_port }}/agents/{{ newagent_api.json.data.id }}"
         validate_certs: no
         method: GET
         return_content: yes
@@ -116,10 +113,8 @@
       when:
         - check_keys.stat.size == 0
         - wazuh_managers.0.address is not none
-        - wazuh_managers.0.api_user is not none
-        - api_pass is not none
         - newagent_api.json.error == 0
-      register: newagentkey_api
+      register: newagentdata_api
       delegate_to: localhost
       become: no
       tags:
@@ -130,10 +125,10 @@
       command: /var/ossec/bin/manage_agents
       environment:
         OSSEC_ACTION: i
-        OSSEC_AGENT_NAME: '{{ inventory_hostname }}'
-        OSSEC_AGENT_IP: '{{ ansible_default_ipv4.address }}'
+        OSSEC_AGENT_NAME: '{{ newagentdata_api.json.data.name }}'
+        OSSEC_AGENT_IP: '{{ newagentdata_api.json.data.ip }}'
         OSSEC_AGENT_ID: '{{ newagent_api.json.data.id }}'
-        OSSEC_AGENT_KEY: '{{ newagentkey_api.json.data }}'
+        OSSEC_AGENT_KEY: '{{ newagent_api.json.data.key }}'
         OSSEC_ACTION_CONFIRMED: y
       register: manage_agents_output
       when:

--- a/ansible-wazuh-agent/tasks/Linux.yml
+++ b/ansible-wazuh-agent/tasks/Linux.yml
@@ -97,6 +97,8 @@
       when:
         - check_keys.stat.size == 0
         - wazuh_managers.0.address is not none
+        - wazuh_managers.0.api_user is not none
+        - api_pass is not none
       delegate_to: localhost
       become: no
       tags:
@@ -114,6 +116,8 @@
       when:
         - check_keys.stat.size == 0
         - wazuh_managers.0.address is not none
+        - wazuh_managers.0.api_user is not none
+        - api_pass is not none
         - newagent_api.json.error == 0
       register: newagentkey_api
       delegate_to: localhost
@@ -141,7 +145,7 @@
         - api
       notify: restart wazuh-agent
 
-  when: wazuh_agent_authd.enable == false and ( wazuh_managers.0.api_user is defined and api_pass is defined )
+  when: wazuh_agent_authd.enable == false
 
 - name: Linux | Vuls integration deploy (runs in background, can take a while)
   command: /var/ossec/wodles/vuls/deploy_vuls.sh {{ ansible_distribution|lower }} {{ ansible_distribution_major_version|int }}

--- a/ansible-wazuh-agent/tasks/Linux.yml
+++ b/ansible-wazuh-agent/tasks/Linux.yml
@@ -10,60 +10,127 @@
   tags:
     - init
 
-- name: Retrieving authd Credentials
-  include_vars: authd_pass.yml
-  tags:
-    - config
-
-- name: Copy CA, SSL key and cert for authd
-  copy:
-    src: "{{ item }}"
-    dest: "/var/ossec/etc/{{ item | basename }}"
-    mode: 0644
-  with_items:
-    - "{{ wazuh_agent_authd.ssl_agent_ca }}"
-    - "{{ wazuh_agent_authd.ssl_agent_cert }}"
-    - "{{ wazuh_agent_authd.ssl_agent_key }}"
-  tags:
-    - config
-  when:
-    - wazuh_agent_authd.ssl_agent_ca is not none
-    - wazuh_agent_authd.enable == true
-
 - name: Linux | Check if client.keys exists
   stat: path=/var/ossec/etc/client.keys
   register: check_keys
   tags:
     - config
 
-- name: Linux | Register agent
-  shell: >
-    /var/ossec/bin/agent-auth
-    -m {{ wazuh_managers.0.address }}
-    -p {{ wazuh_agent_authd.port }}
-    {% if authd_pass is defined %}-P {{ authd_pass }}{% endif %}
-    {% if wazuh_agent_authd.ssl_agent_ca is not none %}
-    -v "/var/ossec/etc/{{ wazuh_agent_authd.ssl_agent_ca | basename }}"
-    -x "/var/ossec/etc/{{ wazuh_agent_authd.ssl_agent_cert | basename }}"
-    -k "/var/ossec/etc/{{ wazuh_agent_authd.ssl_agent_key | basename }}"
-    {% endif %}
-    {% if wazuh_agent_authd.ssl_auto_negotiate == 'yes' %}-a{% endif %}
-  register: agent_auth_output
-  when:
-    - wazuh_agent_authd.enable == true
-    - check_keys.stat.size == 0
-    - wazuh_managers.0.address is not none
-  tags:
-    - config
+- name: Linux | Agent registration via authd
+  block:
 
-- name: Linux | Verify agent registration
-  shell: echo {{ agent_auth_output }} | grep "Valid key created"
-  when:
-    - wazuh_agent_authd.enable == true
-    - check_keys.stat.size == 0
-    - wazuh_managers.0.address is not none
-  tags:
-    - config
+    - name: Retrieving authd Credentials
+      include_vars: authd_pass.yml
+      tags:
+        - config
+
+    - name: Copy CA, SSL key and cert for authd
+      copy:
+        src: "{{ item }}"
+        dest: "/var/ossec/etc/{{ item | basename }}"
+        mode: 0644
+      with_items:
+        - "{{ wazuh_agent_authd.ssl_agent_ca }}"
+        - "{{ wazuh_agent_authd.ssl_agent_cert }}"
+        - "{{ wazuh_agent_authd.ssl_agent_key }}"
+      tags:
+        - config
+      when:
+        - wazuh_agent_authd.ssl_agent_ca is not none
+
+    - name: Linux | Register agent (via authd)
+      shell: >
+        /var/ossec/bin/agent-auth
+        -m {{ wazuh_managers.0.address }}
+        -p {{ wazuh_agent_authd.port }}
+        {% if authd_pass is defined %}-P {{ authd_pass }}{% endif %}
+        {% if wazuh_agent_authd.ssl_agent_ca is not none %}
+        -v "/var/ossec/etc/{{ wazuh_agent_authd.ssl_agent_ca | basename }}"
+        -x "/var/ossec/etc/{{ wazuh_agent_authd.ssl_agent_cert | basename }}"
+        -k "/var/ossec/etc/{{ wazuh_agent_authd.ssl_agent_key | basename }}"
+        {% endif %}
+        {% if wazuh_agent_authd.ssl_auto_negotiate == 'yes' %}-a{% endif %}
+      register: agent_auth_output
+      when:
+        - check_keys.stat.size == 0
+        - wazuh_managers.0.address is not none
+      tags:
+        - config
+
+    - name: Linux | Verify agent registration
+      shell: echo {{ agent_auth_output }} | grep "Valid key created"
+      when:
+        - check_keys.stat.size == 0
+        - wazuh_managers.0.address is not none
+      tags:
+        - config
+
+  when: wazuh_agent_authd.enable == true
+
+- name: Linux | Agent registration via rest-API
+  block:
+
+    - name: Linux | Create the agent key via rest-API
+      uri:
+        url: "{{ wazuh_managers.0.api_proto }}://{{ wazuh_managers.0.address }}:{{ wazuh_managers.0.api_port }}/agents/"
+        validate_certs: no
+        method: POST
+        body: {"name":"{{ inventory_hostname }}","ip":"{{ ansible_default_ipv4.address }}"}
+        body_format: json
+        status_code: 200
+        headers:
+          Content-Type: "application/json"
+        user: "{{ wazuh_managers.0.api_user }}"
+        password: "{{ wazuh_managers.0.api_password }}"
+      register: newagent_api
+      changed_when: newagent_api.json.error == 0
+      when:
+        - check_keys.stat.size == 0
+        - wazuh_managers.0.address is not none
+      delegate_to: localhost
+      become: no
+      tags:
+        - config
+        - api
+
+    - name: Linux | Retieve the client key via rest-API
+      uri:
+        url: "{{ wazuh_managers.0.api_proto }}://{{ wazuh_managers.0.address }}:{{ wazuh_managers.0.api_port }}/agents/{{ newagent_api.json.data.id }}/key"
+        validate_certs: no
+        method: GET
+        return_content: yes
+        user: "{{ wazuh_managers.0.api_user }}"
+        password: "{{ wazuh_managers.0.api_password }}"
+      when:
+        - check_keys.stat.size == 0
+        - wazuh_managers.0.address is not none
+        - newagent_api.json.error == 0
+      register: newagentkey_api
+      delegate_to: localhost
+      become: no
+      tags:
+        - config
+        - api
+
+    - name: Linux | Register agent (via rest-API)
+      command: /var/ossec/bin/manage_agents
+      environment:
+        OSSEC_ACTION: i
+        OSSEC_AGENT_NAME: '{{ inventory_hostname }}'
+        OSSEC_AGENT_IP: '{{ ansible_default_ipv4.address }}'
+        OSSEC_AGENT_ID: '{{ newagent_api.json.data.id }}'
+        OSSEC_AGENT_KEY: '{{ newagentkey_api.json.data }}'
+        OSSEC_ACTION_CONFIRMED: y
+      register: manage_agents_output
+      when:
+        - check_keys.stat.size == 0
+        - wazuh_managers.0.address is not none
+        - newagent_api.changed
+      tags:
+        - config
+      notify: restart wazuh-agent
+
+  when: wazuh_agent_authd.enable == false
 
 - name: Linux | Vuls integration deploy (runs in background, can take a while)
   command: /var/ossec/wodles/vuls/deploy_vuls.sh {{ ansible_distribution|lower }} {{ ansible_distribution_major_version|int }}

--- a/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
+++ b/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
@@ -1,4 +1,5 @@
 #jinja2: trim_blocks: False
+<!-- {{ ansible_managed }} -->
 <!--
   Wazuh - Agent
   More info at: https://documentation.wazuh.com

--- a/ansible-wazuh-agent/vars/api_pass.yml
+++ b/ansible-wazuh-agent/vars/api_pass.yml
@@ -1,3 +1,3 @@
 ---
 # We recommend the use of Ansible Vault to protect Wazuh, api, agentless and authd credentials.
-#authd_pass: 'foobar'
+#api_pass: 'changeme'

--- a/wazuh-agent.yml
+++ b/wazuh-agent.yml
@@ -7,9 +7,8 @@
         port: 1514
         protocol: udp
         api_port: 55000
-        api_proto: 'https'
+        api_proto: 'http'
         api_user: ansible
-        api_password: changeme
     wazuh_agent_authd:
       enable: true
       port: 1515

--- a/wazuh-agent.yml
+++ b/wazuh-agent.yml
@@ -6,6 +6,10 @@
       - address: 127.0.0.1
         port: 1514
         protocol: udp
+        api_port: 55000
+        api_proto: 'https'
+        api_user: ansible
+        api_password: changeme
     wazuh_agent_authd:
       enable: true
       port: 1515


### PR DESCRIPTION
This PR will help to register new wazuh-agent using the **restapi** instead of _authd_. 
The registration steps are:
- add a new agent entry on the manger via api
- retrieve the key via api
- register the agent using `manage_agents` in unattended-mode

N.B.: in this case Ansible management host should be able to remote connect to the wazuh-api but it should be also possible to change `delegate_to` parameter with the wazuh-manager host so that there will be no need to expose the api port remotely (apart from the kibana host)