### PR TITLE
Fixes #93

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -18,7 +18,7 @@ wazuh_agent_authd:
 wazuh_notify_time: null
 wazuh_time_reconnect: null
 wazuh_winagent_config:
-  install_dir: 'C:\wazuh-agent\'
+  install_dir: 'C:\Program Files(x86)\ossec-agent\'
   version: '3.3.1'
   revision: '1'
   repo: https://packages.wazuh.com/3.x/windows/


### PR DESCRIPTION
Updated the path to match this documentation:

```
By default, all agent files will be found in: C:\Program Files(x86)\ossec-agent.
```
(Source: https://documentation.wazuh.com/current/installation-guide/installing-wazuh-agent/wazuh_agent_windows.html#using-the-gui)