### PR TITLE
Enforce mode of client.keys file.

### DIFF
--- a/ansible-wazuh-agent/tasks/Linux.yml
+++ b/ansible-wazuh-agent/tasks/Linux.yml
@@ -144,6 +144,14 @@
 
   when: wazuh_agent_authd.enable == false
 
+- name: Linux | Ensure client.keys is group-readable.
+  file:
+    group: ossec
+    mode: 0640
+    owner: root
+    path: /var/ossec/etc/client.keys
+    state: file
+
 - name: Linux | Vuls integration deploy (runs in background, can take a while)
   command: /var/ossec/wodles/vuls/deploy_vuls.sh {{ ansible_distribution|lower }} {{ ansible_distribution_major_version|int }}
   args:

--- a/ansible-wazuh-manager/tasks/main.yml
+++ b/ansible-wazuh-manager/tasks/main.yml
@@ -35,6 +35,27 @@
   tags:
     - init
 
+- name: Check whether client.keys exists.
+  stat:
+    get_attributes: False
+    get_checksum: False
+    get_mime: False
+    path: /var/ossec/etc/client.keys
+  register: check_keys
+  tags:
+  - config
+
+- name: Ensure client.keys exists and is group-writable.
+  file:
+    group: ossec
+    mode: 0660
+    owner: root
+    path: /var/ossec/etc/client.keys
+    state: '{{ "file" if check_keys.stat.exists else "touch" }}'
+  notify: restart wazuh-manager
+  tags:
+  - config
+
 - name: Generate SSL files for authd
   command: "openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:1825 -keyout sslmanager.key -out sslmanager.cert -subj /CN={{wazuh_manager_fqdn}}/"
   args:


### PR DESCRIPTION
In both client and manager, the `/var/ossec/etc/client.keys` file is created with `owner=root` and `group=ossec`.  On my test systems, this file is initially created with mode `0600 (u=rw-,g=---,o=---)`.  However, this file must be readable on the client by group `ossec` on the client, and writable by group `ossec` on the manager.

This PR adds code to enforce the existence, ownership, and file mode, as appropriate.