### PR TITLE
Updated Linux.yml

### DIFF
--- a/ansible-wazuh-agent/tasks/Linux.yml
+++ b/ansible-wazuh-agent/tasks/Linux.yml
@@ -6,7 +6,7 @@
   when: ansible_os_family == "Debian"
 
 - name: Linux | Install wazuh-agent
-  package: name=wazuh-agent state=latest
+  package: name=wazuh-agent state=present
   tags:
     - init
 


### PR DESCRIPTION
Using `latest` is an antipattern that does not promote reproducible builds. 
It's better to use a specific version number or `present`.