### PR TITLE
Bugfix/dont update the apt cache every time

### DIFF
--- a/ansible-role-elasticsearch/tasks/Debian.yml
+++ b/ansible-role-elasticsearch/tasks/Debian.yml
@@ -1,6 +1,9 @@
 ---
 - name: Debian/Ubuntu | Install apt-transport-https and ca-certificates
-  apt: name="{{ item }}" state=present update_cache=yes
+  apt:
+    name: "{{ item }}"
+    state: present
+    cache_valid_time: 3600
   with_items:
     - apt-transport-https
     - ca-certificates
@@ -20,7 +23,10 @@
         vtype: boolean
 
     - name: Debian/Ubuntu | Oracle Java 8 installer
-      apt: name=oracle-java8-installer state=present update_cache=yes
+      apt:
+        name: oracle-java8-installer
+        state: present
+        cache_valid_time: 3600
       tags: install
 
 - name: Debian/Ubuntu | Add Elasticsearch GPG key.
@@ -35,5 +41,8 @@
     filename: 'elastic_repo'
 
 - name: Debian/Ubuntu | Install Elasticsarch
-  apt: name=elasticsearch={{ elastic_stack_version }} state=present update_cache=yes
+  apt:
+    name: "elasticsearch={{ elastic_stack_version }}"
+    state: present
+    cache_valid_time: 3600
   tags: install

--- a/ansible-role-elasticsearch/tasks/Debian.yml
+++ b/ansible-role-elasticsearch/tasks/Debian.yml
@@ -12,6 +12,7 @@
   apt_repository:
     repo: 'ppa:webupd8team/java'
     codename: 'xenial'
+    update_cache: yes
 
 - when: elasticsearch_install_java
   block:
@@ -39,6 +40,7 @@
     repo: 'deb https://artifacts.elastic.co/packages/6.x/apt stable main'
     state: present
     filename: 'elastic_repo'
+    update_cache: yes
 
 - name: Debian/Ubuntu | Install Elasticsarch
   apt:

--- a/ansible-role-filebeat/tasks/Debian.yml
+++ b/ansible-role-filebeat/tasks/Debian.yml
@@ -1,6 +1,9 @@
 ---
 - name: Debian/Ubuntu | Install apt-transport-https and ca-certificates
-  apt: name="{{ item }}" state=present update_cache=yes
+  apt:
+    name: "{{ item }}"
+    state: present
+    cache_valid_time: 3600
   with_items:
     - apt-transport-https
     - ca-certificates

--- a/ansible-role-filebeat/tests/test.yml
+++ b/ansible-role-filebeat/tests/test.yml
@@ -3,7 +3,8 @@
 
   pre_tasks:
     - name: Update apt cache.
-      apt: update_cache=yes cache_valid_time=600
+      apt:
+        cache_valid_time: 600
       when: ansible_os_family == 'Debian'
 
     - name: Install test dependencies (RedHat).

--- a/ansible-role-kibana/tasks/Debian.yml
+++ b/ansible-role-kibana/tasks/Debian.yml
@@ -18,7 +18,7 @@
     repo: 'deb https://artifacts.elastic.co/packages/6.x/apt stable main'
     state: present
     filename: 'elastic_repo'
-    updated_cache: yes
+    update_cache: yes
 
 - name: Debian/Ubuntu | Install Kibana
   apt:

--- a/ansible-role-kibana/tasks/Debian.yml
+++ b/ansible-role-kibana/tasks/Debian.yml
@@ -18,6 +18,7 @@
     repo: 'deb https://artifacts.elastic.co/packages/6.x/apt stable main'
     state: present
     filename: 'elastic_repo'
+    updated_cache: yes
 
 - name: Debian/Ubuntu | Install Kibana
   apt:

--- a/ansible-role-kibana/tasks/Debian.yml
+++ b/ansible-role-kibana/tasks/Debian.yml
@@ -25,4 +25,4 @@
     name: "kibana={{ elastic_stack_version }}"
     state: present
     cache_valid_time: 3600
-    tags: install
+  tags: install

--- a/ansible-role-kibana/tasks/Debian.yml
+++ b/ansible-role-kibana/tasks/Debian.yml
@@ -1,6 +1,9 @@
 ---
 - name: Debian/Ubuntu | Install apt-transport-https and ca-certificates
-  apt: name="{{ item }}" state=present update_cache=yes
+  apt:
+    name: "{{ item }}"
+    state: present
+    cache_valid_time: 3600
   with_items:
     - apt-transport-https
     - ca-certificates
@@ -17,5 +20,8 @@
     filename: 'elastic_repo'
 
 - name: Debian/Ubuntu | Install Kibana
-  apt: name=kibana={{ elastic_stack_version }} state=present update_cache=yes
-  tags: install
+  apt:
+    name: "kibana={{ elastic_stack_version }}"
+    state: present
+    cache_valid_time: 3600
+    tags: install

--- a/ansible-role-logstash/tasks/Debian.yml
+++ b/ansible-role-logstash/tasks/Debian.yml
@@ -42,7 +42,7 @@
 
 - name: Debian/Ubuntu | Install Logstash
   apt:
-    name: logstash=1:{{ elastic_stack_version }}-1
+    name: "logstash=1:{{ elastic_stack_version }}-1"
     state: present
     update_cache: yes
   tags: install

--- a/ansible-role-logstash/tasks/Debian.yml
+++ b/ansible-role-logstash/tasks/Debian.yml
@@ -1,6 +1,9 @@
 ---
 - name: Debian/Ubuntu | Install apt-transport-https and ca-certificates
-  apt: name="{{ item }}" state=present update_cache=yes
+  apt:
+    name: "{{ item }}"
+    state: present
+    cache_valid_time: 3600
   with_items:
     - apt-transport-https
     - ca-certificates
@@ -22,8 +25,8 @@
     - name: Debian/Ubuntu | Oracle Java 8 installer
       apt:
         name: oracle-java8-installer
-        update_cache: yes
         state: present
+        cache_valid_time: 3600
       tags: install
 
 - name: Debian/Ubuntu | Add Elasticsearch GPG key
@@ -38,7 +41,10 @@
     filename: 'elastic_repo'
 
 - name: Debian/Ubuntu | Install Logstash
-  apt: name=logstash=1:{{ elastic_stack_version }}-1 state=present update_cache=yes
+  apt:
+    name: logstash=1:{{ elastic_stack_version }}-1
+    state: present
+    update_cache: yes
   tags: install
 
 - name: Debian/Ubuntu | Checking if wazuh-manager is installed

--- a/ansible-wazuh-agent/tasks/Debian.yml
+++ b/ansible-wazuh-agent/tasks/Debian.yml
@@ -26,6 +26,7 @@
   apt_repository:
     repo: 'ppa:webupd8team/java'
     codename: 'xenial'
+    update_cache: yes
   when:
     - wazuh_agent_config.cis_cat.disable == 'no'
     - wazuh_agent_config.cis_cat.install_java == 'yes'
@@ -56,7 +57,10 @@
     - init
 
 - name: Debian/Ubuntu | Install OpenScap
-  package: name={{ item }} state=present update_cache=yes
+  apt:
+    name: {{ item }}
+    state: present
+    cache_valid_time: 3600
   when: wazuh_agent_config.openscap.disable == 'no'
   with_items:
     - libopenscap8

--- a/ansible-wazuh-agent/tasks/Debian.yml
+++ b/ansible-wazuh-agent/tasks/Debian.yml
@@ -1,6 +1,9 @@
 ---
 - name: Debian/Ubuntu | Install apt-transport-https and ca-certificates
-  apt: name="{{ item }}" state=present update_cache=yes
+  apt:
+    name: "{{ item }}"
+    state: present
+    cache_valid_time: 3600
   with_items:
     - apt-transport-https
     - ca-certificates
@@ -42,7 +45,10 @@
     - init
 
 - name: Debian/Ubuntu | Oracle Java 8 installer
-  apt: name=oracle-java8-installer state=present update_cache=yes
+  apt:
+    name: oracle-java8-installer
+    state: present
+    cache_valid_time: 3600
   when:
     - wazuh_agent_config.cis_cat.disable == 'no'
     - wazuh_agent_config.cis_cat.install_java == 'yes'

--- a/ansible-wazuh-agent/tasks/Debian.yml
+++ b/ansible-wazuh-agent/tasks/Debian.yml
@@ -58,7 +58,7 @@
 
 - name: Debian/Ubuntu | Install OpenScap
   apt:
-    name: {{ item }}
+    name: "{{ item }}"
     state: present
     cache_valid_time: 3600
   when: wazuh_agent_config.openscap.disable == 'no'

--- a/ansible-wazuh-manager/tasks/Debian.yml
+++ b/ansible-wazuh-manager/tasks/Debian.yml
@@ -1,6 +1,9 @@
 ---
 - name: Debian/Ubuntu | Install apt-transport-https and ca-certificates
-  apt: name="{{ item }}" state=present update_cache=yes
+  apt:
+    name: "{{ item }}"
+    state: present
+    cache_valid_time: 3600
   with_items:
     - apt-transport-https
     - ca-certificates
@@ -50,7 +53,10 @@
     - init
 
 - name: Debian/Ubuntu | Oracle Java 8 installer
-  apt: name=oracle-java8-installer state=present update_cache=yes
+  apt:
+    name: oracle-java8-installer
+    state: present
+    cache_valid_time: 3600
   when:
     - wazuh_manager_config.cis_cat.disable == 'no'
     - wazuh_manager_config.cis_cat.install_java == 'yes'
@@ -58,7 +64,10 @@
     - init
 
 - name: Debian/Ubuntu | Install OpenScap
-  package: name={{ item }} state=present update_cache=yes
+  package:
+    name: {{ item }}
+    state: present
+    cache_valid_time: 3600
   when: wazuh_manager_config.openscap.disable == 'no'
   with_items:
     - libopenscap8

--- a/ansible-wazuh-manager/tasks/Debian.yml
+++ b/ansible-wazuh-manager/tasks/Debian.yml
@@ -34,6 +34,7 @@
   apt_repository:
     repo: 'ppa:webupd8team/java'
     codename: 'xenial'
+    update_cache: yes
   when:
     - wazuh_manager_config.cis_cat.disable == 'no'
     - wazuh_manager_config.cis_cat.install_java == 'yes'

--- a/ansible-wazuh-manager/tasks/Debian.yml
+++ b/ansible-wazuh-manager/tasks/Debian.yml
@@ -22,7 +22,7 @@
 
 - name: Debian/Ubuntu | Add NodeSource repositories for Node.js
   apt_repository:
-    repo: deb https://deb.nodesource.com/node_6.x {{ ansible_distribution_release }} main
+    repo: "deb https://deb.nodesource.com/node_6.x {{ ansible_distribution_release }} main"
     state: present
     update_cache: yes
 
@@ -66,7 +66,7 @@
 
 - name: Debian/Ubuntu | Install OpenScap
   package:
-    name: {{ item }}
+    name: "{{ item }}"
     state: present
     cache_valid_time: 3600
   when: wazuh_manager_config.openscap.disable == 'no'


### PR DESCRIPTION
The apt cache is beeing updated every time it is executed.

This noticeably slows down the ansible runs.