### PR TITLE
client.keys registration triggers

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
@@ -56,7 +56,7 @@
         {% if wazuh_agent_authd.ssl_auto_negotiate == 'yes' %}-a{% endif %}
       register: agent_auth_output
       when:
-        - check_keys.stat.size == 0
+        - check_keys.stat.exists == false or check_keys.stat.size == 0
         - wazuh_managers.0.address is not none
       tags:
         - config
@@ -65,7 +65,7 @@
     - name: Linux | Verify agent registration
       shell: echo {{ agent_auth_output }} | grep "Valid key created"
       when:
-        - check_keys.stat.size == 0
+        - check_keys.stat.exists == false or check_keys.stat.size == 0
         - wazuh_managers.0.address is not none
       tags:
         - config
@@ -97,7 +97,7 @@
       register: newagent_api
       changed_when: newagent_api.json.error == 0
       when:
-        - check_keys.stat.size == 0
+        - check_keys.stat.exists == false or check_keys.stat.size == 0
         - wazuh_managers.0.address is not none
       become: no
       tags:
@@ -113,7 +113,7 @@
         user: "{{ wazuh_managers.0.api_user }}"
         password: "{{ api_pass }}"
       when:
-        - check_keys.stat.size == 0
+        - check_keys.stat.exists == false or check_keys.stat.size == 0
         - wazuh_managers.0.address is not none
         - newagent_api.json.error == 0
       register: newagentdata_api
@@ -134,7 +134,7 @@
         OSSEC_ACTION_CONFIRMED: y
       register: manage_agents_output
       when:
-        - check_keys.stat.size == 0
+        - check_keys.stat.exists == false or check_keys.stat.size == 0
         - wazuh_managers.0.address is not none
         - newagent_api.changed
       tags:

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Windows.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Windows.yml
@@ -62,7 +62,7 @@
   notify: restart wazuh-agent windows
   when:
     - wazuh_agent_authd.enable == true
-    - check_windows_key.stat.exists == false
+    - check_windows_key.stat.exists == false or check_windows_key.stat.size == 0
     - wazuh_managers.0.address is not none
   tags:
     - config


### PR DESCRIPTION
This PR is an update of the PR #54  made by the user @pillarsdotnet  with the new structure of the branch 3.7
The porpouse of this PR is to update the registration triggers for Linux and Windows agents:
`check_windows_key.stat.exists == false
check_windows_key.stat.exists == false or check_windows_key.stat.size == 0`