### PR TITLE
Make rootcheck and syscheck optional.

### DIFF
--- a/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
+++ b/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
@@ -39,6 +39,7 @@
     <disabled>no</disabled>
   </active-response>
 
+  {% if wazuh_agent_config.rootcheck is defined %}
   <rootcheck>
     <disabled>no</disabled>
     <check_unixaudit>yes</check_unixaudit>
@@ -71,7 +72,9 @@
 
     <skip_nfs>yes</skip_nfs>
   </rootcheck>
+  {% endif %}
 
+  {% if wazuh_agent_config.syscheck is defined %}
   <syscheck>
     <disabled>no</disabled>
     {% if ansible_os_family == "Windows" %}
@@ -117,6 +120,7 @@
     {% endfor %}
     {% endif %}
   </syscheck>
+  {% endif %}
 
   {% if ansible_system == "Linux" and wazuh_agent_config.openscap.disable == 'no' %}
   <wodle name="open-scap">


### PR DESCRIPTION
With [centralized configuration](https://documentation.wazuh.com/current/user-manual/reference/centralized-configuration.html), the [rootcheck](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/rootcheck.html) and [syscheck](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html) configuration sections should be moved from the local [ossec.conf](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/index.html) file to the shared/[agent.conf](https://documentation.wazuh.com/current/user-manual/reference/centralized-configuration.html#agent-conf) distributed by the manager.

This PR allows for skipping these sections by removing the `orootcheck` and `syscheck` keys from `ossec_agent_config`.