### PR TITLE
Erasing extra spaces in playbooks

### DIFF
--- a/playbooks/wazuh-elastic.yml
+++ b/playbooks/wazuh-elastic.yml
@@ -1,3 +1,3 @@
 - hosts: <your elasticsearch host>
   roles:
-    - { role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-elasticsearch, elasticsearch_network_host: 'your elasticsearch IP' }
+    - {role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-elasticsearch, elasticsearch_network_host: 'your elasticsearch IP'}

--- a/playbooks/wazuh-elastic_stack-distributed.yml
+++ b/playbooks/wazuh-elastic_stack-distributed.yml
@@ -1,9 +1,9 @@
 - hosts: <your wazuh server host>
   roles:
     - role: /etc/ansible/roles/wazuh-ansible/roles/wazuh/ansible-wazuh-manager
-    - { role: /etc/ansible/roles/wazuh-ansible/roles/wazuh/ansible-filebeat, filebeat_output_logstash_hosts: 'your elastic stack server IP' }
+    - {role: /etc/ansible/roles/wazuh-ansible/roles/wazuh/ansible-filebeat, filebeat_output_logstash_hosts: 'your elastic stack server IP'}
 - hosts: <your elastic stack server host>
   roles:
-    - { role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-elasticsearch, elasticsearch_network_host: 'localhost' }
-    - { role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-logstash, logstash_input_beats: true, elasticsearch_network_host: 'localhost' }
-    - { role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-kibana, elasticsearch_network_host: 'localhost' }
+    - {role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-elasticsearch, elasticsearch_network_host: 'localhost'}
+    - {role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-logstash, logstash_input_beats: true, elasticsearch_network_host: 'localhost'}
+    - {role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-kibana, elasticsearch_network_host: 'localhost'}

--- a/playbooks/wazuh-elastic_stack-single.yml
+++ b/playbooks/wazuh-elastic_stack-single.yml
@@ -1,6 +1,6 @@
 - hosts: <your single server host>
   roles:
-      - { role: /etc/ansible/roles/wazuh-ansible/roles/wazuh/ansible-wazuh-manager }
-      - { role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-elasticsearch, elasticsearch_network_host: 'localhost' }
+      - {role: /etc/ansible/roles/wazuh-ansible/roles/wazuh/ansible-wazuh-manager}
+      - {role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-elasticsearch, elasticsearch_network_host: 'localhost'}
       - { role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-logstash, elasticsearch_network_host: 'localhost' }
       - { role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-kibana, elasticsearch_network_host: 'localhost' }

--- a/playbooks/wazuh-kibana.yml
+++ b/playbooks/wazuh-kibana.yml
@@ -1,3 +1,3 @@
 - hosts: <your kibana host>
   roles:
-    - { role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-kibana, elasticsearch_network_host: 'your elasticsearch IP' }
+    - {role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-kibana, elasticsearch_network_host: 'your elasticsearch IP'}

--- a/playbooks/wazuh-logstash.yml
+++ b/playbooks/wazuh-logstash.yml
@@ -1,3 +1,3 @@
 - hosts: <your logstash host>
   roles:
-    - { role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-logstash, elasticsearch_network_host: ["localhost"] }
+    - {role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-logstash, elasticsearch_network_host: ["localhost"]}

--- a/playbooks/wazuh-manager.yml
+++ b/playbooks/wazuh-manager.yml
@@ -1,4 +1,4 @@
 - hosts: <your wazuh server host>
   roles:
     - role: /etc/ansible/roles/wazuh-ansible/roles/wazuh/ansible-wazuh-manager
-    - { role: /etc/ansible/roles/wazuh-ansible/roles/wazuh/ansible-filebeat, filebeat_output_logstash_hosts: 'your logstash IP' }
+    - {role: /etc/ansible/roles/wazuh-ansible/roles/wazuh/ansible-filebeat, filebeat_output_logstash_hosts: 'your logstash IP'}

--- a/roles/wazuh/ansible-wazuh-manager/playbook.yml
+++ b/roles/wazuh/ansible-wazuh-manager/playbook.yml
@@ -1,3 +1,0 @@
-- hosts: wazuh-server.example.com
-  roles:
-     - { role: ansible-wazuh-server }


### PR DESCRIPTION
Hi team,

This PR comes from the idea that @paulcalabro gave us in the PR #124. Thank you @paulcalabro for your idea and your contribution.

In this PR we modified:
- Erase extra spaces in all the playbook files.
- Erase wazuh-manager/playbook.yml. That file is useless, it seems we forgot to erase it in the restructuration  of the repository #66.

Regards,
Carlos