### PR TITLE
Installing concurrent apt packages

### DIFF
--- a/roles/elastic-stack/ansible-elasticsearch/tasks/Debian.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/Debian.yml
@@ -1,12 +1,10 @@
 ---
 - name: Debian/Ubuntu | Install apt-transport-https and ca-certificates
   apt:
-    name: "{{ item }}"
+    pkg:
+      - apt-transport-https
+      - ca-certificates
     state: present
-    cache_valid_time: 3600
-  with_items:
-    - apt-transport-https
-    - ca-certificates
 
 - when: elasticsearch_install_java
   block:

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/Debian.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/Debian.yml
@@ -1,9 +1,7 @@
 ---
 - name: Debian/Ubuntu | Install apt-transport-https and ca-certificates
   apt:
-    pkg:
-      - apt-transport-https
-      - ca-certificates
+    name: ['apt-transport-https', 'ca-certificates']
     state: present
 
 - when: elasticsearch_install_java

--- a/roles/elastic-stack/ansible-kibana/tasks/Debian.yml
+++ b/roles/elastic-stack/ansible-kibana/tasks/Debian.yml
@@ -1,9 +1,7 @@
 ---
 - name: Debian/Ubuntu | Install apt-transport-https and ca-certificates
   apt:
-    pkg:
-        - apt-transport-https
-        - ca-certificates
+    name: ['apt-transport-https', 'ca-certificates']
     state: present
 
 - name: Debian/Ubuntu | Add Elasticsearch GPG key

--- a/roles/elastic-stack/ansible-kibana/tasks/Debian.yml
+++ b/roles/elastic-stack/ansible-kibana/tasks/Debian.yml
@@ -1,12 +1,10 @@
 ---
 - name: Debian/Ubuntu | Install apt-transport-https and ca-certificates
   apt:
-    name: "{{ item }}"
+    pkg:
+        - apt-transport-https
+        - ca-certificates
     state: present
-    cache_valid_time: 3600
-  with_items:
-    - apt-transport-https
-    - ca-certificates
 
 - name: Debian/Ubuntu | Add Elasticsearch GPG key
   apt_key:

--- a/roles/elastic-stack/ansible-logstash/tasks/Debian.yml
+++ b/roles/elastic-stack/ansible-logstash/tasks/Debian.yml
@@ -1,12 +1,10 @@
 ---
 - name: Debian/Ubuntu | Install apt-transport-https and ca-certificates
   apt:
-    name: "{{ item }}"
+    pkg:
+      - apt-transport-https
+      - ca-certificates
     state: present
-    cache_valid_time: 3600
-  with_items:
-    - apt-transport-https
-    - ca-certificates
 
 - when: logstash_install_java
   block:

--- a/roles/elastic-stack/ansible-logstash/tasks/Debian.yml
+++ b/roles/elastic-stack/ansible-logstash/tasks/Debian.yml
@@ -1,9 +1,7 @@
 ---
 - name: Debian/Ubuntu | Install apt-transport-https and ca-certificates
   apt:
-    pkg:
-      - apt-transport-https
-      - ca-certificates
+    name: ['apt-transport-https', 'ca-certificates']
     state: present
 
 - when: logstash_install_java

--- a/roles/wazuh/ansible-filebeat/tasks/Debian.yml
+++ b/roles/wazuh/ansible-filebeat/tasks/Debian.yml
@@ -1,9 +1,7 @@
 ---
 - name: Debian/Ubuntu | Install apt-transport-https and ca-certificates
   apt:
-    pkg:
-        - apt-transport-https
-        - ca-certificates
+    name: ['apt-transport-https', 'ca-certificates']
     state: present
 
 

--- a/roles/wazuh/ansible-filebeat/tasks/Debian.yml
+++ b/roles/wazuh/ansible-filebeat/tasks/Debian.yml
@@ -1,12 +1,11 @@
 ---
 - name: Debian/Ubuntu | Install apt-transport-https and ca-certificates
   apt:
-    name: "{{ item }}"
+    pkg:
+        - apt-transport-https
+        - ca-certificates
     state: present
-    cache_valid_time: 3600
-  with_items:
-    - apt-transport-https
-    - ca-certificates
+
 
 - name: Debian/Ubuntu | Add Elasticsearch apt key.
   apt_key:

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
@@ -1,9 +1,7 @@
 ---
 - name: Debian/Ubuntu | Install apt-transport-https and ca-certificates
   apt:
-    pkg:
-        - apt-transport-https
-        - ca-certificates
+    name: ['apt-transport-https', 'ca-certificates']
     state: present
 
 - name: Debian/Ubuntu | Installing repository key
@@ -47,11 +45,9 @@
 
 - name: Debian/Ubuntu | Install OpenScap
   apt:
+    name: ['libopenscap8', 'xsltproc']
     state: present
     when: wazuh_agent_config.openscap.disable == 'no'
-    pkg:
-        - libopenscap8
-        - xsltproc
     tags:
         - init
 

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
@@ -1,12 +1,10 @@
 ---
 - name: Debian/Ubuntu | Install apt-transport-https and ca-certificates
   apt:
-    name: "{{ item }}"
+    pkg:
+        - apt-transport-https
+        - ca-certificates
     state: present
-    cache_valid_time: 3600
-  with_items:
-    - apt-transport-https
-    - ca-certificates
 
 - name: Debian/Ubuntu | Installing repository key
   apt_key: url=https://packages.wazuh.com/key/GPG-KEY-WAZUH
@@ -49,15 +47,13 @@
 
 - name: Debian/Ubuntu | Install OpenScap
   apt:
-    name: "{{ item }}"
     state: present
-    cache_valid_time: 3600
-  when: wazuh_agent_config.openscap.disable == 'no'
-  with_items:
-    - libopenscap8
-    - xsltproc
-  tags:
-    - init
+    when: wazuh_agent_config.openscap.disable == 'no'
+    pkg:
+        - libopenscap8
+        - xsltproc
+    tags:
+        - init
 
 - name: Debian/Ubuntu | Get OpenScap installed version
   shell: "dpkg-query --showformat='${Version}' --show libopenscap8"

--- a/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
@@ -1,12 +1,10 @@
 ---
 - name: Debian/Ubuntu | Install apt-transport-https and ca-certificates
   apt:
-    name: "{{ item }}"
+    pkg:
+        - apt-transport-https
+        - ca-certificates
     state: present
-    cache_valid_time: 3600
-  with_items:
-    - apt-transport-https
-    - ca-certificates
 
 - name: Debian/Ubuntu | Installing Wazuh repository key
   apt_key: url=https://packages.wazuh.com/key/GPG-KEY-WAZUH

--- a/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
@@ -1,9 +1,7 @@
 ---
 - name: Debian/Ubuntu | Install apt-transport-https and ca-certificates
   apt:
-    pkg:
-        - apt-transport-https
-        - ca-certificates
+    name: ['apt-transport-https', 'ca-certificates']
     state: present
 
 - name: Debian/Ubuntu | Installing Wazuh repository key


### PR DESCRIPTION
Hi, this PR changes the way that `apt` packages are installed. Before it was done by iterating over items using `with_items`, now a list of packages is described like this:

```
pkg:
       - package1
       - package2
```
Which allows to install the packages concurrently.
Related issue: #109 

Regards