### PR TITLE
Fix a couple of minor warnings from default 3.8 manager role

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -29,7 +29,6 @@ wazuh_manager_config:
     node_name: 'manager_01'
     node_type: 'master'
     key: 'ugdtAnd7Pi9myP7CVts4qZaZQEQcRYZa'
-    interval: '2m'
     port: '1516'
     bind_addr: '0.0.0.0'
     nodes:

--- a/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
@@ -235,7 +235,7 @@
       <disabled>{{ wazuh_manager_config.vul_detector.ubuntu.disable }}</disabled>
       <update_interval>{{ wazuh_manager_config.vul_detector.ubuntu.update_interval }}</update_interval>
     </feed>
-    <feed name="redhat-7">
+    <feed name="redhat">
       <disabled>{{ wazuh_manager_config.vul_detector.redhat.disable }}</disabled>
       <update_interval>{{ wazuh_manager_config.vul_detector.redhat.update_interval }}</update_interval>
     </feed>


### PR DESCRIPTION
For #145 to fix a couple of minor warnings in the ossec.log file when starting a Manager based upon the defaults when using the 3.8 branch of the ansible-wazuh-manager role.