### PR TITLE
adding custom rules/decoders files

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/custom_ruleset/decoders/sample_custom_decoders.xml
+++ b/roles/wazuh/ansible-wazuh-manager/custom_ruleset/decoders/sample_custom_decoders.xml
@@ -1,0 +1,25 @@
+<!-- Local Decoders -->
+
+<!-- Modify it at your will. -->
+
+<!--
+  - Allowed static fields:
+  - location   - where the log came from (only on FTS)
+  - srcuser    - extracts the source username
+  - dstuser    - extracts the destination (target) username
+  - user       - an alias to dstuser (only one of the two can be used)
+  - srcip      - source ip
+  - dstip      - dst ip
+  - srcport    - source port
+  - dstport    - destination port
+  - protocol   - protocol
+  - id         - event id
+  - url        - url of the event
+  - action     - event action (deny, drop, accept, etc)
+  - status     - event status (success, failure, etc)
+  - extra_data - Any extra data
+-->
+
+<decoder name="sample_custom_decoder">
+    <program_name>sample_custom_decoder</program_name>
+</decoder>

--- a/roles/wazuh/ansible-wazuh-manager/custom_ruleset/rules/sample_custom_rules.xml
+++ b/roles/wazuh/ansible-wazuh-manager/custom_ruleset/rules/sample_custom_rules.xml
@@ -1,0 +1,18 @@
+<!-- Local rules -->
+
+<!-- Modify it at your will. -->
+
+<!-- Example -->
+<group name="local,syslog,sshd,">
+
+  <!--
+  Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2
+  -->
+  <rule id="200001" level="5">
+    <if_sid>5716</if_sid>
+    <srcip>1.1.1.1</srcip>
+    <description>sshd: authentication failed from IP 1.1.1.1.</description>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
+  </rule>
+
+</group>

--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -167,6 +167,9 @@ wazuh_manager_config:
       executable: 'route-null.cmd'
       expect: 'srcip'
       timeout_allowed: 'yes'
+  ruleset:
+      rules_path: '/etc/ansible/roles/wazuh-ansible/roles/wazuh/ansible-wazuh-manager/custom_ruleset/rules/'
+      decoders_path: '/etc/ansible/roles/wazuh-ansible/roles/wazuh/ansible-wazuh-manager/custom_ruleset/decoders/'
   rule_exclude:
     - '0215-policy_rules.xml'
   active_responses:

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -96,12 +96,36 @@
     - config
     - rules
 
+- name: Adding local rules files
+  copy: src="{{ wazuh_manager_config.ruleset.rules_path }}"
+        dest=/var/ossec/etc/rules/
+        owner=root
+        group=ossec
+        mode=0640
+  notify: restart wazuh-manager
+  tags:
+    - init
+    - config
+    - rules
+
 - name: Installing the local_decoder.xml
   template: src=var-ossec-rules-local_decoder.xml.j2
             dest=/var/ossec/etc/decoders/local_decoder.xml
             owner=root
             group=ossec
             mode=0640
+  notify: restart wazuh-manager
+  tags:
+    - init
+    - config
+    - rules
+
+- name: Adding local decoders files
+  copy: src="{{ wazuh_manager_config.ruleset.decoders_path }}"
+        dest=/var/ossec/etc/decoders/
+        owner=root
+        group=ossec
+        mode=0640
   notify: restart wazuh-manager
   tags:
     - init


### PR DESCRIPTION
This PR is inspired by the PR #62 that the user @memelet, thank you @memelet for your work, with the aim of adding extra local rules/decoders files.

To make this work we have modified the files:
- tasks/main.yml adding new tasks ("Adding local rules" and "Adding local decoders")
- defaults/main.yml to include the variables used in the new tasks in tasks/main.yml

In addition, we have created the example files:
- custom_ruleset/rules/sample_custom_rules.xml
- custom_ruleset/decoders/sample_custom_decoders.xml 
