### PR TITLE
Validate the generated agent.conf file.

### DIFF
--- a/ansible-wazuh-manager/tasks/main.yml
+++ b/ansible-wazuh-manager/tasks/main.yml
@@ -109,11 +109,13 @@
     - rules
 
 - name: Configure the shared-agent.conf
-  template: src=var-ossec-etc-shared-agent.conf.j2
-            dest=/var/ossec/etc/shared/default/agent.conf
-            owner=ossec
-            group=ossec
-            mode=0640
+  template:
+    src: var-ossec-etc-shared-agent.conf.j2
+    dest: /var/ossec/etc/shared/default/agent.conf
+    owner: ossec
+    group: ossec
+    mode: 0640
+    validate: '/var/ossec/bin/verify-agent-conf -f %s'
   notify: restart wazuh-manager
   tags:
     - init


### PR DESCRIPTION
We should use the [`verify-agent-conf`](https://documentation.wazuh.com/current/user-manual/reference/tools/verify-agent-conf.html) tool to [validate](https://github.com/wazuh/wazuh-ansible/commit/74391a6745deecacdcfe3574274a888acbb7fb08) the generated [`/var/ossec/etc/shared/agent.conf`](https://documentation.wazuh.com/current/user-manual/reference/centralized-configuration.html#reference-agent-conf) file before copying it into place.