### PR TITLE
Fixed a couple linting issues with yamllint and ansible-review

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/handlers/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/handlers/main.yml
@@ -1,13 +1,15 @@
 ---
 - name: rebuild cdb_lists
-  shell: /var/ossec/bin/ossec-makelists
+  command: /var/ossec/bin/ossec-makelists
 
 - name: restart wazuh-manager
-  service: name=wazuh-manager
-           state=restarted
-           enabled=yes
+  service:
+    name: wazuh-manager
+    state: restarted
+    enabled: true
 
 - name: restart wazuh-api
-  service: name=wazuh-api
-           state=restarted
-           enabled=yes
+  service:
+    name: wazuh-api
+    state: restarted
+    enabled: true


### PR DESCRIPTION
- yamllint: "truthy value should be true or false"
   (Docs: https://github.com/adrienverge/yamllint/blob/master/yamllint/rules/truthy.py)

- ansible-review: "WARN: Best practice 'Use YAML format for tasks and handlers rather than key=value' not met"
  (Docs: https://github.com/willthames/ansible-review/blob/2aacd7462f6a8a96165d9218122171b74de54b13/lib/ansiblereview/tasks.py)

- ansible-review: "Shell should only be used when essential"
  (Docs: https://github.com/willthames/ansible-review/blob/2aacd7462f6a8a96165d9218122171b74de54b13/lib/ansiblereview/examples/standards.py#L95) 