### PR TITLE
Add flag to accept remote commands from manager

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -281,7 +281,7 @@ wazuh_agent_config:
       - format: 'syslog'
         location: '/var/ossec/logs/active-responses.log'
       - format: 'command'
-        command: 'df -P'
+        command: df -P -x squashfs -x tmpfs -x devtmpfs
         frequency: '360'
       - format: 'full_command'
         command: ss -nutal | awk '{print $1,$5,$6;}' | sort -b | column -t

--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -284,7 +284,7 @@ wazuh_agent_config:
         command: 'df -P'
         frequency: '360'
       - format: 'full_command'
-        command: netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d         
+        command: ss -nutal | awk '{print $1,$5,$6;}' | sort -b | column -t
         alias: 'netstat listening ports'      
         frequency: '360'
       - format: 'full_command'

--- a/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-local-internal-options.conf.j2
+++ b/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-local-internal-options.conf.j2
@@ -10,3 +10,7 @@
 
 # This is the template of Ansible for the file local_internal_options.conf
 # In this file you could include the configuration settings for your agents
+
+# Logcollector - If it should accept remote commands from the manager
+logcollector.remote_commands=1
+

--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -183,7 +183,7 @@ wazuh_manager_config:
   localfiles:
     common:
        - format: 'command'
-         command: 'df -P'
+         command: df -P -x squashfs -x tmpfs -x devtmpfs
          frequency: '360'
        - format: 'full_command'
          command: ss -nutal | awk '{print $1,$5,$6;}' | sort -b | column -t

--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -186,7 +186,7 @@ wazuh_manager_config:
          command: 'df -P'
          frequency: '360'
        - format: 'full_command'
-         command: netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d
+         command: ss -nutal | awk '{print $1,$5,$6;}' | sort -b | column -t
          alias: 'netstat listening ports'
          frequency: '360'
        - format: 'full_command'


### PR DESCRIPTION
Without this flag the agent will not accept any system check     commands (`command` and `full_command`) configured in the Wazuh     Manager settings to cascade down to agents.
