### PR TITLE
Updated Windows Agent Version to latest

### DIFF
--- a/ansible-wazuh-agent/defaults/main.yml
+++ b/ansible-wazuh-agent/defaults/main.yml
@@ -19,10 +19,10 @@ wazuh_notify_time: null
 wazuh_time_reconnect: null
 wazuh_winagent_config:
   install_dir: 'C:\wazuh-agent\'
-  version: '3.1.0'
+  version: '3.3.1'
   revision: '1'
   repo: https://packages.wazuh.com/3.x/windows/
-  md5: 484900d5006a50304bbf284917d7fa14
+  md5: 935d1993029021f3951b9511e2171207
 wazuh_agent_config:
   log_format: 'plain'
   syscheck:


### PR DESCRIPTION
Wazuh agent latest version is 3.3.1. Meanwhile the Ansible configuration for windows is still using 3.1.0.

I have updated the version and md5 accordingly. 

You can double check here, but I have tested and deployed the agent on all our servers.

src: https://documentation.wazuh.com/3.x/installation-guide/packages-list/index.html

Distribution | Version | Architecture | Package | MD5 Checksum
-- | -- | -- | -- | --
Debian based | 3.3.1 | 32bits | wazuh-agent_3.3.1-1_i386.deb | c424ffd249085fbf2b42cbd432b473a4
wazuh-manager_3.3.1-1_i386.deb | f3d0a39c2459e69e75e2226804906562
64bits | wazuh-agent_3.3.1-1_amd64.deb | 1f667129cb9ac4f37081a5c0165ad4a1
wazuh-manager_3.3.1-1_amd64.deb | dd4cfb69a2f36a5a3586e93e9e0d2345
wazuh-api_3.3.1-1_amd64.deb | d367bfe239952c5142307da132ce59ad
RPM based | 3.3.1 | 32bits | wazuh-agent-3.3.1-1.i386.rpm | 196af565712f3302beb1984d8f6469f5
wazuh-manager-3.3.1-1.i386.rpm | 175b78b1ed86393704c81cddbcb8b704
64bits | wazuh-agent-3.3.1-1.x86_64.rpm | 3616ab5cd21f095fdb605de550fa692b
wazuh-manager-3.3.1-1.x86_64.rpm | f23e355181509077ec38e6f3aa44abc7
wazuh-api-3.3.1-1.x86_64.rpm | e8ba870eb46bb88084de6ea668f0c3b1
CentOS 5RedHat 5SUSE 11 | 3.3.1 | 32bits | wazuh-agent-3.3.1-1.el5.i386.rpm | 587298805cc7b44323dce616248dd2c2
wazuh-manager-3.3.1-1.el5.i386.rpm | 7f918d0e64fb9794a8d167744a2babc9
64bits | wazuh-agent-3.3.1-1.el5.x86_64.rpm | 9cc9d841b424158e07c146e2e92b0fe0
wazuh-manager-3.3.1-1.el5.x86_64.rpm | cfff1d8c700736d01370af8eda17bab7
Windows | 3.3.1 | 32/64bits | wazuh-agent-3.3.1-1.msi | 935d1993029021f3951b9511e2171207
Mac OS X | 3.3.1 | 64bits | wazuh-agent-3.3.1-1.pkg | 38c515ee999f578b1523c121af2feb51
HP-UX 11.31 | 3.3.1 | Itanium | wazuh-agent-3.3.1-1-hpux-11v3-ia64.tar | eec8b07650e0ba026dffa9a1721eca81
Solaris 10 | 3.3.1 | i386 | wazuh-agent_v3.3.1-sol10-i386.pkg | 1291d73c3946ba78cbb50cc9c85cb506
SPARC | wazuh-agent_v3.3.1-sol10-sparc.pkg | 6e52fac133c8795a90803cd9465e64c7
Solaris 11 | 3.3.1 | i386 | wazuh-agent_v3.3.1-sol11-i386.p5p | 15e2c07bf0eef70be346edb8eb705730
SPARC | wazuh-agent_v3.3.1-sol11-sparc.p5p | c126a9cc00f2b6367aa1d5ba0d81ff19
AIX 5.3 | 3.3.1 | LPARs | wazuh-agent_v3.3.1-aix5.3.tar | d6055cc0a6721d9e0a49825018cc8472
AIX 6 or greater | 3.3.1 | LPARs | wazuh-agent_v3.3.1-aix6.1.tar | c18ecb0ba9c7d5d757973bc3bdf4bc95

