### PR TITLE
Changed Windows installation directory

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -18,7 +18,10 @@ wazuh_agent_authd:
 wazuh_notify_time: null
 wazuh_time_reconnect: null
 wazuh_winagent_config:
-  install_dir: 'C:\wazuh-agent\'
+  install_dir: 'C:\Program Files\ossec-agent\'
+  install_dir_x86: 'C:\Program Files (x86)\ossec-agent\'
+  auth_path: C:\'Program Files'\ossec-agent\agent-auth.exe
+  auth_path_x86: C:\'Program Files (x86)'\ossec-agent\agent-auth.exe
   version: '3.7.0'
   revision: '1'
   repo: https://packages.wazuh.com/3.x/windows/

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Windows.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Windows.yml
@@ -1,8 +1,15 @@
 ---
+- name: Windows | Check if Program Files (x86) exists
+  win_stat: 
+    path: C:\Program Files (x86)
+  register: check_path
+
 - name: Windows | Get current installed version
-  win_shell: "{{ wazuh_winagent_config.install_dir }}ossec-agent.exe -h"
+  win_shell: "{% if check_path.stat.exists == true %}{{ wazuh_winagent_config.install_dir_x86 }}{% else %}
+  {{ wazuh_winagent_config.install_dir }}{% endif %}ossec-agent.exe -h"
   args:
-    removes: "{{ wazuh_winagent_config.install_dir }}ossec-agent.exe"
+    removes: "{% if check_path.stat.exists == true %}{{ wazuh_winagent_config.install_dir_x86 }}{% else %}
+    {{ wazuh_winagent_config.install_dir }}{% endif %}ossec-agent.exe"
   register: agent_version
   failed_when: False
   changed_when: False
@@ -34,12 +41,11 @@
 - name: Windows | Install Wazuh agent
   win_package:
     path: C:\wazuh-agent-installer.msi
-    arguments: APPLICATIONFOLDER={{ wazuh_winagent_config.install_dir }}
   when:
     - correct_version is not defined
 
 - name: Windows | Check if client.keys exists
-  win_stat: path="{{ wazuh_winagent_config.install_dir }}client.keys"
+  win_stat: path="{% if check_path.stat.exists == true %}{{ wazuh_winagent_config.install_dir_x86 }}{% else %}{{ wazuh_winagent_config.install_dir }}{% endif %}client.keys"
   register: check_windows_key
   notify: restart wazuh-agent windows
   tags:
@@ -52,12 +58,13 @@
 
 - name: Windows | Register agent
   win_shell: >
-    {{ wazuh_winagent_config.install_dir }}agent-auth.exe
+    {% if check_path.stat.exists == true %}{{ wazuh_winagent_config.auth_path_x86 }}{% else %}
+    {{ wazuh_winagent_config.auth_path }}{% endif %}
     -m {{ wazuh_managers.0.address }}
     -p {{ wazuh_agent_authd.port }}
-    {% if authd_pass is defined %}-P {{ authd_pass }}{% endif %}
+    {% if authd_pass is defined %} -P {{ authd_pass }}{% endif %}
   args:
-    chdir: "{{ wazuh_winagent_config.install_dir }}"
+    chdir: "{% if check_path.stat.exists == true %}{{ wazuh_winagent_config.install_dir_x86 }}{% else %}{{ wazuh_winagent_config.install_dir }}{% endif %}"
   register: agent_auth_output
   notify: restart wazuh-agent windows
   when:
@@ -70,7 +77,7 @@
 - name: Windows | Installing agent configuration (ossec.conf)
   win_template:
     src: var-ossec-etc-ossec-agent.conf.j2
-    dest: "{{ wazuh_winagent_config.install_dir }}ossec.conf"
+    dest: "{% if check_path.stat.exists == true %}{{ wazuh_winagent_config.install_dir_x86 }}{% else %}{{ wazuh_winagent_config.install_dir }}{% endif %}ossec.conf"
   notify: restart wazuh-agent windows
   tags:
     - config
@@ -78,7 +85,7 @@
 - name: Windows | Installing local_internal_options.conf
   win_template:
     src: var-ossec-etc-local-internal-options.conf.j2
-    dest: "{{ wazuh_winagent_config.install_dir }}local_internal_options.conf"
+    dest: "{% if check_path.stat.exists == true %}{{ wazuh_winagent_config.install_dir_x86 }}{% else %}{{ wazuh_winagent_config.install_dir }}{% endif %}local_internal_options.conf"
   notify: restart wazuh-agent windows
   tags:
     - config


### PR DESCRIPTION
Hi team,

Like @manuasir said in the Issue #93 Ansible was installing the Wazuh agents for Windows in an incorrect path, this PR fix this. Thank you @manuasir for noticing.

- Added a task to check if the path `C:\Program Files (x86)` exists.
- Changed the path installation to the default one.
- IF/ELSE condition in the need it tasks depending if `C:\Program Files (x86)` exists.

I tested this changes in:
- windows7
- windows 8.1
- windows 10

and tested if the agents communicate well with the manager and that the manager recieves the alerts of the agents

Regards,
Carlos