### PR TITLE
Add meta for ansible-galaxy.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,29 @@
+---
+
+dependencies: []
+
+galaxy_info:
+  author: Wazuh
+  categories:
+  - monitoring
+  company: wazuh.com
+  description: Installing, deploying and configuring Wazuh Manager.
+  galaxy_tags:
+    - monitoring
+    - system
+    - web
+  license: license (GPLv3)
+  min_ansible_version: 2.0
+  platforms:
+  - name: Debian
+    versions:
+    - all
+  - name: EL
+    versions:
+    - all
+  - name: Fedora
+    versions:
+    - all
+  - name: Ubuntu
+    versions:
+    - all


### PR DESCRIPTION
When pulling this repo, ansible-galaxy rearranges the directories in a confusing way.  Apparently, it searches for a valid `meta/main.yml` file and moves those files into the role directory, then moves all other files into a subdirectory of that role.  Running the following command:

```
ansible-galaxy install -f -n -p . git+https://github.com/wazuh/wazuh-ansible.git
```

yields a `wazuh-ansible` directory with the following contents:

* `defaults` (moved from [`ansible-role-kibana/defaults`](https://github.com/wazuh/wazuh-ansible/tree/master/ansible-role-kibana/defaults)
* `handlers` (moved from [`ansible-role-kibana/handlers`](https://github.com/wazuh/wazuh-ansible/tree/master/ansible-role-kibana/handlers)
* `meta` (moved from [`ansible-role-kibana/meta`](https://github.com/wazuh/wazuh-ansible/tree/master/ansible-role-kibana/meta)
* `README.md` (moved from [`ansible-role-kibana/README.md`](https://github.com/wazuh/wazuh-ansible/tree/master/ansible-role-kibana/README.md)
* `tasks` (moved from [`ansible-role-kibana/tasks`](https://github.com/wazuh/wazuh-ansible/tree/master/ansible-role-kibana/tasks)
* `templates` (moved from [`ansible-role-kibana/templates`](https://github.com/wazuh/wazuh-ansible/tree/master/ansible-role-kibana/templates)
* `wazuh-ansible` (which contains everything from [this repo](https://github.com/wazuh/wazuh-ansible/tree/master) except the [`ansible-role-kibana`](https://github.com/wazuh/wazuh-ansible/tree/master/ansible-role-kibana) directory.)

I'd prefer that the directory-structure created by ansible-galaxy matches the directory-structure in this repo.  To make that happen, I've created a [`meta/main.yml`](https://github.com/wazuh/wazuh-ansible/pull/50/commits/cb0ee202fa98d174ab63a411715cbb1fa910b1a3#diff-9b4ddf055111f4371f04fbb8b5366655) file.  With this file in place, running the same ansible-galaxy command yields a directory structure that exactly corresponds to this repo.