### PR TITLE
comment out example wazuh_api_user

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/vars/wazuh_api_creds.yml
+++ b/roles/wazuh/ansible-wazuh-manager/vars/wazuh_api_creds.yml
@@ -1,3 +1,3 @@
 ---
-wazuh_api_user:
-  - "foo:$apr1$/axqZYWQ$Xo/nz/IG3PdwV82EnfYKh/"
+#wazuh_api_user:
+#  - "foo:$apr1$/axqZYWQ$Xo/nz/IG3PdwV82EnfYKh/"


### PR DESCRIPTION
Due to the high precedence of the content of the vars directory,
it is not possible to override wazuh_api_user from the vars of the
role, the play or the host/group vars directories.