### PR TITLE
Added molecule test for the Wazuh Agent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ before_script:
   - pipenv install --dev --system
 script:
   - pipenv run test
+  - pipenv run agent

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/Users/wdijkerman/.venv3/bin/python"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/Users/wdijkerman/.venv3/bin/python"
-}

--- a/Pipfile
+++ b/Pipfile
@@ -15,3 +15,4 @@ python_version = "2.7"
 
 [scripts]
 test ="molecule test"
+agent ="molecule test -s wazuh-agent"

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ These playbooks install and configure Wazuh agent, manager and Elastic Stack.
 pip install pipenv
 sudo pipenv install
 pipenv run test
+pipenv run agent
 ```
 
 ## Contribute

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,13 +5,13 @@ driver:
   name: docker
 lint:
   name: yamllint
-  enabled: false # fix in seperate PR
+  enabled: false
 platforms:
   - name: bionic
     image: ubuntu:bionic
   - name: xenial
     image: solita/ubuntu-systemd:xenial
-    privileged: True
+    privileged: true
     command: /sbin/init
   - name: trusty
     image: ubuntu:trusty
@@ -19,14 +19,14 @@ platforms:
     image: centos:6
   - name: centos7
     image: milcom/centos7-systemd
-    privileged: True
+    privileged: true
 provisioner:
   name: ansible
   env:
     ANSIBLE_ROLES_PATH: ../../roles
   lint:
     name: ansible-lint
-    enabled: true # fix in seperate PR
+    enabled: true
 scenario:
   name: default
   test_sequence:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -4,9 +4,8 @@
   roles:
     - role: wazuh/ansible-wazuh-manager
 
-
-    # - {role: wazuh/ansible-filebeat} #, filebeat_output_logstash_hosts: 'your elastic stack server IP'
-    # Elasticsearch requires too much memory to test multiple containers concurrently - To Fix
-    #- {role: elastic-stack/ansible-elasticsearch, elasticsearch_network_host: 'localhost'}
-    #- {role: elastic-stack/ansible-logstash, logstash_input_beats: true, elasticsearch_network_host: 'localhost'}
-    #- {role: elastic-stack/ansible-kibana, elasticsearch_network_host: 'localhost'}
+# - {role: wazuh/ansible-filebeat} #, filebeat_output_logstash_hosts: 'your elastic stack server IP'
+# Elasticsearch requires too much memory to test multiple containers concurrently - To Fix
+# - {role: elastic-stack/ansible-elasticsearch, elasticsearch_network_host: 'localhost'}
+# - {role: elastic-stack/ansible-logstash, logstash_input_beats: true, elasticsearch_network_host: 'localhost'}
+# - {role: elastic-stack/ansible-kibana, elasticsearch_network_host: 'localhost'}

--- a/molecule/wazuh-agent/Dockerfile.j2
+++ b/molecule/wazuh-agent/Dockerfile.j2
@@ -1,0 +1,14 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi

--- a/molecule/wazuh-agent/INSTALL.rst
+++ b/molecule/wazuh-agent/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule[docker]'

--- a/molecule/wazuh-agent/molecule.yml
+++ b/molecule/wazuh-agent/molecule.yml
@@ -1,0 +1,82 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+platforms:
+  - name: wazuh_server_centos7
+    image: milcom/centos7-systemd
+    networks:
+      - name: wazuh
+    privileged: true
+    groups:
+      - manager
+  - name: wazuh_agent_bionic
+    image: ubuntu:bionic
+    networks:
+      - name: wazuh
+    groups:
+      - agent
+  - name: wazuh_agent_xenial
+    image: solita/ubuntu-systemd:xenial
+    privileged: true
+    command: /sbin/init
+    networks:
+      - name: wazuh
+    groups:
+      - agent
+  - name: wazuh_agent_trusty
+    image: ubuntu:trusty
+    networks:
+      - name: wazuh
+    groups:
+      - agent
+  - name: wazuh_agent_centos6
+    image: centos:6
+    networks:
+      - name: wazuh
+    groups:
+      - agent
+  - name: wazuh_agent_centos7
+    image: milcom/centos7-systemd
+    privileged: true
+    networks:
+      - name: wazuh
+    groups:
+      - agent
+provisioner:
+  name: ansible
+  playbooks:
+    docker:
+      create: ../default/create.yml
+      destroy: ../default/destroy.yml
+  env:
+    ANSIBLE_ROLES_PATH: ../../roles
+  inventory:
+    group_vars:
+      agent:
+        api_pass: password
+        wazuh_managers:
+          - address: "{{ wazuh_manager_ip }}"
+            port: 1514
+            protocol: tcp
+            api_port: 55000
+            api_proto: 'http'
+            api_user: null
+        wazuh_agent_authd:
+          enable: true
+          port: 1515
+          ssl_agent_ca: null
+          ssl_agent_cert: null
+          ssl_agent_key: null
+          ssl_auto_negotiate: 'no'
+
+  lint:
+    name: ansible-lint
+    enabled: true
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/molecule/wazuh-agent/playbook.yml
+++ b/molecule/wazuh-agent/playbook.yml
@@ -1,0 +1,20 @@
+---
+- name: Converge
+  hosts: agent
+  pre_tasks:
+    - name: "Get ip Wazuh Manager"
+      shell: |
+        set -o pipefail
+        grep $(hostname) /etc/hosts | awk '{print $1}' | sort | head -n 2 | tail -n 1
+      register: wazuh_manager_ip_stdout
+      changed_when: false
+      delegate_to: wazuh_server_centos7
+      args:
+        executable: /bin/bash
+
+    - name: "Set fact for ip address"
+      set_fact:
+        wazuh_manager_ip: "{{ wazuh_manager_ip_stdout.stdout }}"
+
+  roles:
+    - role: wazuh/ansible-wazuh-agent

--- a/molecule/wazuh-agent/prepare.yml
+++ b/molecule/wazuh-agent/prepare.yml
@@ -1,6 +1,23 @@
 ---
 - name: Prepare
-  hosts: all
+  hosts: manager
+  gather_facts: true
+  tasks:
+
+    - name: "Install dependencies"
+      package:
+        name:
+          - curl
+          - net-tools
+        state: latest
+      register: wazuh_manager_dependencies_packages_installed
+      until: wazuh_manager_dependencies_packages_installed is succeeded
+
+  roles:
+    - role: wazuh/ansible-wazuh-manager
+
+- name: Prepare
+  hosts: agent
   gather_facts: true
   tasks:
 
@@ -22,5 +39,5 @@
           - curl
           - net-tools
         state: latest
-      register: wazuh_manager_dependencies_packages_installed
-      until: wazuh_manager_dependencies_packages_installed is succeeded
+      register: wazuh_agent_dependencies_packages_installed
+      until: wazuh_agent_dependencies_packages_installed is succeeded

--- a/molecule/wazuh-agent/tests/test_agents.py
+++ b/molecule/wazuh-agent/tests/test_agents.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('agent')
+
+
+def test_ossec_package_installed(Package):
+    ossec = Package('wazuh-agent')
+    assert ossec.is_installed
+
+
+@pytest.mark.parametrize("wazuh_service, wazuh_owner", (
+        ("ossec-agentd", "ossec"),
+        ("ossec-execd", "root"),
+        ("ossec-syscheckd", "root"),
+        ("wazuh-modulesd", "root"),
+))
+def test_wazuh_processes_running(host, wazuh_service, wazuh_owner):
+    master = host.process.get(user=wazuh_owner, comm=wazuh_service)
+    assert master.args == "/var/ossec/bin/" + wazuh_service

--- a/molecule/wazuh-agent/tests/test_manager.py
+++ b/molecule/wazuh-agent/tests/test_manager.py
@@ -1,0 +1,15 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('manager')
+
+
+def test_agents_registered_on_manager(host):
+    cmd = host.run("/var/ossec/bin/manage_agents -l")
+    assert 'wazuh_agent_bionic' in cmd.stdout
+    assert 'wazuh_agent_xenial' in cmd.stdout
+    assert 'wazuh_agent_trusty' in cmd.stdout
+    assert 'wazuh_agent_centos6' in cmd.stdout
+    assert 'wazuh_agent_centos7' in cmd.stdout

--- a/playbooks/wazuh-agent.yml
+++ b/playbooks/wazuh-agent.yml
@@ -1,3 +1,4 @@
+---
 - hosts: <your wazuh agents hosts>
   roles:
     - /etc/ansible/roles/wazuh-ansible/roles/wazuh/ansible-wazuh-agent

--- a/playbooks/wazuh-elastic.yml
+++ b/playbooks/wazuh-elastic.yml
@@ -1,3 +1,4 @@
+---
 - hosts: <your elasticsearch host>
   roles:
     - {role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-elasticsearch, elasticsearch_network_host: 'your elasticsearch IP'}

--- a/playbooks/wazuh-elastic_stack-distributed.yml
+++ b/playbooks/wazuh-elastic_stack-distributed.yml
@@ -1,3 +1,4 @@
+---
 - hosts: <your wazuh server host>
   roles:
     - role: /etc/ansible/roles/wazuh-ansible/roles/wazuh/ansible-wazuh-manager

--- a/playbooks/wazuh-elastic_stack-single.yml
+++ b/playbooks/wazuh-elastic_stack-single.yml
@@ -1,3 +1,4 @@
+---
 - hosts: <your single server host>
   roles:
       - {role: /etc/ansible/roles/wazuh-ansible/roles/wazuh/ansible-wazuh-manager}

--- a/playbooks/wazuh-kibana.yml
+++ b/playbooks/wazuh-kibana.yml
@@ -1,3 +1,4 @@
+---
 - hosts: <your kibana host>
   roles:
     - {role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-kibana, elasticsearch_network_host: 'your elasticsearch IP'}

--- a/playbooks/wazuh-logstash.yml
+++ b/playbooks/wazuh-logstash.yml
@@ -1,3 +1,4 @@
+---
 - hosts: <your logstash host>
   roles:
     - {role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-logstash, elasticsearch_network_host: ["localhost"]}

--- a/playbooks/wazuh-manager.yml
+++ b/playbooks/wazuh-manager.yml
@@ -1,3 +1,4 @@
+---
 - hosts: <your wazuh server host>
   roles:
     - role: /etc/ansible/roles/wazuh-ansible/roles/wazuh/ansible-wazuh-manager

--- a/roles/ansible-galaxy/meta/main.yml
+++ b/roles/ansible-galaxy/meta/main.yml
@@ -5,7 +5,7 @@ dependencies: []
 galaxy_info:
   author: Wazuh
   categories:
-  - monitoring
+    - monitoring
   company: wazuh.com
   description: Installing, deploying and configuring Wazuh Manager.
   galaxy_tags:
@@ -15,15 +15,15 @@ galaxy_info:
   license: license (GPLv3)
   min_ansible_version: 2.0
   platforms:
-  - name: Debian
-    versions:
-    - all
-  - name: EL
-    versions:
-    - all
-  - name: Fedora
-    versions:
-    - all
-  - name: Ubuntu
-    versions:
-    - all
+    - name: Debian
+      versions:
+        - all
+    - name: EL
+      versions:
+        - all
+    - name: Fedora
+      versions:
+        - all
+    - name: Ubuntu
+      versions:
+        - all

--- a/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
@@ -7,4 +7,4 @@ elasticsearch_jvm_xms: null
 elastic_stack_version: 6.7.1
 elasticsearch_shards: 5
 elasticsearch_replicas: 1
-elasticsearch_install_java: yes
+elasticsearch_install_java: true

--- a/roles/elastic-stack/ansible-elasticsearch/meta/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/meta/main.yml
@@ -6,18 +6,18 @@ galaxy_info:
   license: license (GPLv3)
   min_ansible_version: 2.0
   platforms:
-  - name: EL
-    versions:
-    - all
-  - name: Ubuntu
-    versions:
-    - all
-  - name: Debian
-    versions:
-    - all
-  - name: Fedora
-    versions:
-    - all
+    - name: EL
+      versions:
+        - all
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+    - name: Fedora
+      versions:
+        - all
   galaxy_tags:
     - web
     - system

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/Debian.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/Debian.yml
@@ -10,7 +10,7 @@
       apt_repository:
         repo: 'ppa:webupd8team/java'
         codename: 'xenial'
-        update_cache: yes
+        update_cache: true
 
     - name: Debian/Ubuntu | Accept Oracle Java 8 license
       debconf:
@@ -36,7 +36,7 @@
     repo: 'deb https://artifacts.elastic.co/packages/6.x/apt stable main'
     state: present
     filename: 'elastic_repo'
-    update_cache: yes
+    update_cache: true
 
 - name: Debian/Ubuntu | Install Elasticsarch
   apt:

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/RedHat.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/RedHat.yml
@@ -20,7 +20,7 @@
     description: Elastic repository for 6.x packages
     baseurl: https://artifacts.elastic.co/packages/6.x/yum
     gpgkey: https://artifacts.elastic.co/GPG-KEY-elasticsearch
-    gpgcheck: yes
+    gpgcheck: true
 
 - name: RedHat/CentOS/Fedora | Install Elasticsarch
   package: name=elasticsearch-{{ elastic_stack_version }} state=present

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
@@ -68,19 +68,20 @@
   notify: restart elasticsearch
   tags: configure
 
+# fix in new PR (ignore_errors)
 - name: Reload systemd
-  systemd: daemon_reload=yes
-  ignore_errors: yes #fix in new PR
-  when: 
+  systemd: daemon_reload=true
+  ignore_errors: true
+  when:
     - not (ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA")
     - not (ansible_distribution == "Ubuntu" and ansible_distribution_version is version('15.04', '<'))
     - not (ansible_distribution == "Debian" and ansible_distribution_version is version('8', '<'))
 
 - name: Ensure Elasticsearch started and enabled
-  ignore_errors: yes
+  ignore_errors: true
   service:
     name: elasticsearch
-    enabled: yes
+    enabled: true
     state: started
 
 - name: Make sure Elasticsearch is running before proceeding

--- a/roles/elastic-stack/ansible-kibana/defaults/main.yml
+++ b/roles/elastic-stack/ansible-kibana/defaults/main.yml
@@ -5,4 +5,3 @@ kibana_server_host: "0.0.0.0"
 kibana_server_port: "5601"
 elastic_stack_version: 6.7.1
 wazuh_version: 3.8.2
-

--- a/roles/elastic-stack/ansible-kibana/meta/main.yml
+++ b/roles/elastic-stack/ansible-kibana/meta/main.yml
@@ -6,18 +6,18 @@ galaxy_info:
   license: license (GPLv3)
   min_ansible_version: 2.0
   platforms:
-  - name: EL
-    versions:
-    - all
-  - name: Fedora
-    versions:
-    - all
-  - name: Debian
-    versions:
-    - all
-  - name: Ubuntu
-    versions:
-    - all
+    - name: EL
+      versions:
+        - all
+    - name: Fedora
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+    - name: Ubuntu
+      versions:
+        - all
   galaxy_tags:
     - web
     - system

--- a/roles/elastic-stack/ansible-kibana/tasks/Debian.yml
+++ b/roles/elastic-stack/ansible-kibana/tasks/Debian.yml
@@ -14,7 +14,7 @@
     repo: 'deb https://artifacts.elastic.co/packages/6.x/apt stable main'
     state: present
     filename: 'elastic_repo'
-    update_cache: yes
+    update_cache: true
 
 - name: Debian/Ubuntu | Install Kibana
   apt:

--- a/roles/elastic-stack/ansible-kibana/tasks/RedHat.yml
+++ b/roles/elastic-stack/ansible-kibana/tasks/RedHat.yml
@@ -5,7 +5,7 @@
     description: Elastic repository for 6.x packages
     baseurl: https://artifacts.elastic.co/packages/6.x/yum
     gpgkey: https://artifacts.elastic.co/GPG-KEY-elasticsearch
-    gpgcheck: yes
+    gpgcheck: true
 
 - name: RedHat/CentOS/Fedora | Install Kibana
   package: name=kibana-{{ elastic_stack_version }} state=present

--- a/roles/elastic-stack/ansible-kibana/tasks/main.yml
+++ b/roles/elastic-stack/ansible-kibana/tasks/main.yml
@@ -8,12 +8,11 @@
 - name: Make sure Elasticsearch is running before proceeding.
   wait_for: host={{ elasticsearch_network_host }} port={{ elasticsearch_http_port }} delay=3 timeout=300
   tags: configure
-  ignore_errors: yes # fix
-  wait_for: 50
+  ignore_errors: true
 
 - name: Reload systemd
-  systemd: daemon_reload=yes
-  ignore_errors: yes
+  systemd: daemon_reload=true
+  ignore_errors: true
   when:
     - not (ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA")
     - not (ansible_distribution == "Ubuntu" and ansible_distribution_version is version('15.04', '<'))
@@ -34,7 +33,7 @@
   args:
     removes: /usr/share/kibana/plugins/wazuh/package.json
   register: wazuh_app_verify
-  changed_when: False
+  changed_when: false
   tags: install
 
 - name: Removing old Wazuh-APP
@@ -59,7 +58,7 @@
 - name: Ensure Kibana started and enabled
   service:
     name: kibana
-    enabled: yes
+    enabled: true
     state: started
 
 - import_tasks: RMRedHat.yml

--- a/roles/elastic-stack/ansible-logstash/defaults/main.yml
+++ b/roles/elastic-stack/ansible-logstash/defaults/main.yml
@@ -2,7 +2,7 @@
 logstash_create_config: true
 logstash_input_beats: false
 
-#You can introduce Multiples IPs
+# You can introduce Multiples IPs
 # elasticseacrh_network_host: ["Localhost1", "Localhost2", "Localhost3", ...]
 elasticsearch_network_host: ["Localhost"]
 
@@ -16,4 +16,4 @@ logstash_ssl_dir: /etc/pki/logstash
 logstash_ssl_certificate_file: ""
 logstash_ssl_key_file: ""
 
-logstash_install_java: yes
+logstash_install_java: true

--- a/roles/elastic-stack/ansible-logstash/meta/main.yml
+++ b/roles/elastic-stack/ansible-logstash/meta/main.yml
@@ -6,18 +6,18 @@ galaxy_info:
   license: license (GPLv3)
   min_ansible_version: 2.0
   platforms:
-  - name: EL
-    versions:
-    - all
-  - name: Fedora
-    versions:
-    - all
-  - name: Debian
-    versions:
-    - all
-  - name: Ubuntu
-    versions:
-    - all
+    - name: EL
+      versions:
+        - all
+    - name: Fedora
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+    - name: Ubuntu
+      versions:
+        - all
   galaxy_tags:
     - web
     - system

--- a/roles/elastic-stack/ansible-logstash/tasks/Debian.yml
+++ b/roles/elastic-stack/ansible-logstash/tasks/Debian.yml
@@ -40,7 +40,7 @@
   apt:
     name: "logstash=1:{{ elastic_stack_version }}-1"
     state: present
-    update_cache: yes
+    update_cache: true
   tags: install
 
 - name: Debian/Ubuntu | Checking if wazuh-manager is installed
@@ -48,13 +48,13 @@
   register: wazuh_manager_check_deb
   when: logstash_input_beats == false
   args:
-    warn: no
+    warn: false
 
 - name: Debian/Ubuntu | Add user logstash to group ossec
   user:
     name: logstash
     groups: ossec
-    append: yes
+    append: true
   when:
     - logstash_input_beats == false
     - wazuh_manager_check_deb.rc == 0

--- a/roles/elastic-stack/ansible-logstash/tasks/RedHat.yml
+++ b/roles/elastic-stack/ansible-logstash/tasks/RedHat.yml
@@ -20,7 +20,7 @@
     description: Elastic repository for 6.x packages
     baseurl: https://artifacts.elastic.co/packages/6.x/yum
     gpgkey: https://artifacts.elastic.co/GPG-KEY-elasticsearch
-    gpgcheck: yes
+    gpgcheck: true
 
 - name: RedHat/CentOS/Fedora | Install Logstash
   package: name=logstash-{{ elastic_stack_version }} state=present
@@ -32,13 +32,13 @@
   register: wazuh_manager_check_rpm
   when: logstash_input_beats == false
   args:
-    warn: no
+    warn: false
 
 - name: RedHat/CentOS/Fedora | Add user logstash to group ossec
   user:
     name: logstash
     groups: ossec
-    append: yes
+    append: true
   when:
     - logstash_input_beats == false
     - wazuh_manager_check_rpm.rc == 0

--- a/roles/elastic-stack/ansible-logstash/tasks/main.yml
+++ b/roles/elastic-stack/ansible-logstash/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Reload systemd
   systemd: daemon_reload=yes
-  ignore_errors: yes
+  ignore_errors: true
   when:
     - not (ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA")
     - not (ansible_distribution == "Ubuntu" and ansible_distribution_version is version('15.04', '<'))
@@ -23,13 +23,13 @@
 - name: Ensure Logstash started and enabled
   service:
     name: logstash
-    enabled: yes
+    enabled: true
     state: started
 
 - name: Amazon Linux start Logstash
   service:
     name: logstash
-    enabled: yes
+    enabled: true
     state: started
   when: ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA"
 

--- a/roles/wazuh/ansible-filebeat/meta/main.yml
+++ b/roles/wazuh/ansible-filebeat/meta/main.yml
@@ -8,21 +8,21 @@ galaxy_info:
   license: license (GPLv3)
   min_ansible_version: 2.0
   platforms:
-  - name: EL
-    versions:
-    - 6
-    - 7
-  - name: Fedora
-    versions:
-    - all
-  - name: Debian
-    versions:
-    - jessie
-  - name: Ubuntu
-    versions:
-    - precise
-    - trusty
-    - xenial
+    - name: EL
+      versions:
+        - 6
+        - 7
+    - name: Fedora
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - jessie
+    - name: Ubuntu
+      versions:
+        - precise
+        - trusty
+        - xenial
   galaxy_tags:
     - web
     - system

--- a/roles/wazuh/ansible-filebeat/tasks/Debian.yml
+++ b/roles/wazuh/ansible-filebeat/tasks/Debian.yml
@@ -14,4 +14,4 @@
   apt_repository:
     repo: 'deb https://artifacts.elastic.co/packages/6.x/apt stable main'
     state: present
-    update_cache: yes
+    update_cache: true

--- a/roles/wazuh/ansible-filebeat/tasks/RedHat.yml
+++ b/roles/wazuh/ansible-filebeat/tasks/RedHat.yml
@@ -5,4 +5,4 @@
     description: Elastic repository for 6.x packages
     baseurl: https://artifacts.elastic.co/packages/6.x/yum
     gpgkey: https://artifacts.elastic.co/GPG-KEY-elasticsearch
-    gpgcheck: yes
+    gpgcheck: true

--- a/roles/wazuh/ansible-filebeat/tasks/main.yml
+++ b/roles/wazuh/ansible-filebeat/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: Reload systemd
   systemd: daemon_reload=yes
-  ignore_errors: yes
+  ignore_errors: true
   when:
     - not (ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA")
     - not (ansible_distribution == "Ubuntu" and ansible_distribution_version is version('15.04', '<'))
@@ -25,7 +25,7 @@
   service:
     name: filebeat
     state: started
-    enabled: yes
+    enabled: true
 
 - import_tasks: "RMRedHat.yml"
   when: ansible_os_family == "RedHat"

--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -29,10 +29,10 @@ wazuh_winagent_config:
   md5: 43936e7bc7eb51bd186f47dac4a6f477
 wazuh_agent_config:
   active_response:
-     ar_disabled: 'no'
-     ca_store: '/var/ossec/etc/wpk_root.pem'
-     ca_store_win: 'wpk_root.pem'
-     ca_verification: 'yes'
+    ar_disabled: 'no'
+    ca_store: '/var/ossec/etc/wpk_root.pem'
+    ca_store_win: 'wpk_root.pem'
+    ca_verification: 'yes'
   log_format: 'plain'
   client_buffer:
     disable: 'no'
@@ -49,7 +49,6 @@ wazuh_agent_config:
     skip_nfs: 'yes'
     ignore:
       - /etc/mtab
-      #- /etc/mnttab
       - /etc/hosts.deny
       - /etc/mail/statistics
       - /etc/random-seed
@@ -247,7 +246,7 @@ wazuh_agent_config:
     content:
       - type: 'xccdf'
         path: 'benchmarks/CIS_Ubuntu_Linux_16.04_LTS_Benchmark_v1.0.0-xccdf.xml'
-        profile: 'xccdf_org.cisecurity.benchmarks_profile_Level_1_-_Server' 
+        profile: 'xccdf_org.cisecurity.benchmarks_profile_Level_1_-_Server'
   vuls:
     disable: 'yes'
     interval: '1d'
@@ -273,7 +272,7 @@ wazuh_agent_config:
         location: '/var/log/messages'
       - format: 'syslog'
         location: '/var/log/secure'
-      - format: 'syslog' 
+      - format: 'syslog'
         location: '/var/log/maillog'
       - format: 'audit'
         location: '/var/log/audit/audit.log'
@@ -285,17 +284,17 @@ wazuh_agent_config:
         frequency: '360'
       - format: 'full_command'
         command: ss -nutal | awk '{print $1,$5,$6;}' | sort -b | column -t
-        alias: 'netstat listening ports'      
+        alias: 'netstat listening ports'
         frequency: '360'
       - format: 'full_command'
         command: 'last -n 20'
         frequency: '360'
     windows:
-      - format: 'eventlog' 
+      - format: 'eventlog'
         location: 'Application'
       - format: 'eventchannel'
         location: 'Security'
-        query: 'Event/System[EventID != 5145 and EventID != 5156 and EventID != 5447 and EventID != 4656 and EventID != 4658 and EventID != 4663 and EventID != 4660 and EventID != 4670 and EventID != 4690 and EventID != 4703 and EventID != 4907]'  
+        query: 'Event/System[EventID != 5145 and EventID != 5156 and EventID != 5447 and EventID != 4656 and EventID != 4658 and EventID != 4663 and EventID != 4660 and EventID != 4670 and EventID != 4690 and EventID != 4703 and EventID != 4907]'
       - format: 'eventlog'
         location: 'System'
       - format: 'syslog'

--- a/roles/wazuh/ansible-wazuh-agent/meta/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/meta/main.yml
@@ -6,18 +6,18 @@ galaxy_info:
   license: license (GPLv3)
   min_ansible_version: 2.0
   platforms:
-  - name: EL
-    versions:
-    - all
-  - name: Ubuntu
-    versions:
-    - all
-  - name: Debian
-    versions:
-    - all
-  - name: Fedora
-    versions:
-    - all
-  categories:
-  - monitoring
+    - name: EL
+      versions:
+        - all
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+    - name: Fedora
+      versions:
+        - all
+  galaxy_tags:
+    - monitoring
 dependencies: []

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
@@ -1,60 +1,83 @@
 ---
 - name: Debian/Ubuntu | Install apt-transport-https and ca-certificates
   apt:
-    name: ['apt-transport-https', 'ca-certificates']
+    name:
+      - apt-transport-https
+      - ca-certificates
     state: present
+  register: wazuh_agent_ca_package_install
+  until: wazuh_agent_ca_package_install is succeeded
 
-- name: Debian/Ubuntu | Installing repository key
+- name: Debian/Ubuntu | Installing Wazuh repository key (Ubuntu 14)
+  become: true
+  shell: |
+    set -o pipefail
+    curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add -
+  args:
+    warn: false
+    executable: /bin/bash
+  changed_when: false
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_distribution_major_version | int == 14
+
+- name: Debian/Ubuntu | Installing Wazuh repository key
   apt_key: url=https://packages.wazuh.com/key/GPG-KEY-WAZUH
+  when:
+    - not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int == 14)
 
 - name: Debian/Ubuntu | Add Wazuh repositories
   apt_repository:
     repo: 'deb https://packages.wazuh.com/3.x/apt/ stable main'
     state: present
-    update_cache: yes
+    update_cache: true
 
 - name: Debian/Ubuntu | Set Distribution CIS filename for debian
   set_fact:
     cis_distribution_filename: cis_debian_linux_rcl.txt
   when: ansible_os_family == "Debian"
 
-- when:
-  - wazuh_agent_config.cis_cat.disable == 'no'
-  - wazuh_agent_config.cis_cat.install_java == 'yes'
-  block:
-  - name: Debian/Ubuntu | Setting webupd8 repository
-    apt_repository:
-      repo: 'ppa:webupd8team/java'
-      codename: 'xenial'
-      update_cache: yes
+- block:
+    - name: Debian/Ubuntu | Setting webupd8 repository
+      apt_repository:
+        repo: 'ppa:webupd8team/java'
+        codename: 'xenial'
+        update_cache: true
 
-  - name: Debian/Ubuntu | Accept Oracle Java 8 license
-    debconf:
-      name: oracle-java8-installer
-      question: shared/accepted-oracle-license-v1-1
-      value: true
-      vtype: boolean
+    - name: Debian/Ubuntu | Accept Oracle Java 8 license
+      debconf:
+        name: oracle-java8-installer
+        question: shared/accepted-oracle-license-v1-1
+        value: true
+        vtype: boolean
 
-  - name: Debian/Ubuntu | Oracle Java 8 installer
-    apt:
-      name: oracle-java8-installer
-      state: present
-      cache_valid_time: 3600
+    - name: Debian/Ubuntu | Oracle Java 8 installer
+      apt:
+        name: oracle-java8-installer
+        state: present
+        cache_valid_time: 3600
+  when:
+    - wazuh_agent_config.cis_cat.disable == 'no'
+    - wazuh_agent_config.cis_cat.install_java == 'yes'
   tags:
     - init
 
 - name: Debian/Ubuntu | Install OpenScap
   apt:
-    name: ['libopenscap8', 'xsltproc']
+    name:
+      - libopenscap8
+      - xsltproc
     state: present
-    when: wazuh_agent_config.openscap.disable == 'no'
-    tags:
-        - init
+  when: wazuh_agent_config.openscap.disable == 'no'
+  tags:
+    - init
+  register: wazuh_agent_OpenScap_package_install
+  until: wazuh_agent_OpenScap_package_install is succeeded
 
 - name: Debian/Ubuntu | Get OpenScap installed version
   shell: "dpkg-query --showformat='${Version}' --show libopenscap8"
   register: openscap_version
-  changed_when: true
+  changed_when: false
   when: wazuh_agent_config.openscap.disable == 'no'
   tags:
     - config
@@ -62,7 +85,7 @@
 - name: Debian/Ubuntu | Check OpenScap version
   shell: "dpkg --compare-versions '{{ openscap_version.stdout }}' '>=' '1.2'; echo $?"
   register: openscap_version_valid
-  changed_when: true
+  changed_when: false
   when: wazuh_agent_config.openscap.disable == 'no'
   tags:
     - config

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
@@ -53,16 +53,16 @@
       vars:
         agent_name: "{% if single_agent_name is defined %}{{ single_agent_name }}{% else %}{{ ansible_hostname }}{% endif %}"
       when:
-        - check_keys.stat.exists == false or check_keys.stat.size == 0
+        - not check_keys.stat.exists or check_keys.stat.size == 0
         - wazuh_managers.0.address is not none
 
     - name: Linux | Verify agent registration
       shell: echo {{ agent_auth_output }} | grep "Valid key created"
       when:
-        - check_keys.stat.exists == false or check_keys.stat.size == 0
+        - not check_keys.stat.exists or check_keys.stat.size == 0
         - wazuh_managers.0.address is not none
 
-  when: wazuh_agent_authd.enable == true
+  when: wazuh_agent_authd.enable
   tags:
     - config
     - authd
@@ -76,9 +76,9 @@
     - name: Linux | Create the agent key via rest-API
       uri:
         url: "{{ wazuh_managers.0.api_proto }}://{{ wazuh_managers.0.address }}:{{ wazuh_managers.0.api_port }}/agents/"
-        validate_certs: no
+        validate_certs: false
         method: POST
-        body: {"name":"{{ agent_name }}"}
+        body: '{"name":"{{ agent_name }}"}'
         body_format: json
         status_code: 200
         headers:
@@ -86,29 +86,30 @@
         user: "{{ wazuh_managers.0.api_user }}"
         password: "{{ api_pass }}"
       register: newagent_api
-      changed_when: newagent_api.json.error == 0
+      # changed_when: newagent_api.json.error == 0
       vars:
-        agent_name: "{% if single_agent_name is defined %}{{ single_agent_name }}{% else %}{{ inventory_hostname }}{% endif %}"      
+        agent_name: "{% if single_agent_name is defined %}{{ single_agent_name }}{% else %}{{ inventory_hostname }}{% endif %}"
       when:
-        - check_keys.stat.exists == false or check_keys.stat.size == 0
+        - not check_keys.stat.exists or check_keys.stat.size == 0
         - wazuh_managers.0.address is not none
-      become: no
+      become: false
+      ignore_errors: true
 
     - name: Linux | Retieve new agent data via rest-API
       uri:
         url: "{{ wazuh_managers.0.api_proto }}://{{ wazuh_managers.0.address }}:{{ wazuh_managers.0.api_port }}/agents/{{ newagent_api.json.data.id }}"
-        validate_certs: no
+        validate_certs: false
         method: GET
-        return_content: yes
+        return_content: true
         user: "{{ wazuh_managers.0.api_user }}"
         password: "{{ api_pass }}"
       when:
-        - check_keys.stat.exists == false or check_keys.stat.size == 0
+        - not check_keys.stat.exists or check_keys.stat.size == 0
         - wazuh_managers.0.address is not none
         - newagent_api.json.error == 0
       register: newagentdata_api
       delegate_to: localhost
-      become: no
+      become: false
 
     - name: Linux | Register agent (via rest-API)
       command: /var/ossec/bin/manage_agents
@@ -121,12 +122,13 @@
         OSSEC_ACTION_CONFIRMED: y
       register: manage_agents_output
       when:
-        - check_keys.stat.exists == false or check_keys.stat.size == 0
+        - not check_keys.stat.exists or check_keys.stat.size == 0
         - wazuh_managers.0.address is not none
         - newagent_api.changed
       notify: restart wazuh-agent
 
-  when: wazuh_agent_authd.enable == false
+  when:
+    - not wazuh_agent_authd.enable
   tags:
     - config
     - api
@@ -139,7 +141,7 @@
   poll: 0
   when:
     - wazuh_agent_config.vuls.disable != 'yes'
-    - ansible_distribution == 'Redhat' or ansible_distribution == 'CentOS' or ansible_distribution == 'Ubuntu' or ansible_distribution == 'Debian' or ansible_distribution == 'Oracle'
+    - ansible_distribution in ['Redhat', 'CentOS', 'Ubuntu', 'Debian', 'Oracle']
   tags:
     - init
 
@@ -168,7 +170,7 @@
 - name: Linux | Ensure Wazuh Agent service is started and enabled
   service:
     name: wazuh-agent
-    enabled: yes
+    enabled: true
     state: started
 
 - import_tasks: "RMRedHat.yml"

--- a/roles/wazuh/ansible-wazuh-agent/tasks/RMDebian.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/RMDebian.yml
@@ -3,3 +3,4 @@
   apt_repository:
     repo: deb https://packages.wazuh.com/apt {{ ansible_distribution_release }} main
     state: absent
+  changed_when: false

--- a/roles/wazuh/ansible-wazuh-agent/tasks/RMRedHat.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/RMRedHat.yml
@@ -3,3 +3,4 @@
   yum_repository:
     name: wazuh_repo
     state: absent
+  changed_when: false

--- a/roles/wazuh/ansible-wazuh-agent/tasks/RedHat.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/RedHat.yml
@@ -5,7 +5,8 @@
     description: Wazuh repository
     baseurl: https://packages.wazuh.com/3.x/yum/
     gpgkey: https://packages.wazuh.com/key/GPG-KEY-WAZUH
-    gpgcheck: yes
+    gpgcheck: true
+  changed_when: false
   when:
     - ansible_distribution_major_version|int > 5
 
@@ -15,7 +16,8 @@
     description: Wazuh repository
     baseurl: https://packages.wazuh.com/3.x/yum/5/
     gpgkey: https://packages.wazuh.com/key/GPG-KEY-WAZUH-5
-    gpgcheck: yes
+    gpgcheck: true
+  changed_when: false
   when:
     - ansible_distribution_major_version|int == 5
 
@@ -25,7 +27,8 @@
     description: Wazuh repository
     baseurl: https://packages.wazuh.com/3.x/yum/
     gpgkey: https://packages.wazuh.com/key/GPG-KEY-WAZUH
-    gpgcheck: yes
+    gpgcheck: true
+  changed_when: false
   when:
     - ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA"
 
@@ -35,6 +38,7 @@
     dest: /tmp/jre-8-linux-x64.rpm
     headers: 'Cookie:oraclelicense=accept-securebackup-cookie'
   register: oracle_java_task_rpm_download
+  until: oracle_java_task_rpm_download is succeeded
   when:
     - wazuh_agent_config.cis_cat.disable == 'no'
     - wazuh_agent_config.cis_cat.install_java == 'yes'
@@ -43,6 +47,8 @@
 
 - name: RedHat/CentOS/Fedora | Install Oracle Java RPM
   package: name=/tmp/jre-8-linux-x64.rpm state=present
+  register: wazuh_agent_java_package_install
+  until: wazuh_agent_java_package_install is succeeded
   when:
     - wazuh_agent_config.cis_cat.disable == 'no'
     - wazuh_agent_config.cis_cat.install_java == 'yes'
@@ -63,10 +69,21 @@
 - name: Set Distribution CIS filename for RHEL7
   set_fact:
     cis_distribution_filename: cis_rhel7_linux_rcl.txt
-  when: (ansible_os_family == "RedHat" and ansible_distribution_major_version == "7") or (ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA")
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version == "7"
+
+- name: Set Distribution CIS filename for RHEL7 (Amazon)
+  set_fact:
+    cis_distribution_filename: cis_rhel7_linux_rcl.txt
+  when:
+    - ansible_distribution == "Amazon"
+    - ansible_distribution_major_version == "NA"
 
 - name: RedHat/CentOS/RedHat | Install openscap
   package: name=openscap-scanner state=present
+  register: wazuh_agent_openscap_package_install
+  until: wazuh_agent_openscap_package_install is succeeded
   when: wazuh_agent_config.openscap.disable == 'no'
   tags:
     - init

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Windows.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Windows.yml
@@ -1,18 +1,22 @@
 ---
 - name: Windows | Check if Program Files (x86) exists
-  win_stat: 
+  win_stat:
     path: C:\Program Files (x86)
   register: check_path
 
+- name: "Set Win Path"
+  set_fact:
+    wazuh_agent_win_path: "{% wazuh_winagent_config.install_dir_x86 if check_path.stat.exists else wazuh_winagent_config.install_dir %}"
+
 - name: Windows | Get current installed version
-  win_shell: "{% if check_path.stat.exists == true %}{{ wazuh_winagent_config.install_dir_x86 }}{% else %}
+  win_shell: "{% if check_path.stat.exists %}{{ wazuh_winagent_config.install_dir_x86 }}{% else %}
   {{ wazuh_winagent_config.install_dir }}{% endif %}ossec-agent.exe -h"
   args:
-    removes: "{% if check_path.stat.exists == true %}{{ wazuh_winagent_config.install_dir_x86 }}{% else %}
+    removes: "{% if check_path.stat.exists %}{{ wazuh_winagent_config.install_dir_x86 }}{% else %}
     {{ wazuh_winagent_config.install_dir }}{% endif %}ossec-agent.exe"
   register: agent_version
-  failed_when: False
-  changed_when: False
+  failed_when: false
+  changed_when: false
 
 - name: Windows | Check Wazuh agent version installed
   set_fact: correct_version=true
@@ -30,7 +34,7 @@
 - name: Windows | Verify the downloaded Wazuh agent installer
   win_stat:
     path: C:\wazuh-agent-installer.msi
-    get_checksum: yes
+    get_checksum: true
     checksum_algorithm: md5
   register: installer_md5
   when:
@@ -45,7 +49,7 @@
     - correct_version is not defined
 
 - name: Windows | Check if client.keys exists
-  win_stat: path="{% if check_path.stat.exists == true %}{{ wazuh_winagent_config.install_dir_x86 }}{% else %}{{ wazuh_winagent_config.install_dir }}{% endif %}client.keys"
+  win_stat: path="{{ wazuh_agent_win_path }}"
   register: check_windows_key
   notify: restart wazuh-agent windows
   tags:
@@ -58,18 +62,18 @@
 
 - name: Windows | Register agent
   win_shell: >
-    {% if check_path.stat.exists == true %}{{ wazuh_winagent_config.auth_path_x86 }}{% else %}
+    {% if check_path.stat.exists %}{{ wazuh_winagent_config.auth_path_x86 }}{% else %}
     {{ wazuh_winagent_config.auth_path }}{% endif %}
     -m {{ wazuh_managers.0.address }}
     -p {{ wazuh_agent_authd.port }}
     {% if authd_pass is defined %} -P {{ authd_pass }}{% endif %}
   args:
-    chdir: "{% if check_path.stat.exists == true %}{{ wazuh_winagent_config.install_dir_x86 }}{% else %}{{ wazuh_winagent_config.install_dir }}{% endif %}"
+    chdir: "{{ wazuh_agent_win_path }}"
   register: agent_auth_output
   notify: restart wazuh-agent windows
   when:
-    - wazuh_agent_authd.enable == true
-    - check_windows_key.stat.exists == false or check_windows_key.stat.size == 0
+    - wazuh_agent_authd.enable
+    - not check_windows_key.stat.exists or check_windows_key.stat.size == 0
     - wazuh_managers.0.address is not none
   tags:
     - config
@@ -77,7 +81,7 @@
 - name: Windows | Installing agent configuration (ossec.conf)
   win_template:
     src: var-ossec-etc-ossec-agent.conf.j2
-    dest: "{% if check_path.stat.exists == true %}{{ wazuh_winagent_config.install_dir_x86 }}{% else %}{{ wazuh_winagent_config.install_dir }}{% endif %}ossec.conf"
+    dest: "{{ wazuh_agent_win_path }}ossec.conf"
   notify: restart wazuh-agent windows
   tags:
     - config
@@ -85,7 +89,7 @@
 - name: Windows | Installing local_internal_options.conf
   win_template:
     src: var-ossec-etc-local-internal-options.conf.j2
-    dest: "{% if check_path.stat.exists == true %}{{ wazuh_winagent_config.install_dir_x86 }}{% else %}{{ wazuh_winagent_config.install_dir }}{% endif %}local_internal_options.conf"
+    dest: "{{ wazuh_agent_win_path }}local_internal_options.conf"
   notify: restart wazuh-agent windows
   tags:
     - config

--- a/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
+++ b/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
@@ -254,7 +254,7 @@
     {% endif %}
     <log_path>{% if ansible_os_family == "Windows" %}{{ wazuh_agent_config.osquery.log_path_win }}{% else %}{{ wazuh_agent_config.osquery.log_path }}{% endif %}</log_path>
     <config_path>{% if ansible_os_family == "Windows" %}{{ wazuh_agent_config.osquery.config_path_win }}{% else %}{{ wazuh_agent_config.osquery.config_path }}{% endif %}</config_path>
-    <add_labels>{{ wazuh_agent_config.osquery.ad_labels }}</add_labels>
+    <add_labels>{{ wazuh_agent_config.osquery.add_labels }}</add_labels>
   </wodle>
 
   <!-- System inventory -->

--- a/roles/wazuh/ansible-wazuh-agent/vars/api_pass.yml
+++ b/roles/wazuh/ansible-wazuh-agent/vars/api_pass.yml
@@ -1,3 +1,3 @@
 ---
 # We recommend the use of Ansible Vault to protect Wazuh, api, agentless and authd credentials.
-#api_pass: 'changeme'
+# api_pass: 'changeme'

--- a/roles/wazuh/ansible-wazuh-agent/vars/authd_pass.yml
+++ b/roles/wazuh/ansible-wazuh-agent/vars/authd_pass.yml
@@ -1,3 +1,3 @@
 ---
 # We recommend the use of Ansible Vault to protect Wazuh, api, agentless and authd credentials.
-#authd_pass: 'foobar'
+# authd_pass: 'foobar'

--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -182,35 +182,35 @@ wazuh_manager_config:
   email_level: 12
   localfiles:
     common:
-       - format: 'command'
-         command: df -P -x squashfs -x tmpfs -x devtmpfs
-         frequency: '360'
-       - format: 'full_command'
-         command: ss -nutal | awk '{print $1,$5,$6;}' | sort -b | column -t
-         alias: 'netstat listening ports'
-         frequency: '360'
-       - format: 'full_command'
-         command: 'last -n 20'
-       - format: 'syslog'
-         location: '/var/ossec/logs/active-responses.log'
+      - format: 'command'
+        command: df -P -x squashfs -x tmpfs -x devtmpfs
+        frequency: '360'
+      - format: 'full_command'
+        command: ss -nutal | awk '{print $1,$5,$6;}' | sort -b | column -t
+        alias: 'netstat listening ports'
+        frequency: '360'
+      - format: 'full_command'
+        command: 'last -n 20'
+      - format: 'syslog'
+        location: '/var/ossec/logs/active-responses.log'
     debian:
-       - format: 'syslog'
-         location: '/var/log/auth.log'
-       - format: 'syslog'
-         location: '/var/log/syslog'
-       - format: 'syslog'
-         location: '/var/log/dpkg.log'
-       - format: 'syslog'
-         location: '/var/log/kern.log'
+      - format: 'syslog'
+        location: '/var/log/auth.log'
+      - format: 'syslog'
+        location: '/var/log/syslog'
+      - format: 'syslog'
+        location: '/var/log/dpkg.log'
+      - format: 'syslog'
+        location: '/var/log/kern.log'
     centos:
-       - format: 'syslog'
-         location: '/var/log/messages'
-       - format: 'syslog'
-         location: '/var/log/secure'
-       - format: 'syslog'
-         location: '/var/log/maillog'
-       - format: 'audit'
-         location: '/var/log/audit/audit.log'
+      - format: 'syslog'
+        location: '/var/log/messages'
+      - format: 'syslog'
+        location: '/var/log/secure'
+      - format: 'syslog'
+        location: '/var/log/maillog'
+      - format: 'audit'
+        location: '/var/log/audit/audit.log'
   globals:
     - '127.0.0.1'
     - '192.168.2.1'
@@ -219,10 +219,10 @@ wazuh_manager_config:
       executable: 'disable-account.sh'
       expect: 'user'
       timeout_allowed: 'yes'
-    #- name: 'restart-ossec'
-    #  executable: 'restart-ossec.sh'
-    #  expect: ''
-    #  timeout_allowed: 'no'
+    # - name: 'restart-ossec'
+    #   executable: 'restart-ossec.sh'
+    #   expect: ''
+    #   timeout_allowed: 'no'
     - name: 'win_restart-ossec'
       executable: 'restart-ossec.cmd'
       expect: ''
@@ -252,8 +252,8 @@ wazuh_manager_config:
       expect: 'srcip'
       timeout_allowed: 'yes'
   ruleset:
-      rules_path: 'custom_ruleset/rules/'
-      decoders_path: 'custom_ruleset/decoders/'
+    rules_path: 'custom_ruleset/rules/'
+    decoders_path: 'custom_ruleset/decoders/'
   rule_exclude:
     - '0215-policy_rules.xml'
   syslog_outputs:
@@ -275,17 +275,13 @@ wazuh_agent_configs:
       auto_ignore: 'no'
       alert_new_files: 'yes'
       ignore:
-      - /etc/mtab
-      - /etc/mnttab
-      - /etc/hosts.deny
-      - /etc/mail/statistics
-      - /etc/svc/volatile
+        - /etc/mtab
+        - /etc/mnttab
+        - /etc/hosts.deny
+        - /etc/mail/statistics
+        - /etc/svc/volatile
       no_diff:
         - /etc/ssl/private.key
-      # Example
-      #directories:
-        #- dirs: /etc,/usr/bin,/usr/sbin
-        #  checks: 'check_all="yes"'
     rootcheck:
       frequency: 43200
       cis_distribution_filename: null

--- a/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
@@ -11,14 +11,14 @@
   until: wazuh_manager_https_packages_installed is succeeded
 
 - name: Debian/Ubuntu | Installing Wazuh repository key (Ubuntu 14)
-  become: yes
+  become: true
   shell: |
     set -o pipefail
     curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add -
   args:
-    warn: False
+    warn: false
     executable: /bin/bash
-  changed_when: False
+  changed_when: false
   when:
     - ansible_distribution == "Ubuntu"
     - ansible_distribution_major_version | int == 14
@@ -32,18 +32,18 @@
   apt_repository:
     repo: 'deb https://packages.wazuh.com/3.x/apt/ stable main'
     state: present
-    update_cache: yes
-  changed_when: False
+    update_cache: true
+  changed_when: false
 
 - name: Debian/Ubuntu | Installing NodeJS repository key (Ubuntu 14)
-  become: yes
+  become: true
   shell: |
     set -o pipefail
     curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
   args:
-    warn: False
+    warn: false
     executable: /bin/bash
-  changed_when: False
+  changed_when: false
   when:
     - ansible_distribution == "Ubuntu"
     - ansible_distribution_major_version | int == 14
@@ -57,37 +57,37 @@
   apt_repository:
     repo: "deb https://deb.nodesource.com/node_6.x {{ ansible_distribution_release }} main"
     state: present
-    update_cache: yes
-  changed_when: False
+    update_cache: true
+  changed_when: false
 
 - name: Debian/Ubuntu | Set Distribution CIS filename for Debian/Ubuntu
   set_fact:
     cis_distribution_filename: cis_debian_linux_rcl.txt
 
-- when:
-   - wazuh_manager_config.cis_cat.disable == 'no'
-   - wazuh_manager_config.cis_cat.install_java == 'yes'
-  block:
-  - name: Debian/Ubuntu | Setting webupd8 repository
-    apt_repository:
-      repo: 'ppa:webupd8team/java'
-      codename: 'xenial'
-      update_cache: yes
+- block:
+    - name: Debian/Ubuntu | Setting webupd8 repository
+      apt_repository:
+        repo: 'ppa:webupd8team/java'
+        codename: 'xenial'
+        update_cache: true
 
-  - name: Debian/Ubuntu | Accept Oracle Java 8 license
-    debconf:
-      name: oracle-java8-installer
-      question: shared/accepted-oracle-license-v1-1
-      value: true
-      vtype: boolean
+    - name: Debian/Ubuntu | Accept Oracle Java 8 license
+      debconf:
+        name: oracle-java8-installer
+        question: shared/accepted-oracle-license-v1-1
+        value: true
+        vtype: boolean
 
-  - name: Debian/Ubuntu | Oracle Java 8 installer
-    apt:
-      name: oracle-java8-installer
-      state: present
-      cache_valid_time: 3600
-    register: wazuh_manager_oracle_java_8_installed
-    until: wazuh_manager_oracle_java_8_installed is succeeded
+    - name: Debian/Ubuntu | Oracle Java 8 installer
+      apt:
+        name: oracle-java8-installer
+        state: present
+        cache_valid_time: 3600
+      register: wazuh_manager_oracle_java_8_installed
+      until: wazuh_manager_oracle_java_8_installed is succeeded
+  when:
+    - wazuh_manager_config.cis_cat.disable == 'no'
+    - wazuh_manager_config.cis_cat.install_java == 'yes'
   tags:
     - init
 
@@ -109,7 +109,7 @@
   shell: "dpkg-query --showformat='${Version}' --show libopenscap8"
   when: wazuh_manager_config.openscap.disable == 'no'
   register: openscap_version
-  changed_when: False
+  changed_when: false
   tags:
     - config
 
@@ -117,6 +117,6 @@
   shell: "dpkg --compare-versions '{{ openscap_version.stdout }}' '>=' '1.2'; echo $?"
   when: wazuh_manager_config.openscap.disable == 'no'
   register: openscap_version_valid
-  changed_when: False
+  changed_when: false
   tags:
     - config

--- a/roles/wazuh/ansible-wazuh-manager/tasks/RMDebian.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/RMDebian.yml
@@ -3,10 +3,10 @@
   apt_repository:
     repo: deb https://packages.wazuh.com/apt {{ ansible_distribution_release }} main
     state: absent
-  changed_when: False
+  changed_when: false
 
 - name: Debian/Ubuntu | Remove Nodejs repository.
   apt_repository:
     repo: deb https://deb.nodesource.com/node_6.x {{ ansible_distribution_release }} main
     state: absent
-  changed_when: False
+  changed_when: false

--- a/roles/wazuh/ansible-wazuh-manager/tasks/RMRedHat.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/RMRedHat.yml
@@ -3,10 +3,10 @@
   yum_repository:
     name: NodeJS
     state: absent
-  changed_when: False
+  changed_when: false
 
 - name: RedHat/CentOS/Fedora | Remove Wazuh repository (and clean up left-over metadata)
   yum_repository:
     name: wazuh_repo
     state: absent
-  changed_when: False
+  changed_when: false

--- a/roles/wazuh/ansible-wazuh-manager/tasks/RedHat.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/RedHat.yml
@@ -5,8 +5,8 @@
     description: NodeJS-$releasever
     baseurl: https://rpm.nodesource.com/pub_6.x/el/{{ ansible_distribution_major_version }}/x86_64
     gpgkey: https://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL
-    gpgcheck: yes
-  changed_when: False
+    gpgcheck: true
+  changed_when: false
   when:
     - ansible_distribution_major_version|int > 5
 
@@ -16,7 +16,7 @@
     description: NodeJS-$releasever
     baseurl: https://rpm.nodesource.com/pub_6.x/fc/$releasever/x86_64
     gpgkey: https://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL
-    gpgcheck: yes
+    gpgcheck: true
   when: ansible_distribution == 'Fedora'
 
 - name: AmazonLinux | Get Nodejs
@@ -24,7 +24,7 @@
     set -o pipefail
     curl --silent --location https://rpm.nodesource.com/setup_8.x | bash -
   args:
-    warn: no
+    warn: fakse
     executable: /bin/bash
   when:
     - ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA"
@@ -44,8 +44,8 @@
     description: Wazuh repository
     baseurl: https://packages.wazuh.com/3.x/yum/
     gpgkey: https://packages.wazuh.com/key/GPG-KEY-WAZUH
-    gpgcheck: yes
-  changed_when: False
+    gpgcheck: true
+  changed_when: false
   when:
     - (ansible_distribution_major_version|int > 5) or (ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA")
 
@@ -55,7 +55,7 @@
     description: Wazuh repository
     baseurl: https://packages.wazuh.com/3.x/yum/5/
     gpgkey: https://packages.wazuh.com/key/GPG-KEY-WAZUH
-    gpgcheck: yes
+    gpgcheck: true
   when:
     - ansible_distribution_major_version|int == 5
 

--- a/roles/wazuh/ansible-wazuh-manager/tasks/RedHat.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/RedHat.yml
@@ -24,7 +24,7 @@
     set -o pipefail
     curl --silent --location https://rpm.nodesource.com/setup_8.x | bash -
   args:
-    warn: fakse
+    warn: false
     executable: /bin/bash
   when:
     - ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA"

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -45,7 +45,7 @@
     creates: sslmanager.cert
     chdir: /var/ossec/etc/
   tags:
-      - config
+    - config
   when: not wazuh_manager_config.authd.ssl_agent_ca is not none
 
 - name: Copy CA, SSL key and cert for authd
@@ -208,8 +208,8 @@
   args:
     removes: /var/ossec/bin/.process_list
     executable: /bin/bash
-  changed_when: False
-  check_mode: no
+  changed_when: false
+  check_mode: false
   register: csyslog_enabled
   tags:
     - config
@@ -230,8 +230,8 @@
   args:
     removes: /var/ossec/bin/.process_list
     executable: /bin/bash
-  changed_when: False
-  check_mode: no
+  changed_when: false
+  check_mode: false
   register: agentlessd_enabled
   tags:
     - config
@@ -349,7 +349,7 @@
 - name: Ensure Wazuh Manager, wazuh API service is started and enabled
   service:
     name: "{{ item }}"
-    enabled: yes
+    enabled: true
     state: started
   with_items:
     - wazuh-manager
@@ -364,7 +364,7 @@
 - name: Ensure Wazuh Manager is started and enabled (EL5)
   service:
     name: wazuh-manager
-    enabled: yes
+    enabled: true
     state: started
   tags:
     - config

--- a/roles/wazuh/ansible-wazuh-manager/vars/authd_pass.yml
+++ b/roles/wazuh/ansible-wazuh-manager/vars/authd_pass.yml
@@ -1,2 +1,2 @@
 ---
-#authd_pass: foobar
+# authd_pass: foobar


### PR DESCRIPTION
This PR contains the following changes:
* Added a Molecule scenario for testing the Wazuh Agent role.
* Added various minor changes that where found during linting;

**Scenario**
A Molecule scenario `wazuh-agent` is added and starts a single Wazuh Manager on CentOS 7. Once that is done, it start 5 containers (CentOS 6+7, Ubuntu 14, 16 + 18) and install the Wazuh Agent. During the `molecule verify`, a test is executed on the Wazuh Manager to see if all agents are registered correctly.

**linting**
During executing `molecule lint -s wazuh-agent`, a lot of messages like the following where printed:

```
      71:3      error    wrong indentation: expected 4 but found 2  (indentation)
      75:21     warning  truthy value should be true or false  (truthy)
      298:247   error    trailing spaces  (trailing-spaces).
      222:6     warning  missing starting space in comment  (comments)
```

I had to change various file to make these lint issues disappear. Most of them where indentation errors, 1 or more spaces on the end of the line. Most of them where changing `no` or `yes` to `false` or `true`. In some of the playbooks, I had to add `---` to the beginning of the file, so it is correctly `yaml`.

If there are any questions, don't hesitate to ask. I did not knew that the PR would be that big (58 files changed), so apologies for that. 