### PR TITLE
Java-Repository is no longer beeing installed when java is not needed

### DIFF
--- a/ansible-role-elasticsearch/tasks/Debian.yml
+++ b/ansible-role-elasticsearch/tasks/Debian.yml
@@ -8,16 +8,16 @@
     - apt-transport-https
     - ca-certificates
 
-- name: Debian/Ubuntu | Setting webupd8 repository
-  apt_repository:
-    repo: 'ppa:webupd8team/java'
-    codename: 'xenial'
-    update_cache: yes
-
 - when: elasticsearch_install_java
   block:
-    - name: Debian/Ubuntu | Accept Oracle Java 8 license
-      debconf:
+   - name: Debian/Ubuntu | Setting webupd8 repository
+     apt_repository:
+        repo: 'ppa:webupd8team/java'
+        codename: 'xenial'
+        update_cache: yes
+
+   - name: Debian/Ubuntu | Accept Oracle Java 8 license
+     debconf:
         name: oracle-java8-installer
         question: shared/accepted-oracle-license-v1-1
         value: true

--- a/ansible-role-elasticsearch/tasks/Debian.yml
+++ b/ansible-role-elasticsearch/tasks/Debian.yml
@@ -10,14 +10,14 @@
 
 - when: elasticsearch_install_java
   block:
-   - name: Debian/Ubuntu | Setting webupd8 repository
-     apt_repository:
+    - name: Debian/Ubuntu | Setting webupd8 repository
+      apt_repository:
         repo: 'ppa:webupd8team/java'
         codename: 'xenial'
         update_cache: yes
 
-   - name: Debian/Ubuntu | Accept Oracle Java 8 license
-     debconf:
+    - name: Debian/Ubuntu | Accept Oracle Java 8 license
+      debconf:
         name: oracle-java8-installer
         question: shared/accepted-oracle-license-v1-1
         value: true

--- a/ansible-role-logstash/tasks/Debian.yml
+++ b/ansible-role-logstash/tasks/Debian.yml
@@ -8,13 +8,13 @@
     - apt-transport-https
     - ca-certificates
 
-- name: Debian/Ubuntu | Setting webupd8 repository
-  apt_repository:
-    repo: 'ppa:webupd8team/java'
-    codename: 'xenial'
-
 - when: logstash_install_java
   block:
+    - name: Debian/Ubuntu | Setting webupd8 repository
+      apt_repository:
+        repo: 'ppa:webupd8team/java'
+        codename: 'xenial'
+
     - name: Debian/Ubuntu | Accept Oracle Java 8 license
       debconf:
         name: oracle-java8-installer


### PR DESCRIPTION
The java repository was installed even if the isntallation of java was beeing skipped by the user in the elastic search and logstash repository