### PR TITLE
Allow active-response.disable=yes

### DIFF
--- a/ansible-wazuh-agent/defaults/main.yml
+++ b/ansible-wazuh-agent/defaults/main.yml
@@ -24,6 +24,7 @@ wazuh_winagent_config:
   repo: https://packages.wazuh.com/3.x/windows/
   md5: 935d1993029021f3951b9511e2171207
 wazuh_agent_config:
+  active_response_disabled: 'no'
   log_format: 'plain'
   syscheck:
     frequency: 43200

--- a/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
+++ b/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
@@ -36,7 +36,7 @@
   </logging>
 
   <active-response>
-    <disabled>no</disabled>
+    <disabled>{{ wazuh_agent_config.active_response_disabled|default('no') }}</disabled>
   </active-response>
 
   {% if wazuh_agent_config.rootcheck is defined %}


### PR DESCRIPTION
The [wazuh-agent template](https://github.com/wazuh/wazuh-ansible/blob/master/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2#L39) hardcodes:

```
<active-response>
  <disabled>no</disabled>
</active-response>
```

This PR adds an optional [`wazuh_agent_config.active_response_disabled`](https://github.com/wazuh/wazuh-ansible/blob/7fc09fb79f6674336407a49818327a3f0e828eac/ansible-wazuh-agent/defaults/main.yml#L27) key which [defaults](https://github.com/wazuh/wazuh-ansible/blob/7fc09fb79f6674336407a49818327a3f0e828eac/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2#L39) to `'no'`.