### PR TITLE
Exceptions reload systemd

### DIFF
--- a/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
@@ -71,7 +71,10 @@
 - name: Reload systemd
   systemd: daemon_reload=yes
   ignore_errors: yes
-  when: not (ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA")
+  when: 
+    - not (ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA")
+    - not (ansible_distribution == "Ubuntu" and ansible_distribution_version is version('15.04', '<'))
+    - not (ansible_distribution == "Debian" and ansible_distribution_version is version('8', '<'))
 
 - name: Ensure Elasticsearch started and enabled
   service:

--- a/roles/elastic-stack/ansible-kibana/tasks/main.yml
+++ b/roles/elastic-stack/ansible-kibana/tasks/main.yml
@@ -12,7 +12,10 @@
 - name: Reload systemd
   systemd: daemon_reload=yes
   ignore_errors: yes
-  when: not (ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA")
+  when:
+    - not (ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA")
+    - not (ansible_distribution == "Ubuntu" and ansible_distribution_version is version('15.04', '<'))
+    - not (ansible_distribution == "Debian" and ansible_distribution_version is version('8', '<'))
 
 - name: Kibana configuration
   template:

--- a/roles/elastic-stack/ansible-logstash/tasks/main.yml
+++ b/roles/elastic-stack/ansible-logstash/tasks/main.yml
@@ -11,7 +11,10 @@
 - name: Reload systemd
   systemd: daemon_reload=yes
   ignore_errors: yes
-  when: not (ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA")
+  when:
+    - not (ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA")
+    - not (ansible_distribution == "Ubuntu" and ansible_distribution_version is version('15.04', '<'))
+    - not (ansible_distribution == "Debian" and ansible_distribution_version is version('8', '<'))
 
 - name: Amazon Linux create service
   shell: /usr/share/logstash/bin/system-install /etc/logstash/startup.options

--- a/roles/wazuh/ansible-filebeat/tasks/main.yml
+++ b/roles/wazuh/ansible-filebeat/tasks/main.yml
@@ -16,7 +16,10 @@
 - name: Reload systemd
   systemd: daemon_reload=yes
   ignore_errors: yes
-  when: not (ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA")
+  when:
+    - not (ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA")
+    - not (ansible_distribution == "Ubuntu" and ansible_distribution_version is version('15.04', '<'))
+    - not (ansible_distribution == "Debian" and ansible_distribution_version is version('8', '<'))
 
 - name: Ensure Filebeat is started and enabled at boot.
   service:


### PR DESCRIPTION
Hi team,

This PR add exceptions for the task `Reload systemd` for those case where the task would fail. This PR is created from the idea of the PR #103 and the Issue #102 created by the user @paulcalabro but also adding the exception for debian. Thank you @paulcalabro for your work and your collaboration.

Regards,
Carlos