### PR TITLE
wazuh-agent: do not scan_on_start openscap

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -75,7 +75,7 @@ wazuh_agent_config:
     disable: 'no'
     timeout: 1800
     interval: '1d'
-    scan_on_start: 'yes'
+    scan_on_start: 'no' # see https://github.com/wazuh/wazuh/issues/2331
   osquery:
     disable: 'yes'
     run_daemon: 'yes'


### PR DESCRIPTION
it requires a lot of CPU and RAM[0] and is very likely to cause
problems at boot time on production systems, either because the
processes timeout or because they run out of memory.

[0] https://github.com/wazuh/wazuh/issues/2331

Fixes: https://github.com/wazuh/wazuh-ansible/issues/139