### PR TITLE
Custom name for single agent registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [v3.7.2]
 
+### Added
+
+- Added custom name for single agent registration ([#117](https://github.com/wazuh/wazuh-ansible/pull/117))
+
 ### Changed
 
 - Adapt configuration to current release ([#106](https://github.com/wazuh/wazuh-ansible/pull/106))

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
@@ -45,6 +45,7 @@
     - name: Linux | Register agent (via authd)
       shell: >
         /var/ossec/bin/agent-auth
+        -A {{ agent_name }}
         -m {{ wazuh_managers.0.address }}
         -p {{ wazuh_agent_authd.port }}
         {% if authd_pass is defined %}-P {{ authd_pass }}{% endif %}
@@ -55,6 +56,8 @@
         {% endif %}
         {% if wazuh_agent_authd.ssl_auto_negotiate == 'yes' %}-a{% endif %}
       register: agent_auth_output
+      vars:
+        agent_name: "{% if single_agent_name is defined %}{{ single_agent_name }}{% else %}{{ ansible_hostname }}{% endif %}"
       when:
         - check_keys.stat.exists == false or check_keys.stat.size == 0
         - wazuh_managers.0.address is not none
@@ -87,7 +90,7 @@
         url: "{{ wazuh_managers.0.api_proto }}://{{ wazuh_managers.0.address }}:{{ wazuh_managers.0.api_port }}/agents/"
         validate_certs: no
         method: POST
-        body: {"name":"{{ inventory_hostname }}"}
+        body: {"name":"{{ agent_name }}"}
         body_format: json
         status_code: 200
         headers:
@@ -96,6 +99,8 @@
         password: "{{ api_pass }}"
       register: newagent_api
       changed_when: newagent_api.json.error == 0
+      vars:
+        agent_name: "{% if single_agent_name is defined %}{{ single_agent_name }}{% else %}{{ inventory_hostname }}{% endif %}"      
       when:
         - check_keys.stat.exists == false or check_keys.stat.size == 0
         - wazuh_managers.0.address is not none


### PR DESCRIPTION
Hi team,

This PR solve the Issue #91, this issue was requested by the user @colbyprior in the PR #68. Thank you @colbyprior for the idea and helping us improve the repository. 

The aim of this PR is to add the possibility, during the installation of a single agent, to name the agent with a desired name. The custom name has to be entered through the command line by adding `--extra-vars "single_agent_name =custom_name"` if we don't enter this command the agent will be installed with its default name.

For example, in a single agent installation with a default named debian-1:
- ansible-playbook wazuh-agent.yml --extra-vars "single_agent_name =custom_name" --> custom_name
- ansible-playbook wazuh-agent.yml --> debian-1

Regards,
Carlos
