### PR TITLE
Adding alias to agent config file template

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
+++ b/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
@@ -291,6 +291,9 @@
     {% if localfile.format == 'command' or localfile.format == 'full_command' %}
         <command>{{ localfile.command }}</command>
         <frequency>{{ localfile.frequency }}</frequency>
+        {% if localfile.alias is defined %}
+          <alias>{{ localfile.alias }}</alias>
+        {% endif %}
     {% else %}
         <location>{{ localfile.location }}</location>
     {% endif %}
@@ -305,6 +308,9 @@
     {% if localfile.format == 'command' or localfile.format == 'full_command' %}
         <command>{{ localfile.command }}</command>
         <frequency>{{ localfile.frequency }}</frequency>
+        {% if localfile.alias is defined %}
+          <alias>{{ localfile.alias }}</alias>
+        {% endif %}
     {% else %}
         <location>{{ localfile.location }}</location>
     {% endif %}
@@ -319,6 +325,9 @@
     {% if localfile.format == 'command' or localfile.format == 'full_command' %}
         <command>{{ localfile.command }}</command>
         <frequency>{{ localfile.frequency }}</frequency>
+        {% if localfile.alias is defined %}
+          <alias>{{ localfile.alias }}</alias>
+        {% endif %}
     {% else %}
         <location>{{ localfile.location }}</location>
     {% endif %}


### PR DESCRIPTION
Hi team,
this PR solves https://github.com/wazuh/wazuh-ansible/issues/162. It adds the [alias options](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/localfile.html?highlight=localfiles#alias) to the [template](https://github.com/wazuh/wazuh-ansible/blob/3.9/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2) of the agent config file.