### PR TITLE
Configure labels from Ansible

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/README.md
+++ b/roles/wazuh/ansible-wazuh-agent/README.md
@@ -19,6 +19,7 @@ Role Variables
 
 * `wazuh_managers`: Collection of Wazuh Managers' IP address, port, and protocol used by the agent
 * `wazuh_agent_authd`: Collection with the settings to register an agent using authd.
+* `wazuh_agent_labels`: Collection of labels applied to an agent.
 
 Playbook example
 ----------------
@@ -41,7 +42,12 @@ The following is an example of how this role can be used:
            port: 1515
            ssl_agent_ca: null
            ssl_auto_negotiate: 'no'
-     
+         wazuh_agent_labels:
+           - key: Env
+             value: Production
+           - key: installation
+             value: 04/01/2019
+             hidden: "yes"
 
 License and copyright
 ---------------------

--- a/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
+++ b/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
@@ -284,4 +284,12 @@
     </localfile>
   {% endfor %}
   {% endif %}
+  {% if wazuh_agent_labels is defined %}
+
+  <labels>
+  {% for label in wazuh_agent_labels %}
+    <label key="{{ label.key }}"{% if label.hidden is defined %} hidden="{{ label.hidden }}"{% endif %}>{{ label.value }}</label>
+  {% endfor %}
+  </labels>
+  {% endif %}
 </ossec_config>


### PR DESCRIPTION
This allows to configure labels in ossec.conf directly from Ansible. I choose not to touch to `wazuh_agent_config` and instead dedicate a new variable to the labels.

What do you think ?