### PR TITLE
Template API configuration

### DIFF
--- a/ansible-wazuh-agent/tasks/Linux.yml
+++ b/ansible-wazuh-agent/tasks/Linux.yml
@@ -45,7 +45,7 @@
     - name: Linux | Register agent (via authd)
       shell: >
         /var/ossec/bin/agent-auth
-        -A {{ stack_name }}
+        -A {{ wazuh_agent_config.name | inventory_hostname }}
         -m {{ wazuh_managers.0.address }}
         -p {{ wazuh_agent_authd.port }}
         {% if authd_pass is defined %}-P {{ authd_pass }}{% endif %}
@@ -88,8 +88,7 @@
         url: "{{ wazuh_managers.0.api_proto }}://{{ wazuh_managers.0.address }}:{{ wazuh_managers.0.api_port }}/agents/"
         validate_certs: no
         method: POST
-        body: {"name":"{{ stack_name }}"}
-        #body: {"name":"{{ inventory_hostname }}"}
+        body: {"name":"{{ wazuh_agent_config.name | inventory_hostname }}"}
         body_format: json
         status_code: 200
         headers:

--- a/ansible-wazuh-agent/tasks/Linux.yml
+++ b/ansible-wazuh-agent/tasks/Linux.yml
@@ -45,6 +45,7 @@
     - name: Linux | Register agent (via authd)
       shell: >
         /var/ossec/bin/agent-auth
+        -A {{ stack_name }}
         -m {{ wazuh_managers.0.address }}
         -p {{ wazuh_agent_authd.port }}
         {% if authd_pass is defined %}-P {{ authd_pass }}{% endif %}
@@ -87,7 +88,8 @@
         url: "{{ wazuh_managers.0.api_proto }}://{{ wazuh_managers.0.address }}:{{ wazuh_managers.0.api_port }}/agents/"
         validate_certs: no
         method: POST
-        body: {"name":"{{ inventory_hostname }}"}
+        body: {"name":"{{ stack_name }}"}
+        #body: {"name":"{{ inventory_hostname }}"}
         body_format: json
         status_code: 200
         headers:

--- a/ansible-wazuh-agent/tasks/Linux.yml
+++ b/ansible-wazuh-agent/tasks/Linux.yml
@@ -45,7 +45,7 @@
     - name: Linux | Register agent (via authd)
       shell: >
         /var/ossec/bin/agent-auth
-        -A {{ wazuh_agent_config.name | inventory_hostname }}
+        {% if wazuh_agent_config.name is defined %}-A {{ wazuh_agent_config.name }}{% endif %}
         -m {{ wazuh_managers.0.address }}
         -p {{ wazuh_agent_authd.port }}
         {% if authd_pass is defined %}-P {{ authd_pass }}{% endif %}

--- a/ansible-wazuh-manager/defaults/main.yml
+++ b/ansible-wazuh-manager/defaults/main.yml
@@ -6,6 +6,22 @@ wazuh_manager_config:
   alerts_log: 'yes'
   logall: 'no'
   log_format: 'plain'
+  api:
+    bind_addr: '0.0.0.0'
+    port: 55000
+    https: 'no'
+    basic_auth: 'yes'
+    behind_proxy_server: 'no'
+    https_cert: '/var/ossec/etc/sslmanager.cert'
+    https_key: '/var/ossec/etc/sslmanager.key'
+    https_use_ca: 'no'
+    https_ca: ''
+    use_only_authd: 'false'
+    drop_privilages: 'true'
+    experimental_features: 'false'
+    secure_protocol: 'TLSv1_2_method'
+    honor_cipher_order: 'true'
+    ciphers: ''
   cluster:
     disable: 'yes'
     name: 'wazuh'

--- a/ansible-wazuh-manager/defaults/main.yml
+++ b/ansible-wazuh-manager/defaults/main.yml
@@ -17,7 +17,7 @@ wazuh_manager_config:
     https_use_ca: 'no'
     https_ca: ''
     use_only_authd: 'false'
-    drop_privilages: 'true'
+    drop_privileges: 'true'
     experimental_features: 'false'
     secure_protocol: 'TLSv1_2_method'
     honor_cipher_order: 'true'

--- a/ansible-wazuh-manager/tasks/main.yml
+++ b/ansible-wazuh-manager/tasks/main.yml
@@ -119,6 +119,17 @@
     - init
     - config
 
+- name: Installing the config.js (api configuration)
+  template: src=var-ossec-api-configuration-config.js.j2
+            dest=/var/ossec/api/configuration/config.js
+            owner=root
+            group=ossec
+            mode=0740
+  notify: restart wazuh-manager
+  tags:
+    - init
+    - config
+
 - name: Retrieving Agentless Credentials
   include_vars: agentless_creeds.yml
   tags:

--- a/ansible-wazuh-manager/tasks/main.yml
+++ b/ansible-wazuh-manager/tasks/main.yml
@@ -125,7 +125,7 @@
             owner=root
             group=ossec
             mode=0740
-  notify: restart wazuh-manager
+  notify: restart wazuh-api
   tags:
     - init
     - config

--- a/ansible-wazuh-manager/templates/var-ossec-api-configuration-config.js.j2
+++ b/ansible-wazuh-manager/templates/var-ossec-api-configuration-config.js.j2
@@ -1,0 +1,95 @@
+
+var config = {};
+
+// Basic configuration
+
+// Path
+config.ossec_path = "/var/ossec";
+// The host to bind the API to.
+config.host = "{{ wazuh_manager_config.api.bind_addr }}";
+// TCP Port used by the API.
+config.port = "{{ wazuh_manager_config.api.port }}";
+// Use HTTP protocol over TLS/SSL. Values: yes, no.
+config.https = "{{ wazuh_manager_config.api.https }}";
+// Use HTTP authentication. Values: yes, no.
+config.basic_auth = "{{ wazuh_manager_config.api.basic_auth }}";
+//In case the API run behind a proxy server, turn to "yes" this feature. Values: yes, no.
+config.BehindProxyServer = "{{ wazuh_manager_config.api.behind_proxy_server }}";
+
+// HTTPS Certificates
+config.https_key = "{{ wazuh_manager_config.api.https_key }}"
+config.https_cert = "{{ wazuh_manager_config.api.https_cert }}"
+config.https_use_ca = "{{ wazuh_manager_config.api.https_use_ca }}"
+config.https_ca = "{{ wazuh_manager_config.api.https_ca }}"
+
+// Advanced configuration
+
+// Values for API log: disabled, info, warning, error, debug (each level includes the previous level).
+config.logs = "info";
+// Cross-origin resource sharing. Values: yes, no.
+config.cors = "yes";
+// Cache (time in milliseconds)
+config.cache_enabled = "yes";
+config.cache_debug = "no";
+config.cache_time = "750";
+// Log path
+config.log_path = config.ossec_path + "/logs/api.log";
+// Python
+config.python = [
+    // Default installation
+    {
+        bin: "python",
+        lib: ""
+    },
+    // Python 3
+    {
+        bin: "python3",
+        lib: ""
+    },
+    // Package 'python27' for CentOS 6
+    {
+        bin: "/opt/rh/python27/root/usr/bin/python",
+        lib: "/opt/rh/python27/root/usr/lib64"
+    }
+];
+// Shared library path
+config.ld_library_path = config.ossec_path + "/framework/lib"
+
+// Option to force the use of authd to remove and add agents
+config.use_only_authd = {{ wazuh_manager_config.api.use_only_authd }};
+
+// Option to drop privileges (run as ossec)
+config.drop_privileges = {{ wazuh_manager_config.api.drop_privileges }};
+
+// Activate features still under development
+config.experimental_features  = {{ wazuh_manager_config.api.experimental_features }};
+
+/************************* SSL OPTIONS ****************************************/
+// SSL protocol
+
+// SSL protocol to use. All available secure protocols available at:
+// https://www.openssl.org/docs/man1.0.2/ssl/ssl.html#DEALING-WITH-PROTOCOL-METHODS
+config.secureProtocol = "{{ wazuh_manager_config.api.secure_protocol }}";
+try {
+    // Disable the use of SSLv3, TLSv1.1 and TLSv1.0. All available secureOptions at: 
+    // https://nodejs.org/api/crypto.html#crypto_openssl_options
+    const crypto = require('crypto');
+    config.secureOptions = crypto.constants.SSL_OP_NO_SSLv3 |
+                           crypto.constants.SSL_OP_NO_TLSv1 | 
+                           crypto.constants.SSL_OP_NO_TLSv1_1;
+} catch (err) {
+    console.log("Could not configure NodeJS to avoid unsecure SSL/TLS protocols: " + err)
+}
+
+// SSL ciphersuit
+
+// When choosing a cipher, use the server's preferences instead of the client 
+// preferences. When not set, the SSL server will always follow the clients 
+// preferences. More info at: 
+// https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_set_options.html
+config.honorCipherOrder = {{ wazuh_manager_config.api.honor_cipher_order }};
+// Modify default ciphersuit. More info: 
+// https://nodejs.org/api/tls.html#tls_modifying_the_default_tls_cipher_suite
+config.ciphers =  "{{ wazuh_manager_config.api.ciphers }}";
+
+module.exports = config;


### PR DESCRIPTION
Hi,

I wanted to add the ability configure the API so that I can force it to work over HTTPS.

I also added the ability to set wazuh_agent_config.name when registering an agent instead of using hostname for instances I deploy in AWS. Let me know if you would like this as a separate pull request.

Please let me know if there is anything else I should add to the template for the API as I am quite new to Wazuh.

Thanks, Colby