### PR TITLE
Fixes typos: The word credentials doesn't have two consecutive e's

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/README.md
+++ b/roles/wazuh/ansible-wazuh-manager/README.md
@@ -26,11 +26,11 @@ wazuh_agent_configs: []
 Vault variables
 ----------------
 
-### vars/agentless_creeds.yml
+### vars/agentless_creds.yml
 This file has the agenless credentials.
 ```
 ---
- agentless_creeds:
+ agentless_creds:
  - type: ssh_integrity_check_linux
    frequency: 3600
    host: root@example.net

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -168,7 +168,7 @@
     - config
 
 - name: Retrieving Agentless Credentials
-  include_vars: agentless_creeds.yml
+  include_vars: agentless_creds.yml
   tags:
     - config
 
@@ -231,7 +231,7 @@
   notify: restart wazuh-manager
   when:
     - agentlessd_enabled.stdout == '0' or "skipped" in agentlessd_enabled.stdout
-    - agentless_creeds is defined
+    - agentless_creds is defined
   tags:
     - config
 
@@ -324,13 +324,13 @@
     group: root
     mode: 0644
   no_log: true
-  when: agentless_creeds is defined
+  when: agentless_creds is defined
   tags:
     - config
 
 - name: Encode the secret
   shell: /usr/bin/base64 /var/ossec/agentless/.passlist_tmp > /var/ossec/agentless/.passlist && rm /var/ossec/agentless/.passlist_tmp
-  when: agentless_creeds is defined
+  when: agentless_creds is defined
   tags:
     - config
 

--- a/roles/wazuh/ansible-wazuh-manager/templates/agentless.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/agentless.j2
@@ -1,3 +1,3 @@
-{% for agentless in agentless_creeds %}
+{% for agentless in agentless_creds %}
 {{ agentless.host }}|{{ agentless.passwd }}
 {% endfor %}

--- a/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
@@ -382,8 +382,8 @@
   </wodle>
   {% endif %}
 
-{% if agentless_creeds is defined %}
-{% for agentless in agentless_creeds %}
+{% if agentless_creds is defined %}
+{% for agentless in agentless_creds %}
   <agentless>
     <type>{{ agentless.type }}</type>
     <frequency>{{ agentless.frequency }}</frequency>

--- a/roles/wazuh/ansible-wazuh-manager/vars/agentless_creds.yml
+++ b/roles/wazuh/ansible-wazuh-manager/vars/agentless_creds.yml
@@ -1,5 +1,5 @@
 ---
-# agentless_creeds:
+# agentless_creds:
 # - type: ssh_integrity_check_linux
 #   frequency: 3600
 #   host: root@example.net


### PR DESCRIPTION
Matches spelling of `vars/wazuh_api_creds.yml`.