### PR TITLE
Setting polling time to 30 in wazuh-agent install Linux task.

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
@@ -8,7 +8,7 @@
 - name: Linux | Install wazuh-agent
   package: name=wazuh-agent state=present
   async: 90
-  poll: 15
+  poll: 30
   tags:
     - init
 


### PR DESCRIPTION
Hello folks,

This PR solves #171 . The _poll time_ was increased from 15 to 30 seconds. 

Regards

