### PR TITLE
Replace netstat by ss and add filesystem filtering to df

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -281,7 +281,7 @@ wazuh_agent_config:
       - format: 'syslog'
         location: '/var/ossec/logs/active-responses.log'
       - format: 'command'
-        command: 'df -P'
+        command: df -P -x squashfs -x tmpfs -x devtmpfs
         frequency: '360'
       - format: 'full_command'
         command: ss -nutal | awk '{print $1,$5,$6;}' | sort -b | column -t

--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -284,7 +284,7 @@ wazuh_agent_config:
         command: 'df -P'
         frequency: '360'
       - format: 'full_command'
-        command: netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d         
+        command: ss -nutal | awk '{print $1,$5,$6;}' | sort -b | column -t
         alias: 'netstat listening ports'      
         frequency: '360'
       - format: 'full_command'

--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -183,7 +183,7 @@ wazuh_manager_config:
   localfiles:
     common:
        - format: 'command'
-         command: 'df -P'
+         command: df -P -x squashfs -x tmpfs -x devtmpfs
          frequency: '360'
        - format: 'full_command'
          command: ss -nutal | awk '{print $1,$5,$6;}' | sort -b | column -t

--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -186,7 +186,7 @@ wazuh_manager_config:
          command: 'df -P'
          frequency: '360'
        - format: 'full_command'
-         command: netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d
+         command: ss -nutal | awk '{print $1,$5,$6;}' | sort -b | column -t
          alias: 'netstat listening ports'
          frequency: '360'
        - format: 'full_command'


### PR DESCRIPTION
Tell `df` not to report on virtual filesystems such as `squashfs` (used    by `snapd` and always at 100%), `tmpfs` (memory-only) and `devtmpfs`    (used by `udev`)

The `ss` program is now the official replacement for `netstat` which    is deprecated in most Linux distributions. Also replace the messy sed    rules which do not work on all versions with a clean command-line that    just displays the key information that does **not** change on every    command run (e.g. PID) resulting in false positives.