### PR TITLE
validate agent.conf in manager

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -109,11 +109,13 @@
     - rules
 
 - name: Configure the shared-agent.conf
-  template: src=var-ossec-etc-shared-agent.conf.j2
-            dest=/var/ossec/etc/shared/default/agent.conf
-            owner=ossec
-            group=ossec
-            mode=0640
+  template:
+    src: var-ossec-etc-shared-agent.conf.j2
+    dest: /var/ossec/etc/shared/default/agent.conf
+    owner: ossec
+    group: ossec
+    mode: 0640
+    validate: '/var/ossec/bin/verify-agent-conf -f %s'
   notify: restart wazuh-manager
   tags:
     - init


### PR DESCRIPTION
This PR is an update of the PR #58 made by the user @pillarsdotnet with the new structure of the branch 3.7
The porpouse of this PR is to add a validation the file `/var/ossec/etc/shared/agent.conf`