### PR TITLE
Fix RedHat/CentOS 5 wazuh-agent setup

### DIFF
--- a/ansible-wazuh-agent/tasks/RedHat.yml
+++ b/ansible-wazuh-agent/tasks/RedHat.yml
@@ -17,7 +17,7 @@
     gpgkey: https://packages.wazuh.com/key/GPG-KEY-WAZUH-5
     gpgcheck: yes
   when:
-    - ansible_distribution_major_version|int <= 5
+    - ansible_distribution_major_version|int = 5
 
 - name: RedHat/CentOS/Fedora | download Oracle Java RPM
   get_url:

--- a/ansible-wazuh-agent/tasks/RedHat.yml
+++ b/ansible-wazuh-agent/tasks/RedHat.yml
@@ -14,10 +14,10 @@
     name: wazuh_repo
     description: Wazuh repository
     baseurl: https://packages.wazuh.com/3.x/yum/5/
-    gpgkey: https://packages.wazuh.com/key/GPG-KEY-WAZUH
+    gpgkey: https://packages.wazuh.com/key/RPM-GPG-KEY-OSSEC-RHEL5
     gpgcheck: yes
   when:
-    - ansible_distribution_major_version|int < 5
+    - ansible_distribution_major_version|int <= 5
 
 - name: RedHat/CentOS/Fedora | download Oracle Java RPM
   get_url:

--- a/ansible-wazuh-agent/tasks/RedHat.yml
+++ b/ansible-wazuh-agent/tasks/RedHat.yml
@@ -14,7 +14,7 @@
     name: wazuh_repo
     description: Wazuh repository
     baseurl: https://packages.wazuh.com/3.x/yum/5/
-    gpgkey: https://packages.wazuh.com/key/RPM-GPG-KEY-OSSEC-RHEL5
+    gpgkey: https://packages.wazuh.com/key/GPG-KEY-WAZUH-5
     gpgcheck: yes
   when:
     - ansible_distribution_major_version|int <= 5


### PR DESCRIPTION
Before these 2 small changes, the agent can't be successfully installed on a RedHat/CentOS 5