### PR TITLE
Interval option is not longer available.

### DIFF
--- a/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
+++ b/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
@@ -28,7 +28,9 @@
     <node_name>{{ wazuh_manager_config.cluster.node_name }}</node_name>
     <node_type>{{ wazuh_manager_config.cluster.node_type }}</node_type>
     <key>{{ wazuh_manager_config.cluster.key }}</key>
+    {% if wazuh_manger_config.cluster.interval is defined %}
     <interval>{{ wazuh_manager_config.cluster.interval }}</interval>
+    {% endif %}
     <port>{{ wazuh_manager_config.cluster.port }}</port>
     <bind_addr>{{ wazuh_manager_config.cluster.bind_addr }}</bind_addr>
     <nodes>


### PR DESCRIPTION
Fixes: #48 

Current wazuh code [issues a deprecation warning](https://github.com/wazuh/wazuh/blob/master/src/config/cluster-config.c#L74) when the `cluster.interval` option is set:

```
Detected a deprecated configuration for cluster. Interval option is not longer available.
```  

However, wazuh-ansible code [requires `cluster.interval`](https://github.com/wazuh/wazuh-ansible/blob/master/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2#L31) and fails with the following error if it is missing:

```
AnsibleUndefinedVariable: 'dict object' has no attribute 'interval'
```

At a minimum, the template should be [modified](https://github.com/wazuh/wazuh-ansible/pull/49/commits/432d405e690839f86cfddbb079608f299e99e91c) to skip the `cluster.interval` option if it is not defined.