### PR TITLE
Properly handle deleted client.keys file.

### DIFF
--- a/ansible-wazuh-agent/tasks/Linux.yml
+++ b/ansible-wazuh-agent/tasks/Linux.yml
@@ -56,7 +56,7 @@
         {% if wazuh_agent_authd.ssl_auto_negotiate == 'yes' %}-a{% endif %}
       register: agent_auth_output
       when:
-        - check_keys.stat.size == 0
+        - check_keys.stat.exists == false or check_keys.stat.size == 0
         - wazuh_managers.0.address is not none
       tags:
         - config
@@ -65,7 +65,7 @@
     - name: Linux | Verify agent registration
       shell: echo {{ agent_auth_output }} | grep "Valid key created"
       when:
-        - check_keys.stat.size == 0
+        - check_keys.stat.exists == false or check_keys.stat.size == 0
         - wazuh_managers.0.address is not none
       tags:
         - config
@@ -97,7 +97,7 @@
       register: newagent_api
       changed_when: newagent_api.json.error == 0
       when:
-        - check_keys.stat.size == 0
+        - check_keys.stat.exists == false or check_keys.stat.size == 0
         - wazuh_managers.0.address is not none
       become: no
       tags:
@@ -113,7 +113,7 @@
         user: "{{ wazuh_managers.0.api_user }}"
         password: "{{ api_pass }}"
       when:
-        - check_keys.stat.size == 0
+        - check_keys.stat.exists == false or check_keys.stat.size == 0
         - wazuh_managers.0.address is not none
         - newagent_api.json.error == 0
       register: newagentdata_api
@@ -134,7 +134,7 @@
         OSSEC_ACTION_CONFIRMED: y
       register: manage_agents_output
       when:
-        - check_keys.stat.size == 0
+        - check_keys.stat.exists == false or check_keys.stat.size == 0
         - wazuh_managers.0.address is not none
         - newagent_api.changed
       tags:

--- a/ansible-wazuh-agent/tasks/Windows.yml
+++ b/ansible-wazuh-agent/tasks/Windows.yml
@@ -62,7 +62,7 @@
   notify: restart wazuh-agent windows
   when:
     - wazuh_agent_authd.enable == true
-    - check_windows_key.stat.exists == false
+    - check_windows_key.stat.exists == false or check_windows_key.stat.size == 0
     - wazuh_managers.0.address is not none
   tags:
     - config


### PR DESCRIPTION
The [Linux agent registration code](https://github.com/wazuh/wazuh-ansible/blob/master/ansible-wazuh-agent/tasks/Linux.yml#L68) triggers registration when `client.keys` is a zero-length file, and the [Windows agent registration code](https://github.com/wazuh/wazuh-ansible/blob/master/ansible-wazuh-agent/tasks/Windows.yml#L65) triggers registration when `client.keys` does not exist.

Both versions should trigger registration for both cases.  Regardless of O/S, registration should be triggered if `client.keys` is missing *OR* empty.