### PR TITLE
Changing  from Oracle JDK to OpenJDK

### DIFF
--- a/roles/elastic-stack/ansible-elasticsearch/tasks/Debian.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/Debian.yml
@@ -7,7 +7,7 @@
 - when: elasticsearch_install_java
   block:
     - name: Debian/Ubuntu | Install OpenJDK 1.8
-      apt: name=openjdk-8-jre state=present cache_valid_time=3600    
+      apt: name=openjdk-8-jre state=present cache_valid_time=3600
       tags: install
 
 - name: Debian/Ubuntu | Add Elasticsearch GPG key.

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/Debian.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/Debian.yml
@@ -7,7 +7,7 @@
 - when: elasticsearch_install_java
   block:
     - name: Debian/Ubuntu | Install OpenJDK 1.8
-      apt: name: openjdk-8-jre state: present cache_valid_time: 3600    
+      apt: name= openjdk-8-jre state= present cache_valid_time= 3600    
       tags: install
 
 - name: Debian/Ubuntu | Add Elasticsearch GPG key.

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/Debian.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/Debian.yml
@@ -6,24 +6,8 @@
 
 - when: elasticsearch_install_java
   block:
-    - name: Debian/Ubuntu | Setting webupd8 repository
-      apt_repository:
-        repo: 'ppa:webupd8team/java'
-        codename: 'xenial'
-        update_cache: yes
-
-    - name: Debian/Ubuntu | Accept Oracle Java 8 license
-      debconf:
-        name: oracle-java8-installer
-        question: shared/accepted-oracle-license-v1-1
-        value: true
-        vtype: boolean
-
-    - name: Debian/Ubuntu | Oracle Java 8 installer
-      apt:
-        name: oracle-java8-installer
-        state: present
-        cache_valid_time: 3600
+    - name: Debian/Ubuntu | Install OpenJDK 1.8
+      apt: name: openjdk-8-jre state: present cache_valid_time: 3600    
       tags: install
 
 - name: Debian/Ubuntu | Add Elasticsearch GPG key.

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/Debian.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/Debian.yml
@@ -7,7 +7,7 @@
 - when: elasticsearch_install_java
   block:
     - name: Debian/Ubuntu | Install OpenJDK 1.8
-      apt: name= openjdk-8-jre state= present cache_valid_time= 3600    
+      apt: name=openjdk-8-jre state=present cache_valid_time=3600    
       tags: install
 
 - name: Debian/Ubuntu | Add Elasticsearch GPG key.

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/RedHat.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/RedHat.yml
@@ -2,7 +2,7 @@
 - when: elasticsearch_install_java
   block:
     - name: RedHat/CentOS/Fedora | Install OpenJDK 1.8
-      yum: name=java-1.8.0-openjdk state=present    
+      yum: name=java-1.8.0-openjdk state=present
       register: oracle_java_task_rpm_installed
       tags: install
 

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/RedHat.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/RedHat.yml
@@ -1,16 +1,8 @@
 ---
 - when: elasticsearch_install_java
   block:
-    - name: RedHat/CentOS/Fedora | download Oracle Java RPM
-      get_url:
-        url: https://download.oracle.com/otn-pub/java/jdk/8u202-b08/1961070e4c9b4e26a04e7f5a083f551e/jre-8u202-linux-x64.rpm
-        dest: /tmp/jre-8-linux-x64.rpm
-        headers: 'Cookie:oraclelicense=accept-securebackup-cookie'
-      register: oracle_java_task_rpm_download
-
-    - name: RedHat/CentOS/Fedora | Install Oracle Java RPM
-      package: name=/tmp/jre-8-linux-x64.rpm state=present
-      when: oracle_java_task_rpm_download is defined
+    - name: RedHat/CentOS/Fedora | Install OpenJDK 1.8
+      yum: name=java-1.8.0-openjdk state=present    
       register: oracle_java_task_rpm_installed
       tags: install
 

--- a/roles/elastic-stack/ansible-logstash/tasks/Debian.yml
+++ b/roles/elastic-stack/ansible-logstash/tasks/Debian.yml
@@ -6,23 +6,8 @@
 
 - when: logstash_install_java
   block:
-    - name: Debian/Ubuntu | Setting webupd8 repository
-      apt_repository:
-        repo: 'ppa:webupd8team/java'
-        codename: 'xenial'
-
-    - name: Debian/Ubuntu | Accept Oracle Java 8 license
-      debconf:
-        name: oracle-java8-installer
-        question: shared/accepted-oracle-license-v1-1
-        value: true
-        vtype: boolean
-
-    - name: Debian/Ubuntu | Oracle Java 8 installer
-      apt:
-        name: oracle-java8-installer
-        state: present
-        cache_valid_time: 3600
+    - name: Debian/Ubuntu | Install OpenJDK 1.8
+      apt: name: openjdk-8-jre state: present cache_valid_time: 3600    
       tags: install
 
 - name: Debian/Ubuntu | Add Elasticsearch GPG key

--- a/roles/elastic-stack/ansible-logstash/tasks/Debian.yml
+++ b/roles/elastic-stack/ansible-logstash/tasks/Debian.yml
@@ -7,7 +7,7 @@
 - when: logstash_install_java
   block:
     - name: Debian/Ubuntu | Install OpenJDK 1.8
-      apt: name: openjdk-8-jre state: present cache_valid_time: 3600    
+      apt: name= openjdk-8-jre state= present cache_valid_time= 3600    
       tags: install
 
 - name: Debian/Ubuntu | Add Elasticsearch GPG key

--- a/roles/elastic-stack/ansible-logstash/tasks/Debian.yml
+++ b/roles/elastic-stack/ansible-logstash/tasks/Debian.yml
@@ -7,7 +7,7 @@
 - when: logstash_install_java
   block:
     - name: Debian/Ubuntu | Install OpenJDK 1.8
-      apt: name=openjdk-8-jre state=present cache_valid_time=3600    
+      apt: name=openjdk-8-jre state=present cache_valid_time=3600
       tags: install
 
 - name: Debian/Ubuntu | Add Elasticsearch GPG key

--- a/roles/elastic-stack/ansible-logstash/tasks/Debian.yml
+++ b/roles/elastic-stack/ansible-logstash/tasks/Debian.yml
@@ -7,7 +7,7 @@
 - when: logstash_install_java
   block:
     - name: Debian/Ubuntu | Install OpenJDK 1.8
-      apt: name= openjdk-8-jre state= present cache_valid_time= 3600    
+      apt: name=openjdk-8-jre state=present cache_valid_time=3600    
       tags: install
 
 - name: Debian/Ubuntu | Add Elasticsearch GPG key

--- a/roles/elastic-stack/ansible-logstash/tasks/RedHat.yml
+++ b/roles/elastic-stack/ansible-logstash/tasks/RedHat.yml
@@ -1,16 +1,8 @@
 ---
 - when: logstash_install_java
   block:
-    - name: RedHat/CentOS/Fedora | download Oracle Java RPM
-      get_url:
-        url: https://download.oracle.com/otn-pub/java/jdk/8u202-b08/1961070e4c9b4e26a04e7f5a083f551e/jre-8u202-linux-x64.rpm
-        dest: /tmp/jre-8-linux-x64.rpm
-        headers: 'Cookie:oraclelicense=accept-securebackup-cookie'
-      register: oracle_java_task_rpm_download
-
-    - name: RedHat/CentOS/Fedora | Install Oracle Java RPM
-      package: name=/tmp/jre-8-linux-x64.rpm state=present
-      when: oracle_java_task_rpm_download is defined
+    - name: RedHat/CentOS/Fedora | Install OpenJDK 1.8
+      yum: name=java-1.8.0-openjdk state=present    
       register: oracle_java_task_rpm_installed
       tags: install
 

--- a/roles/elastic-stack/ansible-logstash/tasks/RedHat.yml
+++ b/roles/elastic-stack/ansible-logstash/tasks/RedHat.yml
@@ -2,7 +2,7 @@
 - when: logstash_install_java
   block:
     - name: RedHat/CentOS/Fedora | Install OpenJDK 1.8
-      yum: name=java-1.8.0-openjdk state=present    
+      yum: name=java-1.8.0-openjdk state=present
       register: oracle_java_task_rpm_installed
       tags: install
 

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
@@ -22,24 +22,8 @@
   - wazuh_agent_config.cis_cat.disable == 'no'
   - wazuh_agent_config.cis_cat.install_java == 'yes'
   block:
-  - name: Debian/Ubuntu | Setting webupd8 repository
-    apt_repository:
-      repo: 'ppa:webupd8team/java'
-      codename: 'xenial'
-      update_cache: yes
-
-  - name: Debian/Ubuntu | Accept Oracle Java 8 license
-    debconf:
-      name: oracle-java8-installer
-      question: shared/accepted-oracle-license-v1-1
-      value: true
-      vtype: boolean
-
-  - name: Debian/Ubuntu | Oracle Java 8 installer
-    apt:
-      name: oracle-java8-installer
-      state: present
-      cache_valid_time: 3600
+  - name: Debian/Ubuntu | Install OpenJDK 1.8
+    apt: name: openjdk-8-jre state: present cache_valid_time: 3600       
   tags:
     - init
 

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
@@ -37,12 +37,20 @@
     cis_distribution_filename: cis_debian_linux_rcl.txt
   when: ansible_os_family == "Debian"
 
+- name: Debian/Ubuntu | Install OpenJDK-8 repo
+  apt_repository:
+    repo: 'ppa:openjdk-r/ppa'
+    state: present
+    update_cache: true
+  when:
+    - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int == 14)
+
 - when:
-  - wazuh_agent_config.cis_cat.disable == 'no'
-  - wazuh_agent_config.cis_cat.install_java == 'yes'
+    - wazuh_agent_config.cis_cat.disable == 'no'
+    - wazuh_agent_config.cis_cat.install_java == 'yes'
   block:
-  - name: Debian/Ubuntu | Install OpenJDK 1.8
-    apt: name=openjdk-8-jre state=present cache_valid_time=3600       
+    - name: Debian/Ubuntu | Install OpenJDK 1.8
+      apt: name=openjdk-8-jre state=present cache_valid_time=3600
   tags:
     - init
 

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
@@ -23,7 +23,7 @@
   - wazuh_agent_config.cis_cat.install_java == 'yes'
   block:
   - name: Debian/Ubuntu | Install OpenJDK 1.8
-    apt: name: openjdk-8-jre state: present cache_valid_time: 3600       
+    apt: name= openjdk-8-jre state= present cache_valid_time= 3600       
   tags:
     - init
 

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
@@ -23,7 +23,7 @@
   - wazuh_agent_config.cis_cat.install_java == 'yes'
   block:
   - name: Debian/Ubuntu | Install OpenJDK 1.8
-    apt: name= openjdk-8-jre state= present cache_valid_time= 3600       
+    apt: name=openjdk-8-jre state=present cache_valid_time=3600       
   tags:
     - init
 

--- a/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
@@ -36,24 +36,8 @@
    - wazuh_manager_config.cis_cat.disable == 'no'
    - wazuh_manager_config.cis_cat.install_java == 'yes'
   block:
-  - name: Debian/Ubuntu | Setting webupd8 repository
-    apt_repository:
-      repo: 'ppa:webupd8team/java'
-      codename: 'xenial'
-      update_cache: yes
-
-  - name: Debian/Ubuntu | Accept Oracle Java 8 license
-    debconf:
-      name: oracle-java8-installer
-      question: shared/accepted-oracle-license-v1-1
-      value: true
-      vtype: boolean
-
-  - name: Debian/Ubuntu | Oracle Java 8 installer
-    apt:
-      name: oracle-java8-installer
-      state: present
-      cache_valid_time: 3600
+    - name: Debian/Ubuntu | Install OpenJDK 1.8
+      apt: name: openjdk-8-jre state: present cache_valid_time: 3600       
   tags:
     - init
 

--- a/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
@@ -37,7 +37,7 @@
    - wazuh_manager_config.cis_cat.install_java == 'yes'
   block:
     - name: Debian/Ubuntu | Install OpenJDK 1.8
-      apt: name: openjdk-8-jre state: present cache_valid_time: 3600       
+      apt: name= openjdk-8-jre state= present cache_valid_time= 3600       
   tags:
     - init
 

--- a/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
@@ -37,7 +37,7 @@
    - wazuh_manager_config.cis_cat.install_java == 'yes'
   block:
     - name: Debian/Ubuntu | Install OpenJDK 1.8
-      apt: name= openjdk-8-jre state= present cache_valid_time= 3600       
+      apt: name=openjdk-8-jre state=present cache_valid_time=3600       
   tags:
     - init
 

--- a/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
@@ -64,12 +64,20 @@
   set_fact:
     cis_distribution_filename: cis_debian_linux_rcl.txt
 
+- name: Debian/Ubuntu | Install OpenJDK-8 repo
+  apt_repository:
+    repo: 'ppa:openjdk-r/ppa'
+    state: present
+    update_cache: true
+  when:
+    - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int == 14)
+
 - when:
-   - wazuh_manager_config.cis_cat.disable == 'no'
-   - wazuh_manager_config.cis_cat.install_java == 'yes'
+    - wazuh_manager_config.cis_cat.disable == 'no'
+    - wazuh_manager_config.cis_cat.install_java == 'yes'
   block:
     - name: Debian/Ubuntu | Install OpenJDK 1.8
-      apt: name=openjdk-8-jre state=present cache_valid_time=3600       
+      apt: name=openjdk-8-jre state=present cache_valid_time=3600
   tags:
     - init
 

--- a/roles/wazuh/ansible-wazuh-manager/tasks/RedHat.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/RedHat.yml
@@ -115,7 +115,7 @@
     - wazuh_manager_config.cluster.disable != 'yes'
 
 - name: RedHat/CentOS/Fedora | Install OpenJDK 1.8
-  yum: name=java-1.8.0-openjdk state=present    
+  yum: name=java-1.8.0-openjdk state=present
   when:
     - wazuh_manager_config.cis_cat.disable == 'no'
     - wazuh_manager_config.cis_cat.install_java == 'yes'

--- a/roles/wazuh/ansible-wazuh-manager/tasks/RedHat.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/RedHat.yml
@@ -94,24 +94,11 @@
     - not (( ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat') and ansible_distribution_major_version == '6' )
     - wazuh_manager_config.cluster.disable != 'yes'
 
-- name: RedHat/CentOS/Fedora | download Oracle Java RPM
-  get_url:
-    url: https://download.oracle.com/otn-pub/java/jdk/8u202-b08/1961070e4c9b4e26a04e7f5a083f551e/jre-8u202-linux-x64.rpm
-    dest: /tmp/jre-8-linux-x64.rpm
-    headers: 'Cookie:oraclelicense=accept-securebackup-cookie'
-  register: oracle_java_task_rpm_download
+- name: RedHat/CentOS/Fedora | Install OpenJDK 1.8
+  yum: name=java-1.8.0-openjdk state=present    
   when:
     - wazuh_manager_config.cis_cat.disable == 'no'
     - wazuh_manager_config.cis_cat.install_java == 'yes'
-  tags:
-    - init
-
-- name: RedHat/CentOS/Fedora | Install Oracle Java RPM
-  package: name=/tmp/jre-8-linux-x64.rpm state=present
-  when:
-    - wazuh_manager_config.cis_cat.disable == 'no'
-    - wazuh_manager_config.cis_cat.install_java == 'yes'
-    - oracle_java_task_rpm_download is defined
   tags:
     - init
 


### PR DESCRIPTION
Hi team,
this PR closes #172 . Now OpenJDK is used instead of Oracle JDK.
```
[vagrant@localhost ~]$ java -version
openjdk version "1.8.0_212"
OpenJDK Runtime Environment (build 1.8.0_212-b04)
OpenJDK 64-Bit Server VM (build 25.212-b04, mixed mode)
[vagrant@localhost ~]$ sudo systemctl status elasticsearch
● elasticsearch.service - Elasticsearch
   Loaded: loaded (/usr/lib/systemd/system/elasticsearch.service; enabled; vendor preset: disabled)
  Drop-In: /etc/systemd/system/elasticsearch.service.d
           └─elasticsearch.conf
   Active: active (running) since Wed 2019-04-24 11:12:49 UTC; 30min ago
     Docs: http://www.elastic.co
 Main PID: 8123 (java)
   CGroup: /system.slice/elasticsearch.service
           ├─8123 /bin/java -Xms2362m -Xmx2362m -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+AlwaysPreTouch -server -Xss1m -Djava.awt.headless=true -Dfi...
           └─8260 /usr/share/elasticsearch/modules/x-pack-ml/platform/linux-x86_64/bin/controller

Apr 24 11:12:49 localhost.localdomain systemd[1]: Started Elasticsearch.
[vagrant@localhost ~]$ sudo systemctl status kibana
● kibana.service - Kibana
   Loaded: loaded (/etc/systemd/system/kibana.service; enabled; vendor preset: disabled)
   Active: active (running) since Wed 2019-04-24 11:13:09 UTC; 29min ago
 Main PID: 8421 (node)
   CGroup: /system.slice/kibana.service
           └─8421 /usr/share/kibana/bin/../node/bin/node --no-warnings --max-http-header-size=65536 /usr/share/kibana/bin/../src/cli -c /etc/kibana/kibana.yml

Apr 24 11:39:20 localhost.localdomain kibana[8421]: {"type":"response","@timestamp":"2019-04-24T11:39:20Z","tags":[],"pid":8421,"method":"post","statusCode":200,"req":{"url":"/elasticsearch/_msear...11; Ubuntu; L
Apr 24 11:39:47 localhost.localdomain kibana[8421]: {"type":"response","@timestamp":"2019-04-24T11:39:47Z","tags":[],"pid":8421,"method":"post","statusCode":200,"req":{"url":"/elasticsearch/_msear...11; Ubuntu; L
Apr 24 11:40:09 localhost.localdomain kibana[8421]: {"type":"response","@timestamp":"2019-04-24T11:40:09Z","tags":[],"pid":8421,"method":"post","statusCode":200,"req":{"url":"/elasticsearch/_msear...11; Ubuntu; L
Apr 24 11:40:28 localhost.localdomain kibana[8421]: {"type":"response","@timestamp":"2019-04-24T11:40:28Z","tags":[],"pid":8421,"method":"post","statusCode":200,"req":{"url":"/elasticsearch/_msear...11; Ubuntu; L
Apr 24 11:40:49 localhost.localdomain kibana[8421]: {"type":"response","@timestamp":"2019-04-24T11:40:49Z","tags":[],"pid":8421,"method":"post","statusCode":200,"req":{"url":"/elasticsearch/_msear...11; Ubuntu; L
Apr 24 11:41:23 localhost.localdomain kibana[8421]: {"type":"response","@timestamp":"2019-04-24T11:41:23Z","tags":[],"pid":8421,"method":"post","statusCode":200,"req":{"url":"/elasticsearch/_msear...11; Ubuntu; L
Apr 24 11:41:43 localhost.localdomain kibana[8421]: {"type":"response","@timestamp":"2019-04-24T11:41:43Z","tags":[],"pid":8421,"method":"post","statusCode":200,"req":{"url":"/elasticsearch/_msear...11; Ubuntu; L
Apr 24 11:42:10 localhost.localdomain kibana[8421]: {"type":"response","@timestamp":"2019-04-24T11:42:10Z","tags":[],"pid":8421,"method":"post","statusCode":200,"req":{"url":"/elasticsearch/_msear...11; Ubuntu; L
Apr 24 11:42:33 localhost.localdomain kibana[8421]: {"type":"response","@timestamp":"2019-04-24T11:42:33Z","tags":[],"pid":8421,"method":"post","statusCode":200,"req":{"url":"/elasticsearch/_msear...11; Ubuntu; L
Apr 24 11:42:49 localhost.localdomain kibana[8421]: {"type":"response","@timestamp":"2019-04-24T11:42:49Z","tags":[],"pid":8421,"method":"post","statusCode":200,"req":{"url":"/elasticsearch/_msear...11; Ubuntu; L
Hint: Some lines were ellipsized, use -l to show in full.

```