### PR TITLE
Elastic xpack security support

### DIFF
--- a/playbooks/wazuh-elastic_stack-distributed.yml
+++ b/playbooks/wazuh-elastic_stack-distributed.yml
@@ -1,9 +1,42 @@
 ---
-- hosts: <your wazuh server host>
+
+- hosts: 172.16.0.161
   roles:
-    - role: /etc/ansible/roles/wazuh-ansible/roles/wazuh/ansible-wazuh-manager
-    - {role: /etc/ansible/roles/wazuh-ansible/roles/wazuh/ansible-filebeat, filebeat_output_logstash_hosts: 'your elastic stack server IP'}
-- hosts: <your elastic stack server host>
+    - role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-elasticsearch
+      elasticsearch_network_host: 172.16.0.161
+      elasticsearch_bootstrap_node: true
+      elasticsearch_cluster_nodes:
+      - 172.16.0.161
+      node_generate_certs: true
+      node_name: node-1
+
+  vars:
+    instances:
+      node_1:
+        name: node-1
+        ip: 172.16.0.161
+      node_2:
+        name: node-2
+        ip: 172.16.0.162
+      node_3:
+        name: node-3
+        ip: 172.16.0.163
+
+- hosts: 172.16.0.162
   roles:
-    - {role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-elasticsearch, elasticsearch_network_host: 'localhost'}
-    - {role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-kibana, elasticsearch_network_host: 'localhost'}
+    - role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-elasticsearch
+      elasticsearch_network_host: 172.16.0.162
+      elasticsearch_discovery_nodes:
+        - 172.16.0.161
+        - 172.16.0.162
+        - 172.16.0.163
+  
+- hosts: 172.16.0.163
+  roles:
+    - role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-elasticsearch 
+      elasticsearch_network_host: 172.16.0.163
+      elasticsearch_discovery_nodes:
+        - 172.16.0.161
+        - 172.16.0.162
+        - 172.16.0.163
+

--- a/playbooks/wazuh-elastic_stack-distributed.yml
+++ b/playbooks/wazuh-elastic_stack-distributed.yml
@@ -2,7 +2,7 @@
 
 - hosts: 172.16.0.161
   roles:
-    - role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-elasticsearch
+    - role: ../roles/elastic-stack/ansible-elasticsearch
       elasticsearch_network_host: 172.16.0.161
       elasticsearch_bootstrap_node: true
       elasticsearch_cluster_nodes:
@@ -10,7 +10,6 @@
       node_generate_certs: true
       node_name: node-1
       elasticsearch_xpack_security: true
-
   vars:
     instances:
       - name: node-1       # Important: must be equal to node name.                    
@@ -24,7 +23,7 @@
 
 - hosts: 172.16.0.162
   roles:
-    - role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-elasticsearch
+    - role: ../roles/elastic-stack/ansible-elasticsearch
       elasticsearch_network_host: 172.16.0.162
       elasticsearch_xpack_security: true
       elasticsearch_node_name: node-2
@@ -35,7 +34,7 @@
   
 - hosts: 172.16.0.163
   roles:
-    - role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-elasticsearch 
+    - role: ../roles/elastic-stack/ansible-elasticsearch 
       elasticsearch_network_host: 172.16.0.163
       elasticsearch_xpack_security: true
       elasticsearch_node_name: node-3

--- a/playbooks/wazuh-elastic_stack-distributed.yml
+++ b/playbooks/wazuh-elastic_stack-distributed.yml
@@ -1,69 +1,69 @@
 ---
 
-- hosts: 172.16.0.161
+- hosts: <node-1 IP>
   roles:
-    - role: ../roles/elastic-stack/ansible-elasticsearch
-      elasticsearch_network_host: 172.16.0.161
+    - role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-elasticsearch
+      elasticsearch_network_host: <node-1 IP>
       node_name: node-1
       elasticsearch_bootstrap_node: true
       elasticsearch_cluster_nodes: 
-        - 172.16.0.161
-        - 172.16.0.162
-        - 172.16.0.163
+        - <node-1 IP>
+        - <node-2 IP>
+        - <node-3 IP>
       elasticsearch_discovery_nodes:
-        - 172.16.0.161
-        - 172.16.0.162
-        - 172.16.0.163
+        - <node-1 IP>
+        - <node-2 IP>
+        - <node-3 IP>
       elasticsearch_xpack_security: true
       node_certs_generator: true
 
   vars:
     instances:
       - name: node-1       # Important: must be equal to elasticsearch_node_name.                    
-        ip: 172.16.0.161   # When unzipping, node will search for his node name folder to get the cert.
+        ip: <node-1 IP>   # When unzipping, node will search for his node name folder to get the cert.
 
       - name: node-2
-        ip: 172.16.0.162
+        ip: <node-2 IP>
 
       - name: node-3
-        ip: 172.16.0.163
+        ip: <node-3 IP>
 
-- hosts: 172.16.0.162
+- hosts: <node-2 IP>
   roles:
-    - role: ../roles/elastic-stack/ansible-elasticsearch
-      elasticsearch_network_host: 172.16.0.162
+    - role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-elasticsearch
+      elasticsearch_network_host: <node-2 IP>
       elasticsearch_node_name: node-2
       elasticsearch_xpack_security: true
       elasticsearch_master_candidate: true
       elasticsearch_discovery_nodes:
-        - 172.16.0.161
-        - 172.16.0.162
-        - 172.16.0.163
+        - <node-1 IP>
+        - <node-2 IP>
+        - <node-3 IP>
   
-- hosts: 172.16.0.163
+- hosts: <node-3 IP>
   roles:
-    - role: ../roles/elastic-stack/ansible-elasticsearch 
-      elasticsearch_network_host: 172.16.0.163
+    - role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-elasticsearch 
+      elasticsearch_network_host: <node-3 IP>
       elasticsearch_node_name: node-3
       elasticsearch_xpack_security: true
       elasticsearch_master_candidate: true
       elasticsearch_discovery_nodes:
-        - 172.16.0.161
-        - 172.16.0.162
-        - 172.16.0.163
+        - <node-1 IP>
+        - <node-2 IP>
+        - <node-3 IP>
 
 
 # - hosts: 172.16.0.162
 #   roles:
-#     - role: ../roles/wazuh/ansible-wazuh-manager
+#     - role: /etc/ansible/roles/wazuh-ansible/roles/wazuh/ansible-wazuh-manager
 
-#     - role: ../roles/wazuh/ansible-filebeat
+#     - role: /etc/ansible/roles/wazuh-ansible/roles/wazuh/ansible-filebeat
 #       filebeat_output_elasticsearch_hosts: 172.16.0.161:9200
 #       filebeat_xpack_security: true
 #       filebeat_node_name: node-2
 #       node_certs_generator: false
 
-#     - role: ../roles/elastic-stack/ansible-elasticsearch
+#     - role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-elasticsearch
 #       elasticsearch_network_host: 172.16.0.162
 #       node_name: node-2
 #       elasticsearch_bootstrap_node: false
@@ -77,7 +77,7 @@
 
 # - hosts: 172.16.0.163
 #   roles:
-#     - role: ../roles/elastic-stack/ansible-kibana
+#     - role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-kibana
 #       kibana_xpack_security: true
 #       kibana_user: elastic
 #       kibana_password: elastic_pass

--- a/playbooks/wazuh-elastic_stack-distributed.yml
+++ b/playbooks/wazuh-elastic_stack-distributed.yml
@@ -2,14 +2,20 @@
 
 - hosts: 172.16.0.161
   roles:
-    - ../roles/elastic-stack/ansible-elasticsearch
-  elasticsearch_network_host: 172.16.0.161
-  elasticsearch_bootstrap_node: true
-  elasticsearch_cluster_nodes:
-    - 172.16.0.161
-  node_certs_generator: true
-  node_name: node-1
-  elasticsearch_xpack_security: true
+    - role: ../roles/elastic-stack/ansible-elasticsearch
+      elasticsearch_network_host: 172.16.0.161
+      node_name: node-1
+      elasticsearch_bootstrap_node: true
+      elasticsearch_cluster_nodes: 
+        - 172.16.0.161
+        - 172.16.0.162
+        - 172.16.0.163
+      elasticsearch_discovery_nodes:
+        - 172.16.0.161
+        - 172.16.0.162
+        - 172.16.0.163
+      elasticsearch_xpack_security: true
+      node_certs_generator: true
 
   vars:
     instances:
@@ -26,8 +32,9 @@
   roles:
     - role: ../roles/elastic-stack/ansible-elasticsearch
       elasticsearch_network_host: 172.16.0.162
-      elasticsearch_xpack_security: true
       elasticsearch_node_name: node-2
+      elasticsearch_xpack_security: true
+      elasticsearch_master_candidate: true
       elasticsearch_discovery_nodes:
         - 172.16.0.161
         - 172.16.0.162
@@ -37,9 +44,44 @@
   roles:
     - role: ../roles/elastic-stack/ansible-elasticsearch 
       elasticsearch_network_host: 172.16.0.163
-      elasticsearch_xpack_security: true
       elasticsearch_node_name: node-3
+      elasticsearch_xpack_security: true
+      elasticsearch_master_candidate: true
       elasticsearch_discovery_nodes:
         - 172.16.0.161
         - 172.16.0.162
         - 172.16.0.163
+
+
+# - hosts: 172.16.0.162
+#   roles:
+#     - role: ../roles/wazuh/ansible-wazuh-manager
+
+#     - role: ../roles/wazuh/ansible-filebeat
+#       filebeat_output_elasticsearch_hosts: 172.16.0.161:9200
+#       filebeat_xpack_security: true
+#       filebeat_node_name: node-2
+#       node_certs_generator: false
+
+#     - role: ../roles/elastic-stack/ansible-elasticsearch
+#       elasticsearch_network_host: 172.16.0.162
+#       node_name: node-2
+#       elasticsearch_bootstrap_node: false
+#       elasticsearch_master_candidate: true
+#       elasticsearch_discovery_nodes: 
+#         - 172.16.0.161
+#         - 172.16.0.162
+#       elasticsearch_xpack_security: true
+#       node_certs_generator: false
+
+
+# - hosts: 172.16.0.163
+#   roles:
+#     - role: ../roles/elastic-stack/ansible-kibana
+#       kibana_xpack_security: true
+#       kibana_user: elastic
+#       kibana_password: elastic_pass
+#       kibana_node_name: node-3
+#       elasticsearch_network_host: 172.16.0.161
+#       node_certs_generator: false
+

--- a/playbooks/wazuh-elastic_stack-distributed.yml
+++ b/playbooks/wazuh-elastic_stack-distributed.yml
@@ -7,7 +7,7 @@
       elasticsearch_bootstrap_node: true
       elasticsearch_cluster_nodes:
       - 172.16.0.161
-      node_generate_certs: true
+      node_certs_generator: true
       node_name: node-1
       elasticsearch_xpack_security: true
   vars:

--- a/playbooks/wazuh-elastic_stack-distributed.yml
+++ b/playbooks/wazuh-elastic_stack-distributed.yml
@@ -9,17 +9,17 @@
       - 172.16.0.161
       node_generate_certs: true
       node_name: node-1
+      elasticsearch_xpack_security: true
 
   vars:
     instances:
-      node_1:
-        name: node-1
+      - name: node1
         ip: 172.16.0.161
-      node_2:
-        name: node-2
+
+      - name: node2
         ip: 172.16.0.162
-      node_3:
-        name: node-3
+
+      - name: node3
         ip: 172.16.0.163
 
 - hosts: 172.16.0.162

--- a/playbooks/wazuh-elastic_stack-distributed.yml
+++ b/playbooks/wazuh-elastic_stack-distributed.yml
@@ -13,19 +13,21 @@
 
   vars:
     instances:
-      - name: node1
-        ip: 172.16.0.161
+      - name: node-1       # Important: must be equal to node name.                    
+        ip: 172.16.0.161   # When unzipping, node will search for his node name folder to get the cert.
 
-      - name: node2
+      - name: node-2
         ip: 172.16.0.162
 
-      - name: node3
+      - name: node-3
         ip: 172.16.0.163
 
 - hosts: 172.16.0.162
   roles:
     - role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-elasticsearch
       elasticsearch_network_host: 172.16.0.162
+      elasticsearch_xpack_security: true
+      elasticsearch_node_name: node-2
       elasticsearch_discovery_nodes:
         - 172.16.0.161
         - 172.16.0.162
@@ -35,8 +37,9 @@
   roles:
     - role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-elasticsearch 
       elasticsearch_network_host: 172.16.0.163
+      elasticsearch_xpack_security: true
+      elasticsearch_node_name: node-3
       elasticsearch_discovery_nodes:
         - 172.16.0.161
         - 172.16.0.162
         - 172.16.0.163
-

--- a/playbooks/wazuh-elastic_stack-distributed.yml
+++ b/playbooks/wazuh-elastic_stack-distributed.yml
@@ -16,11 +16,12 @@
         - <node-3 IP>
       elasticsearch_xpack_security: true
       node_certs_generator: true
+      elasticsearch_xpack_security_password: elastic_pass
 
   vars:
     instances:
       - name: node-1       # Important: must be equal to elasticsearch_node_name.                    
-        ip: <node-1 IP>   # When unzipping, node will search for his node name folder to get the cert.
+        ip: <node-1 IP>   # When unzipping, the node will search for its node name folder to get the cert.
 
       - name: node-2
         ip: <node-2 IP>
@@ -62,6 +63,7 @@
 #       filebeat_xpack_security: true
 #       filebeat_node_name: node-2
 #       node_certs_generator: false
+#       elasticsearch_xpack_security_password: elastic_pass
 
 #     - role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-elasticsearch
 #       elasticsearch_network_host: 172.16.0.162
@@ -79,9 +81,7 @@
 #   roles:
 #     - role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-kibana
 #       kibana_xpack_security: true
-#       kibana_user: elastic
-#       kibana_password: elastic_pass
 #       kibana_node_name: node-3
 #       elasticsearch_network_host: 172.16.0.161
 #       node_certs_generator: false
-
+#       elasticsearch_xpack_security_password: elastic_pass

--- a/playbooks/wazuh-elastic_stack-distributed.yml
+++ b/playbooks/wazuh-elastic_stack-distributed.yml
@@ -2,17 +2,18 @@
 
 - hosts: 172.16.0.161
   roles:
-    - role: ../roles/elastic-stack/ansible-elasticsearch
-      elasticsearch_network_host: 172.16.0.161
-      elasticsearch_bootstrap_node: true
-      elasticsearch_cluster_nodes:
-      - 172.16.0.161
-      node_certs_generator: true
-      node_name: node-1
-      elasticsearch_xpack_security: true
+    - ../roles/elastic-stack/ansible-elasticsearch
+  elasticsearch_network_host: 172.16.0.161
+  elasticsearch_bootstrap_node: true
+  elasticsearch_cluster_nodes:
+    - 172.16.0.161
+  node_certs_generator: true
+  node_name: node-1
+  elasticsearch_xpack_security: true
+
   vars:
     instances:
-      - name: node-1       # Important: must be equal to node name.                    
+      - name: node-1       # Important: must be equal to elasticsearch_node_name.                    
         ip: 172.16.0.161   # When unzipping, node will search for his node name folder to get the cert.
 
       - name: node-2

--- a/playbooks/wazuh-kibana.yml
+++ b/playbooks/wazuh-kibana.yml
@@ -1,4 +1,10 @@
 ---
-- hosts: <your kibana host>
+- hosts: 172.16.0.162
   roles:
-    - {role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-kibana, elasticsearch_network_host: 'your elasticsearch IP'}
+    - role: ../roles/elastic-stack/ansible-kibana
+      kibana_xpack_security: true
+      kibana_user: elastic
+      kibana_password: elastic_pass
+      kibana_node_name: node-2
+      elasticsearch_network_host: 172.16.0.161
+      node_certs_generator: false

--- a/playbooks/wazuh-manager.yml
+++ b/playbooks/wazuh-manager.yml
@@ -1,5 +1,10 @@
 ---
-- hosts: <your wazuh server host>
+- hosts: 172.16.0.161
   roles:
-    - role: /etc/ansible/roles/wazuh-ansible/roles/wazuh/ansible-wazuh-manager
-    - {role: /etc/ansible/roles/wazuh-ansible/roles/wazuh/ansible-filebeat, filebeat_output_elasticsearch_hosts: 'your elasticsearch IP'}
+    - role: ../roles/wazuh/ansible-wazuh-manager
+    - role: ../roles/wazuh/ansible-filebeat
+      filebeat_output_elasticsearch_hosts: 172.16.0.161:9200
+      filebeat_xpack_security: true
+      filebeat_node_name: node-1
+      node_certs_generator: true
+

--- a/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
@@ -15,6 +15,7 @@ elasticsearch_discovery_nodes:
 
 # X-Pack Security 
 elasticsearch_xpack_security: false
+elasticsearch_xpack_security_user: elastic
 elasticsearch_xpack_security_password: elastic_pass
 
 node_certs_generator: false

--- a/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
@@ -10,5 +10,7 @@ elasticsearch_bootstrap_node: false
 elasticsearch_master_candidate: false
 elasticsearch_cluster_nodes:
   - 127.0.0.1
+elasticsearch_discovery_nodes:
+  - 127.0.0.1
 elasticsearch_xpack_security: false
 node_generate_certs: false

--- a/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
@@ -12,5 +12,20 @@ elasticsearch_cluster_nodes:
   - 127.0.0.1
 elasticsearch_discovery_nodes:
   - 127.0.0.1
+
+# X-Pack Security 
 elasticsearch_xpack_security: false
-node_generate_certs: false
+node_certs_generator: false
+node_certs_generator_ip: 172.16.0.161
+node_certs_source: /usr/share/elasticsearch
+node_certs_destination: /etc/elasticsearch/certs
+
+# Rsync
+rsync_path: /usr/bin/rsync
+rsync_user: vagrant
+rsync_extra_parameters: -avg -e 'ssh -o StrictHostKeyChecking=no' --rsync-path='sudo rsync'
+
+
+
+
+

--- a/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
@@ -11,3 +11,4 @@ elasticsearch_master_candidate: false
 elasticsearch_cluster_nodes:
   - 127.0.0.1
 elasticsearch_xpack_security: false
+node_generate_certs: false

--- a/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
@@ -10,3 +10,4 @@ elasticsearch_bootstrap_node: false
 elasticsearch_master_candidate: false
 elasticsearch_cluster_nodes:
   - 127.0.0.1
+elasticsearch_xpack_security: false

--- a/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
@@ -15,6 +15,8 @@ elasticsearch_discovery_nodes:
 
 # X-Pack Security 
 elasticsearch_xpack_security: false
+elasticsearch_xpack_security_password: elastic_pass
+
 node_certs_generator: false
 node_certs_generator_ip: 172.16.0.161
 node_certs_source: /usr/share/elasticsearch

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
@@ -119,7 +119,15 @@
   when: 
     - node_generate_certs
     - elasticsearch_xpack_security
-  
+
+- name: Check that the instances.yml file exists
+  stat:
+    path: /usr/share/elasticsearch/instances.yml
+  register: instances_file_exists
+  when: 
+    - node_generate_certs
+    - elasticsearch_xpack_security
+
 - name: Generating certificates for Elasticsearch security
   shell: "/usr/share/elasticsearch/bin/elasticsearch-certutil cert ca --pem --in /usr/share/elasticsearch/instances.yml --out /usr/share/elasticsearch/certs.zip"
   when: 

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
@@ -115,11 +115,16 @@
 - name: Check that the instances.yml file exists
   stat:
     path: /usr/share/elasticsearch/instances.yml
-  register: instances_exists
+  register: instances_file_exists
+  when: 
+    - node_generate_certs
+    - elasticsearch_xpack_security
   
 - name: Generating certificates for Elasticsearch security
   shell: "/usr/share/elasticsearch/bin/elasticsearch-certutil cert ca --pem --in /usr/share/elasticsearch/instances.yml --out /usr/share/elasticsearch/certs.zip"
-  when: instances_exists
+  when: 
+    - instances_file_exists
+    - elasticsearch_xpack_security
   tags: xpack-security
 
 - import_tasks: "RMRedHat.yml"

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
@@ -104,7 +104,6 @@
   shell: "/usr/share/elasticsearch/bin/elasticsearch-certutil cert ca --pem --in {{node_certs_source}}/instances.yml --out {{node_certs_source}}/certs.zip"
   when: 
     - node_certs_generator
-    - instances_file_exists.stat.exists
     - elasticsearch_xpack_security
     - not xpack_certs_zip.stat.exists
     - not certificate_file_exists.stat.exists
@@ -165,12 +164,14 @@
   shell: "chown -R elasticsearch: {{node_certs_destination}}/"
   when:
     - check_certs_permissions is defined
+    - elasticsearch_xpack_security
   tags: xpack-security
 
 - name: Ensuring certificates folder owner
   shell: "chmod -R 770 {{node_certs_destination}}/"
   when:
     - check_certs_permissions is defined
+    - elasticsearch_xpack_security
   tags: xpack-security
   
 

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
@@ -69,6 +69,70 @@
   tags: configure
 
 # fix in new PR (ignore_errors)
+
+- name: Check that the instances.yml file exists
+  stat:
+    path: "{{node_certs_source}}/instances.yml"
+  register: instances_file_exists
+  when: 
+    - node_certs_generator
+    - elasticsearch_xpack_security
+
+- name: Write the instances.yml file in the selected node
+  template:
+    src: instances.yml.j2
+    dest: "{{node_certs_source}}/instances.yml"
+  tags:
+    - config
+    - xpack-security
+  when: 
+    - node_certs_generator
+    - elasticsearch_xpack_security
+
+- name: Check that the certificates ZIP file exists
+  stat:
+    path: "{{node_certs_source}}/certs.zip"
+  register: xpack_certs_zip
+  when: 
+    - node_certs_generator
+    - elasticsearch_xpack_security
+
+- name: Generating certificates for Elasticsearch security
+  shell: "/usr/share/elasticsearch/bin/elasticsearch-certutil cert ca --pem --in {{node_certs_source}}/instances.yml --out {{node_certs_source}}/certs.zip"
+  when: 
+    - node_certs_generator
+    - instances_file_exists.stat.exists
+    - elasticsearch_xpack_security
+    - not xpack_certs_zip.stat.exists
+  tags: xpack-security
+
+- name: Unzip generated certs.zip
+  unarchive:
+    src: "{{node_certs_source}}/certs.zip"
+    dest: "{{node_certs_source}}"
+    remote_src: yes
+  when: 
+    - node_certs_generator
+    - elasticsearch_xpack_security
+  tags: xpack-security
+
+- name: Copy local certificate for generator node
+  synchronize:
+    src: "{{node_certs_source}}/{{elasticsearch_node_name}}/"
+    dest: "{{node_certs_destination}}/"
+  delegate_to: "{{ node_certs_generator_ip }}"
+  when: 
+    - node_certs_generator
+    - elasticsearch_xpack_security
+  tags: xpack-security
+
+- name: Importing certificate generated previously
+  shell: "{{rsync_path}} {{rsync_extra_parameters}} {{rsync_user}}@{{node_certs_generator_ip}}:{{node_certs_source}}/{{elasticsearch_node_name}}/ {{node_certs_destination}}/"
+  when:
+    - not node_certs_generator
+    - elasticsearch_xpack_security
+  tags: xpack-security
+
 - name: Reload systemd
   systemd: daemon_reload=true
   ignore_errors: true
@@ -112,58 +176,9 @@
     - wazuh_alerts_template_exits.status != 200
   tags: init
 
-- name: Check that the instances.yml file exists
-  stat:
-    path: /usr/share/elasticsearch/instances.yml
-  register: instances_file_exists
-  when: 
-    - node_generate_certs
-    - elasticsearch_xpack_security
+# - import_tasks: "RMRedHat.yml"
+#   when: ansible_os_family == "RedHat"
 
-- name: Write the instances.yml file in the selected node
-  template:
-    src: instances.yml.j2
-    dest: "/usr/share/elasticsearch/instances.yml"
-  tags:
-    - config
-    - xpack-security
-  when: 
-    - node_generate_certs
-    - elasticsearch_xpack_security
 
-- name: Check that the certificates ZIP file exists
-  stat:
-    path: /usr/share/elasticsearch/certs.zip
-  register: xpack_certs_zip
-  when: 
-    - node_generate_certs
-    - elasticsearch_xpack_security
-
-- name: Generating certificates for Elasticsearch security
-  shell: "/usr/share/elasticsearch/bin/elasticsearch-certutil cert ca --pem --in /usr/share/elasticsearch/instances.yml --out /usr/share/elasticsearch/certs.zip"
-  when: 
-    - node_generate_certs
-    - instances_file_exists
-    - elasticsearch_xpack_security
-    - not xpack_certs_zip
-  tags: xpack-security
-
-# - name: Importing certificates generated previously
-#   synchronize:
-#     mode: push
-#     src: /usr/share/elasticsearch/certs.zip
-#     dest: /usr/share/elasticsearch/certs.zip
-#     rsync_opts:
-#         - "--rsync-path='sudo rsync'"
-#         - "-v"
-#   delegate_to: "{{groups['elk'][0]}}"
-#   when: 
-#     - not node_generate_certs
-#     - elasticsearch_xpack_security
-#   tags: xpack-security
-
-- import_tasks: "RMRedHat.yml"
-  when: ansible_os_family == "RedHat"
-
-- import_tasks: "RMDebian.yml"
-  when: ansible_os_family == "Debian"
+# - import_tasks: "RMDebian.yml"
+#   when: ansible_os_family == "Debian"

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
@@ -70,7 +70,19 @@
 
 # fix in new PR (ignore_errors)
 
-- name: Check that the instances.yml file exists
+- name: Write the instances.yml file in the selected node (force = no)
+  template:
+    src: instances.yml.j2
+    dest: "{{node_certs_source}}/instances.yml"
+    force: no
+  tags:
+    - config
+    - xpack-security
+  when:
+    - node_certs_generator
+    - elasticsearch_xpack_security
+
+- name: Update instances.yml status after generation
   stat:
     path: "{{node_certs_source}}/instances.yml"
   register: instances_file_exists
@@ -78,18 +90,7 @@
     - node_certs_generator
     - elasticsearch_xpack_security
 
-- name: Write the instances.yml file in the selected node
-  template:
-    src: instances.yml.j2
-    dest: "{{node_certs_source}}/instances.yml"
-  tags:
-    - config
-    - xpack-security
-  when: 
-    - node_certs_generator
-    - elasticsearch_xpack_security
-
-- name: Check that the certificates ZIP file exists
+- name: Check if the certificates ZIP file exists
   stat:
     path: "{{node_certs_source}}/certs.zip"
   register: xpack_certs_zip

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
@@ -126,6 +126,7 @@
     dest: "/usr/share/elasticsearch/instances.yml"
   tags:
     - config
+    - xpack-security
   when: 
     - node_generate_certs
     - elasticsearch_xpack_security
@@ -135,6 +136,27 @@
   when: 
     - node_generate_certs
     - instances_file_exists
+    - elasticsearch_xpack_security
+  tags: xpack-security
+
+# - name: Importing certificates generated previously
+#   synchronize:
+#     mode: push
+#     src: /usr/share/elasticsearch/certs.zip
+#     dest: /usr/share/elasticsearch/certs.zip
+#     rsync_opts:
+#         - "--rsync-path='sudo rsync'"
+#         - "-v"
+#   delegate_to: "{{groups['elk'][0]}}"
+#   when: 
+#     - not node_generate_certs
+#     - elasticsearch_xpack_security
+#   tags: xpack-security
+
+- name: Importing certificate generated previously
+  shell: "/usr/bin/rsync -avg -e 'ssh -o StrictHostKeyChecking=no' --rsync-path='sudo rsync' vagrant@172.16.0.161:/usr/share/elasticsearch/{{elasticsearch_node_name}}/ /home/es_certificates/"
+  when: 
+    - not node_generate_certs
     - elasticsearch_xpack_security
   tags: xpack-security
 

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
@@ -48,16 +48,6 @@
     - ansible_service_mgr != "systemd"
     - ansible_os_family == "RedHat"
 
-- name: Configure Elasticsearch.
-  template:
-    src: elasticsearch.yml.j2
-    dest: /etc/elasticsearch/elasticsearch.yml
-    owner: root
-    group: elasticsearch
-    mode: 0660
-  notify: restart elasticsearch
-  tags: configure
-
 - name: Configure Elasticsearch JVM memmory.
   template:
     src: jvm.options.j2
@@ -70,17 +60,29 @@
 
 # fix in new PR (ignore_errors)
 
+- import_tasks: "RMRedHat.yml"
+  when: ansible_os_family == "RedHat"
+
+- name: Check if certificate exists locally
+  stat:
+    path: "{{node_certs_destination}}/{{ elasticsearch_node_name }}.crt"
+  register: certificate_file_exists
+  when:
+    - elasticsearch_xpack_security
+
 - name: Write the instances.yml file in the selected node (force = no)
   template:
     src: instances.yml.j2
     dest: "{{node_certs_source}}/instances.yml"
     force: no
+  register: instances_file_exists
   tags:
     - config
     - xpack-security
   when:
     - node_certs_generator
     - elasticsearch_xpack_security
+    - not certificate_file_exists.stat.exists
 
 - name: Update instances.yml status after generation
   stat:
@@ -105,6 +107,8 @@
     - instances_file_exists.stat.exists
     - elasticsearch_xpack_security
     - not xpack_certs_zip.stat.exists
+    - not certificate_file_exists.stat.exists
+  register: certs_file_generated
   tags: xpack-security
 
 - name: Unzip generated certs.zip
@@ -115,6 +119,8 @@
   when: 
     - node_certs_generator
     - elasticsearch_xpack_security
+    - certs_file_generated is defined
+    - not certificate_file_exists.stat.exists
   tags: xpack-security
 
 - name: Copy key & certificate files in generator node (locally)
@@ -132,13 +138,7 @@
     src: "{{node_certs_source}}/ca/"
     dest: "{{node_certs_destination}}/"
   delegate_to: "{{ node_certs_generator_ip }}"
-  when: 
-    - node_certs_generator
-    - elasticsearch_xpack_security
-  tags: xpack-security
-
-- name: Remove generated certs file
-  shell: /bin/rm -f {{node_certs_source}}/certs.zip*
+  register: check_certs_permissions
   when: 
     - node_certs_generator
     - elasticsearch_xpack_security
@@ -149,6 +149,7 @@
   when:
     - not node_certs_generator
     - elasticsearch_xpack_security
+    - not certificate_file_exists.stat.exists
   tags: xpack-security
 
 - name: Importing ca certificate file from generator node 
@@ -156,13 +157,45 @@
   when:
     - not node_certs_generator
     - elasticsearch_xpack_security
+    - not certificate_file_exists.stat.exists
+  register: check_certs_permissions
   tags: xpack-security
+
+- name: Ensuring certificates folder owner
+  shell: "chown -R elasticsearch: {{node_certs_destination}}/"
+  when:
+    - check_certs_permissions is defined
+  tags: xpack-security
+
+- name: Ensuring certificates folder owner
+  shell: "chmod -R 770 {{node_certs_destination}}/"
+  when:
+    - check_certs_permissions is defined
+  tags: xpack-security
+  
+
+- name: Remove generated certs file
+  shell: /bin/rm -f {{node_certs_source}}/certs.zip*
+  when: 
+    - node_certs_generator
+    - elasticsearch_xpack_security
+  tags: xpack-security
+
+- name: Configure Elasticsearch.
+  template:
+    src: elasticsearch.yml.j2
+    dest: /etc/elasticsearch/elasticsearch.yml
+    owner: root
+    group: elasticsearch
+    mode: 0660
+  notify: restart elasticsearch
+  tags: configure
 
 - name: Set elasticsearch bootstrap password
   shell: "echo '{{elasticsearch_xpack_security_password}}' | {{node_certs_source}}/bin/elasticsearch-keystore add -xf 'bootstrap.password'"
   when:
     - elasticsearch_xpack_security
-
+  
 - name: Reload systemd
   systemd: daemon_reload=true
   ignore_errors: true
@@ -183,6 +216,31 @@
   tags:
     - configure
     - init
+
+- name: Check for Wazuh Alerts template (http)
+  uri:
+    url: "http://{{elasticsearch_network_host}}:{{elasticsearch_http_port}}/_template/wazuh"
+    method: GET
+    status_code: 200, 404
+  when: 
+    - elasticsearch_bootstrap_node or single_node
+    - not elasticsearch_xpack_security
+  poll: 30
+  register: wazuh_alerts_template_exits
+  tags: init
+
+- name: Installing Wazuh Alerts template (http)
+  uri:
+    url: "http://{{elasticsearch_network_host}}:{{elasticsearch_http_port}}/_template/wazuh"
+    method: PUT
+    status_code: 200
+    body_format: json
+    body: "{{ lookup('template','wazuh-elastic7-template-alerts.json.j2') }}"
+  when: 
+    - wazuh_alerts_template_exits.status is defined
+    - wazuh_alerts_template_exits.status != 200
+    - not elasticsearch_xpack_security
+  tags: init
 
 - import_tasks: "RMRedHat.yml"
   when: ansible_os_family == "RedHat"

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
@@ -136,6 +136,13 @@
     - elasticsearch_xpack_security
   tags: xpack-security
 
+- name: Remove generated certs file
+  shell: /bin/rm -f {{node_certs_source}}/certs.zip*
+  when: 
+    - node_certs_generator
+    - elasticsearch_xpack_security
+  tags: xpack-security
+
 - name: Importing key & certificate files from generator node
   shell: "{{rsync_path}} {{rsync_extra_parameters}} {{rsync_user}}@{{node_certs_generator_ip}}:{{node_certs_source}}/{{elasticsearch_node_name}}/ {{node_certs_destination}}/"
   when:
@@ -153,7 +160,6 @@
 - name: Set elasticsearch bootstrap password
   shell: "echo '{{elasticsearch_xpack_security_password}}' | {{node_certs_source}}/bin/elasticsearch-keystore add -xf 'bootstrap.password'"
   when:
-    - node_certs_generator
     - elasticsearch_xpack_security
 
 - name: Reload systemd

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
@@ -116,7 +116,7 @@
     - elasticsearch_xpack_security
   tags: xpack-security
 
-- name: Copy .key & .crt files in generator node
+- name: Copy key & certificate files in generator node (locally)
   synchronize:
     src: "{{node_certs_source}}/{{elasticsearch_node_name}}/"
     dest: "{{node_certs_destination}}/"
@@ -126,7 +126,7 @@
     - elasticsearch_xpack_security
   tags: xpack-security
 
-- name: Copy ca .crt file in generator node
+- name: Copy ca certificate file in generator node (locally)
   synchronize:
     src: "{{node_certs_source}}/ca/"
     dest: "{{node_certs_destination}}/"
@@ -136,14 +136,14 @@
     - elasticsearch_xpack_security
   tags: xpack-security
 
-- name: Importing node .key & .crt files
+- name: Importing key & certificate files from generator node
   shell: "{{rsync_path}} {{rsync_extra_parameters}} {{rsync_user}}@{{node_certs_generator_ip}}:{{node_certs_source}}/{{elasticsearch_node_name}}/ {{node_certs_destination}}/"
   when:
     - not node_certs_generator
     - elasticsearch_xpack_security
   tags: xpack-security
 
-- name: Importing node ca .crt file
+- name: Importing ca certificate file from generator node 
   shell: "{{rsync_path}} {{rsync_extra_parameters}} {{rsync_user}}@{{node_certs_generator_ip}}:{{node_certs_source}}/ca/ {{node_certs_destination}}/"
   when:
     - not node_certs_generator

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
@@ -143,6 +143,14 @@
     - elasticsearch_xpack_security
   tags: xpack-security
 
+- name: Importing node ca .crt file
+  shell: "{{rsync_path}} {{rsync_extra_parameters}} {{rsync_user}}@{{node_certs_generator_ip}}:{{node_certs_source}}/ca/ {{node_certs_destination}}/"
+  when:
+    - not node_certs_generator
+    - elasticsearch_xpack_security
+  tags: xpack-security
+
+
 - name: Reload systemd
   systemd: daemon_reload=true
   ignore_errors: true

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
@@ -172,28 +172,6 @@
     - configure
     - init
 
-- name: Check for Wazuh Alerts template
-  uri:
-    url: "http://{{elasticsearch_network_host}}:{{elasticsearch_http_port}}/_template/wazuh"
-    method: GET
-    status_code: 200, 404
-  when: not elasticsearch_bootstrap_node or single_node
-  poll: 30
-  register: wazuh_alerts_template_exits
-  tags: init
-
-- name: Installing Wazuh Alerts template
-  uri:
-    url: "http://{{elasticsearch_network_host}}:{{elasticsearch_http_port}}/_template/wazuh"
-    method: PUT
-    status_code: 200
-    body_format: json
-    body: "{{ lookup('template','wazuh-elastic7-template-alerts.json.j2') }}"
-  when: 
-    - wazuh_alerts_template_exits.status is defined
-    - wazuh_alerts_template_exits.status != 200
-  tags: init
-
 - import_tasks: "RMRedHat.yml"
   when: ansible_os_family == "RedHat"
 

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
@@ -121,7 +121,7 @@
     - elasticsearch_xpack_security
 
 - name: Write the instances.yml file in the selected node
-  instances_file:
+  template:
     src: instances.yml.j2
     dest: "/usr/share/elasticsearch/instances.yml"
   tags:
@@ -133,6 +133,7 @@
 - name: Generating certificates for Elasticsearch security
   shell: "/usr/share/elasticsearch/bin/elasticsearch-certutil cert ca --pem --in /usr/share/elasticsearch/instances.yml --out /usr/share/elasticsearch/certs.zip"
   when: 
+    - node_generate_certs
     - instances_file_exists
     - elasticsearch_xpack_security
   tags: xpack-security

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
@@ -109,14 +109,14 @@
 - name: Unzip generated certs.zip
   unarchive:
     src: "{{node_certs_source}}/certs.zip"
-    dest: "{{node_certs_source}}"
+    dest: "{{node_certs_source}}/"
     remote_src: yes
   when: 
     - node_certs_generator
     - elasticsearch_xpack_security
   tags: xpack-security
 
-- name: Copy local certificate for generator node
+- name: Copy .key & .crt files in generator node
   synchronize:
     src: "{{node_certs_source}}/{{elasticsearch_node_name}}/"
     dest: "{{node_certs_destination}}/"
@@ -126,7 +126,17 @@
     - elasticsearch_xpack_security
   tags: xpack-security
 
-- name: Importing certificate generated previously
+- name: Copy ca .crt file in generator node
+  synchronize:
+    src: "{{node_certs_source}}/ca/"
+    dest: "{{node_certs_destination}}/"
+  delegate_to: "{{ node_certs_generator_ip }}"
+  when: 
+    - node_certs_generator
+    - elasticsearch_xpack_security
+  tags: xpack-security
+
+- name: Importing node .key & .crt files
   shell: "{{rsync_path}} {{rsync_extra_parameters}} {{rsync_user}}@{{node_certs_generator_ip}}:{{node_certs_source}}/{{elasticsearch_node_name}}/ {{node_certs_destination}}/"
   when:
     - not node_certs_generator
@@ -176,9 +186,9 @@
     - wazuh_alerts_template_exits.status != 200
   tags: init
 
-# - import_tasks: "RMRedHat.yml"
-#   when: ansible_os_family == "RedHat"
+- import_tasks: "RMRedHat.yml"
+  when: ansible_os_family == "RedHat"
 
 
-# - import_tasks: "RMDebian.yml"
-#   when: ansible_os_family == "Debian"
+- import_tasks: "RMDebian.yml"
+  when: ansible_os_family == "Debian"

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
@@ -120,10 +120,12 @@
     - node_generate_certs
     - elasticsearch_xpack_security
 
-- name: Check that the instances.yml file exists
-  stat:
-    path: /usr/share/elasticsearch/instances.yml
-  register: instances_file_exists
+- name: Write the instances.yml file in the selected node
+  instances_file:
+    src: instances.yml.j2
+    dest: "/usr/share/elasticsearch/instances.yml"
+  tags:
+    - config
   when: 
     - node_generate_certs
     - elasticsearch_xpack_security

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
@@ -131,12 +131,21 @@
     - node_generate_certs
     - elasticsearch_xpack_security
 
+- name: Check that the certificates ZIP file exists
+  stat:
+    path: /usr/share/elasticsearch/certs.zip
+  register: xpack_certs_zip
+  when: 
+    - node_generate_certs
+    - elasticsearch_xpack_security
+
 - name: Generating certificates for Elasticsearch security
   shell: "/usr/share/elasticsearch/bin/elasticsearch-certutil cert ca --pem --in /usr/share/elasticsearch/instances.yml --out /usr/share/elasticsearch/certs.zip"
   when: 
     - node_generate_certs
     - instances_file_exists
     - elasticsearch_xpack_security
+    - not xpack_certs_zip
   tags: xpack-security
 
 # - name: Importing certificates generated previously
@@ -152,13 +161,6 @@
 #     - not node_generate_certs
 #     - elasticsearch_xpack_security
 #   tags: xpack-security
-
-- name: Importing certificate generated previously
-  shell: "/usr/bin/rsync -avg -e 'ssh -o StrictHostKeyChecking=no' --rsync-path='sudo rsync' vagrant@172.16.0.161:/usr/share/elasticsearch/{{elasticsearch_node_name}}/ /home/es_certificates/"
-  when: 
-    - not node_generate_certs
-    - elasticsearch_xpack_security
-  tags: xpack-security
 
 - import_tasks: "RMRedHat.yml"
   when: ansible_os_family == "RedHat"

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
@@ -112,6 +112,16 @@
     - wazuh_alerts_template_exits.status != 200
   tags: init
 
+- name: Check that the instances.yml file exists
+  stat:
+    path: /usr/share/elasticsearch/instances.yml
+  register: instances_exists
+  
+- name: Generating certificates for Elasticsearch security
+  shell: "/usr/share/elasticsearch/bin/elasticsearch-certutil cert ca --pem --in /usr/share/elasticsearch/instances.yml --out /usr/share/elasticsearch/certs.zip"
+  when: instances_exists
+  tags: xpack-security
+
 - import_tasks: "RMRedHat.yml"
   when: ansible_os_family == "RedHat"
 

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
@@ -150,6 +150,11 @@
     - elasticsearch_xpack_security
   tags: xpack-security
 
+- name: Set elasticsearch bootstrap password
+  shell: "echo '{{elasticsearch_xpack_security_password}}' | {{node_certs_source}}/bin/elasticsearch-keystore add -xf 'bootstrap.password'"
+  when:
+    - node_certs_generator
+    - elasticsearch_xpack_security
 
 - name: Reload systemd
   systemd: daemon_reload=true

--- a/roles/elastic-stack/ansible-elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/elastic-stack/ansible-elasticsearch/templates/elasticsearch.yml.j2
@@ -15,6 +15,10 @@ cluster.initial_master_nodes:
 {% for item in elasticsearch_cluster_nodes %}
   - {{ item }}
 {% endfor %}
+discovery.seed_hosts:
+{% for item in elasticsearch_discovery_nodes %}
+  - {{ item }}
+{% endfor %}
 {% else %}
 node.master: {{ elasticsearch_master_candidate|lower }}
 discovery.seed_hosts:
@@ -37,5 +41,5 @@ xpack.security.http.ssl.enabled: true
 xpack.security.http.ssl.verification_mode: certificate
 xpack.security.http.ssl.key: {{node_certs_destination}}/{{ elasticsearch_node_name }}.key 
 xpack.security.http.ssl.certificate: {{node_certs_destination}}/{{ elasticsearch_node_name }}.crt 
-xpack.security.http.ssl.certificate_authorities: [ "/etc/elasticsearch/certs/ca.crt" ]
+xpack.security.http.ssl.certificate_authorities: [ "{{ node_certs_destination }}/ca.crt" ]
 {% endif %}

--- a/roles/elastic-stack/ansible-elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/elastic-stack/ansible-elasticsearch/templates/elasticsearch.yml.j2
@@ -22,3 +22,9 @@ discovery.seed_hosts:
   - {{ item }}
 {% endfor %}
 {% endif %}
+
+# XPACK Security
+
+{% if elasticsearch_xpack_security %}
+xpack.security.enabled: true
+{% endif %}

--- a/roles/elastic-stack/ansible-elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/elastic-stack/ansible-elasticsearch/templates/elasticsearch.yml.j2
@@ -26,10 +26,10 @@ discovery.seed_hosts:
 # XPACK Security
 
 {% if elasticsearch_xpack_security %}
-#xpack.security.enabled: false
-#xpack.security.transport.ssl.enabled: true
-#xpack.security.transport.ssl.verification_mode: certificate 
-#xpack.security.transport.ssl.key: /home/es_certificates/{{ elasticsearch_node_name }}.key 
-#xpack.security.transport.ssl.certificate: /home/es_certificates/{{ elasticsearch_node_name }}.crt 
-#xpack.security.transport.ssl.certificate_authorities: [ "/home/es/config/ca.crt" ] 
+xpack.security.enabled: false
+xpack.security.transport.ssl.enabled: true
+xpack.security.transport.ssl.verification_mode: certificate 
+xpack.security.transport.ssl.key: {{node_certs_destination}}/{{ elasticsearch_node_name }}.key 
+xpack.security.transport.ssl.certificate: {{node_certs_destination}}/{{ elasticsearch_node_name }}.crt 
+#xpack.security.transport.ssl.certificate_authorities: [ "{{node_certs_destination}}/ca.crt" ] 
 {% endif %}

--- a/roles/elastic-stack/ansible-elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/elastic-stack/ansible-elasticsearch/templates/elasticsearch.yml.j2
@@ -26,10 +26,16 @@ discovery.seed_hosts:
 # XPACK Security
 
 {% if elasticsearch_xpack_security %}
-xpack.security.enabled: false
+xpack.security.enabled: true
 xpack.security.transport.ssl.enabled: true
 xpack.security.transport.ssl.verification_mode: certificate 
 xpack.security.transport.ssl.key: {{node_certs_destination}}/{{ elasticsearch_node_name }}.key 
 xpack.security.transport.ssl.certificate: {{node_certs_destination}}/{{ elasticsearch_node_name }}.crt 
-#xpack.security.transport.ssl.certificate_authorities: [ "{{node_certs_destination}}/ca.crt" ] 
+xpack.security.transport.ssl.certificate_authorities: [ "{{ node_certs_destination }}/ca.crt" ]
+
+xpack.security.http.ssl.enabled: true
+xpack.security.http.ssl.verification_mode: certificate
+xpack.security.http.ssl.key: {{node_certs_destination}}/{{ elasticsearch_node_name }}.key 
+xpack.security.http.ssl.certificate: {{node_certs_destination}}/{{ elasticsearch_node_name }}.crt 
+xpack.security.http.ssl.certificate_authorities: [ "/etc/elasticsearch/certs/ca.crt" ]
 {% endif %}

--- a/roles/elastic-stack/ansible-elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/elastic-stack/ansible-elasticsearch/templates/elasticsearch.yml.j2
@@ -16,7 +16,7 @@ cluster.initial_master_nodes:
   - {{ item }}
 {% endfor %}
 {% else %}
-node.master: {{ elasticsearch_master_candidate }}
+node.master: "{{ elasticsearch_master_candidate }}"
 discovery.seed_hosts:
 {% for item in elasticsearch_discovery_nodes %}
   - {{ item }}
@@ -26,5 +26,10 @@ discovery.seed_hosts:
 # XPACK Security
 
 {% if elasticsearch_xpack_security %}
-xpack.security.enabled: true
+#xpack.security.enabled: false
+#xpack.security.transport.ssl.enabled: true
+#xpack.security.transport.ssl.verification_mode: certificate 
+#xpack.security.transport.ssl.key: /home/es_certificates/{{ elasticsearch_node_name }}.key 
+#xpack.security.transport.ssl.certificate: /home/es_certificates/{{ elasticsearch_node_name }}.crt 
+#xpack.security.transport.ssl.certificate_authorities: [ "/home/es/config/ca.crt" ] 
 {% endif %}

--- a/roles/elastic-stack/ansible-elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/elastic-stack/ansible-elasticsearch/templates/elasticsearch.yml.j2
@@ -15,10 +15,10 @@ cluster.initial_master_nodes:
 {% for item in elasticsearch_cluster_nodes %}
   - {{ item }}
 {% endfor %}
-{% elif elasticsearch_master_candidate %}
-node.master: true
+{% else %}
+node.master: {{ elasticsearch_master_candidate }}
 discovery.seed_hosts:
-{% for item in elasticsearch_cluster_nodes %}
+{% for item in elasticsearch_discovery_nodes %}
   - {{ item }}
 {% endfor %}
 {% endif %}

--- a/roles/elastic-stack/ansible-elasticsearch/templates/instances.yml.j2
+++ b/roles/elastic-stack/ansible-elasticsearch/templates/instances.yml.j2
@@ -1,0 +1,11 @@
+
+# {{ ansible_managed }}
+# TO-DO
+
+{% if node_generate_certs %}
+instances:
+{% for item in elasticsearch_cluster_nodes %}
+    ip: {{ item.ip }}
+    - "{{ item.name }}"
+{% endfor %}
+{% endif %}

--- a/roles/elastic-stack/ansible-elasticsearch/templates/instances.yml.j2
+++ b/roles/elastic-stack/ansible-elasticsearch/templates/instances.yml.j2
@@ -4,8 +4,11 @@
 
 {% if node_generate_certs %}
 instances:
-{% for item in elasticsearch_cluster_nodes %}
-    ip: {{ item.ip }}
-    - "{{ item.name }}"
+
+{% for node in instances %}
+- name: "{{node.value.name}}"
+    ip:
+        - "{{ node.value.ip }}"
 {% endfor %}
+
 {% endif %}

--- a/roles/elastic-stack/ansible-elasticsearch/templates/instances.yml.j2
+++ b/roles/elastic-stack/ansible-elasticsearch/templates/instances.yml.j2
@@ -2,7 +2,7 @@
 # {{ ansible_managed }}
 # TO-DO
 
-{% if node_generate_certs %}
+{% if node_certs_generator %}
 instances:
 {% for node in instances %}
 - name: "{{ node.name }}"

--- a/roles/elastic-stack/ansible-elasticsearch/templates/instances.yml.j2
+++ b/roles/elastic-stack/ansible-elasticsearch/templates/instances.yml.j2
@@ -4,11 +4,10 @@
 
 {% if node_generate_certs %}
 instances:
-
 {% for node in instances %}
-- name: "{{node.value.name}}"
-    ip:
-        - "{{ node.value.ip }}"
+- name: "{{ node.name }}"
+  ip:
+   - "{{ node.ip }}"
 {% endfor %}
 
 {% endif %}

--- a/roles/elastic-stack/ansible-kibana/defaults/main.yml
+++ b/roles/elastic-stack/ansible-kibana/defaults/main.yml
@@ -1,7 +1,16 @@
 ---
+kibana_node_name: node-1
+
 elasticsearch_http_port: "9200"
 elasticsearch_network_host: "127.0.0.1"
 kibana_server_host: "0.0.0.0"
 kibana_server_port: "5601"
 elastic_stack_version: 7.1.1
 wazuh_version: 3.9.2
+
+# Xpack Security
+kibana_xpack_security: false
+
+kibana_user: kibana
+kibana_password: elastic_pass
+node_certs_destination: /etc/kibana/certs

--- a/roles/elastic-stack/ansible-kibana/defaults/main.yml
+++ b/roles/elastic-stack/ansible-kibana/defaults/main.yml
@@ -13,4 +13,13 @@ kibana_xpack_security: false
 
 kibana_user: kibana
 kibana_password: elastic_pass
+
+node_certs_generator: false
+node_certs_generator_ip: 172.16.0.161
+node_certs_source: /usr/share/elasticsearch
 node_certs_destination: /etc/kibana/certs
+
+# Rsync
+rsync_path: /usr/bin/rsync
+rsync_user: vagrant
+rsync_extra_parameters: -avg -e 'ssh -o StrictHostKeyChecking=no' --rsync-path='sudo rsync'

--- a/roles/elastic-stack/ansible-kibana/defaults/main.yml
+++ b/roles/elastic-stack/ansible-kibana/defaults/main.yml
@@ -11,8 +11,8 @@ wazuh_version: 3.9.2
 # Xpack Security
 kibana_xpack_security: false
 
-kibana_user: kibana
-kibana_password: elastic_pass
+elasticsearch_xpack_security_user: elastic
+elasticsearch_xpack_security_password: elastic_pass
 
 node_certs_generator: false
 node_certs_generator_ip: 172.16.0.161

--- a/roles/elastic-stack/ansible-kibana/tasks/main.yml
+++ b/roles/elastic-stack/ansible-kibana/tasks/main.yml
@@ -63,12 +63,14 @@
   shell: "chown -R kibana: {{node_certs_destination}}/"
   when:
     - check_certs_permissions is defined
+    - kibana_xpack_security
   tags: xpack-security
 
 - name: Ensuring certificates folder owner
   shell: "chmod -R 770 {{node_certs_destination}}/"
   when:
     - check_certs_permissions is defined
+    - kibana_xpack_security
   tags: xpack-security
 
 - name: Kibana configuration

--- a/roles/elastic-stack/ansible-kibana/tasks/main.yml
+++ b/roles/elastic-stack/ansible-kibana/tasks/main.yml
@@ -5,11 +5,6 @@
 - import_tasks: Debian.yml
   when: ansible_os_family == 'Debian'
 
-- name: Make sure Elasticsearch is running before proceeding.
-  wait_for: host={{ elasticsearch_network_host }} port={{ elasticsearch_http_port }} delay=3 timeout=300
-  tags: configure
-  ignore_errors: true
-
 - name: Reload systemd
   systemd: daemon_reload=true
   ignore_errors: true
@@ -17,6 +12,64 @@
     - not (ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA")
     - not (ansible_distribution == "Ubuntu" and ansible_distribution_version is version('15.04', '<'))
     - not (ansible_distribution == "Debian" and ansible_distribution_version is version('8', '<'))
+
+- name: Check if certificate exists locally
+  stat:
+    path: "{{node_certs_destination}}/{{ kibana_node_name }}.crt"
+  register: certificate_file_exists
+  when:
+    - kibana_xpack_security 
+
+- name: Copy key & certificate files in generator node (locally)
+  synchronize:
+    src: "{{node_certs_source}}/{{kibana_node_name}}/"
+    dest: "{{node_certs_destination}}/"
+  delegate_to: "{{ node_certs_generator_ip }}"
+  when: 
+    - node_certs_generator
+    - kibana_xpack_security
+    - not certificate_file_exists.stat.exists
+  tags: xpack-security
+
+- name: Copy ca certificate file in generator node (locally)
+  synchronize:
+    src: "{{node_certs_source}}/ca/"
+    dest: "{{node_certs_destination}}/"
+  delegate_to: "{{ node_certs_generator_ip }}"
+  when: 
+    - node_certs_generator
+    - kibana_xpack_security
+    - not certificate_file_exists.stat.exists
+  tags: xpack-security
+  
+- name: Importing key & certificate files from generator node
+  shell: "{{rsync_path}} {{rsync_extra_parameters}} {{rsync_user}}@{{node_certs_generator_ip}}:{{node_certs_source}}/{{kibana_node_name}}/ {{node_certs_destination}}/"
+  when:
+    - not node_certs_generator
+    - kibana_xpack_security
+    - not certificate_file_exists.stat.exists
+  tags: xpack-security
+
+- name: Importing ca certificate file from generator node 
+  shell: "{{rsync_path}} {{rsync_extra_parameters}} {{rsync_user}}@{{node_certs_generator_ip}}:{{node_certs_source}}/ca/ {{node_certs_destination}}/"
+  when:
+    - not node_certs_generator
+    - kibana_xpack_security
+    - not certificate_file_exists.stat.exists
+  register: check_certs_permissions
+  tags: xpack-security
+
+- name: Ensuring certificates folder owner
+  shell: "chown -R kibana: {{node_certs_destination}}/"
+  when:
+    - check_certs_permissions is defined
+  tags: xpack-security
+
+- name: Ensuring certificates folder owner
+  shell: "chmod -R 770 {{node_certs_destination}}/"
+  when:
+    - check_certs_permissions is defined
+  tags: xpack-security
 
 - name: Kibana configuration
   template:

--- a/roles/elastic-stack/ansible-kibana/templates/kibana.yml.j2
+++ b/roles/elastic-stack/ansible-kibana/templates/kibana.yml.j2
@@ -19,7 +19,11 @@ server.host: {{ kibana_server_host }}
 #server.name: "your-hostname"
 
 # The URL of the Elasticsearch instance to use for all your queries.
+{% if kibana_xpack_security %}
+elasticsearch.hosts: "https://{{ elasticsearch_network_host }}:{{ elasticsearch_http_port }}"
+{% else %}
 elasticsearch.hosts: "http://{{ elasticsearch_network_host }}:{{ elasticsearch_http_port }}"
+{% endif %}
 
 # When this setting's value is true Kibana uses the hostname specified in the server.host
 # setting. When the value of this setting is false, Kibana uses the hostname of the host
@@ -98,3 +102,13 @@ elasticsearch.hosts: "http://{{ elasticsearch_network_host }}:{{ elasticsearch_h
 # Set the interval in milliseconds to sample system and process performance
 # metrics. Minimum is 100ms. Defaults to 5000.
 #ops.interval: 5000
+
+# Xpack Security
+{% if kibana_xpack_security %}
+elasticsearch.username: "{{ kibana_user }}"
+elasticsearch.password: "{{ kibana_password }}"
+server.ssl.enabled: true
+server.ssl.key: "{{node_certs_destination}}/{{ kibana_node_name }}.key"
+server.ssl.certificate: "{{node_certs_destination}}/{{ kibana_node_name }}.crt" 
+elasticsearch.ssl.certificateAuthorities: ["{{ node_certs_destination }}/ca.crt"]
+{% endif %}

--- a/roles/elastic-stack/ansible-kibana/templates/kibana.yml.j2
+++ b/roles/elastic-stack/ansible-kibana/templates/kibana.yml.j2
@@ -105,8 +105,8 @@ elasticsearch.hosts: "http://{{ elasticsearch_network_host }}:{{ elasticsearch_h
 
 # Xpack Security
 {% if kibana_xpack_security %}
-elasticsearch.username: "{{ kibana_user }}"
-elasticsearch.password: "{{ kibana_password }}"
+elasticsearch.username: "{{ elasticsearch_xpack_security_user }}"
+elasticsearch.password: "{{ elasticsearch_xpack_security_password }}"
 server.ssl.enabled: true
 server.ssl.key: "{{node_certs_destination}}/{{ kibana_node_name }}.key"
 server.ssl.certificate: "{{node_certs_destination}}/{{ kibana_node_name }}.crt" 

--- a/roles/wazuh/ansible-filebeat/defaults/main.yml
+++ b/roles/wazuh/ansible-filebeat/defaults/main.yml
@@ -31,4 +31,13 @@ filebeat_xpack_security: false
 
 elasticsearch_user: elastic
 elasticsearch_password: elastic_pass
-node_certs_destination: /etc/elasticsearch/certs
+
+node_certs_generator : false
+node_certs_generator_ip: 172.16.0.161
+node_certs_source: /usr/share/elasticsearch
+node_certs_destination: /etc/filebeat/certs
+
+# Rsync
+rsync_path: /usr/bin/rsync
+rsync_user: vagrant
+rsync_extra_parameters: -avg -e 'ssh -o StrictHostKeyChecking=no' --rsync-path='sudo rsync'

--- a/roles/wazuh/ansible-filebeat/defaults/main.yml
+++ b/roles/wazuh/ansible-filebeat/defaults/main.yml
@@ -29,8 +29,8 @@ filebeat_ssl_insecure: "false"
 # Xpack Security
 filebeat_xpack_security: false
 
-elasticsearch_user: elastic
-elasticsearch_password: elastic_pass
+elasticsearch_xpack_security_user: elastic
+elasticsearch_xpack_security_password: elastic_pass
 
 node_certs_generator : false
 node_certs_generator_ip: 172.16.0.161

--- a/roles/wazuh/ansible-filebeat/defaults/main.yml
+++ b/roles/wazuh/ansible-filebeat/defaults/main.yml
@@ -10,6 +10,8 @@ filebeat_prospectors:
     json.keys_under_root: true
     json.overwrite_keys: true
 
+filebeat_node_name: node-1
+
 filebeat_output_elasticsearch_enabled: false
 filebeat_output_elasticsearch_hosts:
   - "localhost:9200"
@@ -23,3 +25,10 @@ filebeat_ssl_dir: /etc/pki/filebeat
 filebeat_ssl_certificate_file: ""
 filebeat_ssl_key_file: ""
 filebeat_ssl_insecure: "false"
+
+# Xpack Security
+filebeat_xpack_security: false
+
+elasticsearch_user: elastic
+elasticsearch_password: elastic_pass
+node_certs_destination: /etc/elasticsearch/certs

--- a/roles/wazuh/ansible-filebeat/tasks/main.yml
+++ b/roles/wazuh/ansible-filebeat/tasks/main.yml
@@ -10,8 +10,62 @@
   tags:
     - install
 
+- name: Check if certificate exists locally
+  stat:
+    path: "{{node_certs_destination}}/{{ filebeat_node_name }}.crt"
+  register: certificate_file_exists
+  when:
+    - filebeat_xpack_security
+
+- name: Copy key & certificate files in generator node (locally)
+  synchronize:
+    src: "{{node_certs_source}}/{{filebeat_node_name}}/"
+    dest: "{{node_certs_destination}}/"
+  delegate_to: "{{ node_certs_generator_ip }}"
+  when: 
+    - node_certs_generator
+    - filebeat_xpack_security
+    - not certificate_file_exists.stat.exists
+  tags: xpack-security
+
+- name: Copy ca certificate file in generator node (locally)
+  synchronize:
+    src: "{{node_certs_source}}/ca/"
+    dest: "{{node_certs_destination}}/"
+  delegate_to: "{{ node_certs_generator_ip }}"
+  when: 
+    - node_certs_generator
+    - filebeat_xpack_security
+    - not certificate_file_exists.stat.exists
+  register: check_certs_permissions
+  tags: xpack-security
+  
+- name: Importing key & certificate files from generator node
+  shell: "{{rsync_path}} {{rsync_extra_parameters}} {{rsync_user}}@{{node_certs_generator_ip}}:{{node_certs_source}}/{{filebeat_node_name}}/ {{node_certs_destination}}/"
+  when:
+    - not node_certs_generator
+    - filebeat_xpack_security
+    - not certificate_file_exists.stat.exists
+  tags: xpack-security
+
+- name: Importing ca certificate file from generator node 
+  shell: "{{rsync_path}} {{rsync_extra_parameters}} {{rsync_user}}@{{node_certs_generator_ip}}:{{node_certs_source}}/ca/ {{node_certs_destination}}/"
+  when:
+    - not node_certs_generator
+    - filebeat_xpack_security
+    - not certificate_file_exists.stat.exists
+  register: check_certs_permissions
+  tags: xpack-security
+
+- name: Ensuring certificates folder owner
+  shell: "chmod -R 770 {{node_certs_destination}}/"
+  when:
+    - check_certs_permissions is defined
+  tags: xpack-security
+
 - import_tasks: config.yml
   when: filebeat_create_config
+  notify: restart filebeat
 
 - name: Reload systemd
   systemd: daemon_reload=yes

--- a/roles/wazuh/ansible-filebeat/tasks/main.yml
+++ b/roles/wazuh/ansible-filebeat/tasks/main.yml
@@ -61,6 +61,7 @@
   shell: "chmod -R 770 {{node_certs_destination}}/"
   when:
     - check_certs_permissions is defined
+    - filebeat_xpack_security
   tags: xpack-security
 
 - import_tasks: config.yml

--- a/roles/wazuh/ansible-filebeat/templates/filebeat.yml.j2
+++ b/roles/wazuh/ansible-filebeat/templates/filebeat.yml.j2
@@ -53,6 +53,15 @@ output.elasticsearch:
   #pipeline: geoip
   indices:
     - index: 'wazuh-alerts-3.x-%{+yyyy.MM.dd}'
+{% if filebeat_xpack_security %}
+  username: {{ elasticsearch_user }}
+  password: {{ elasticsearch_password }}
+  protocol: https
+  ssl.certificate_authorities: 
+    - {{node_certs_destination}}/ca.crt
+  ssl.certificate: "{{node_certs_destination}}/{{ filebeat_node_name }}.crt" 
+  ssl.key: "{{node_certs_destination}}/{{ filebeat_node_name }}.key"
+{% endif %}
 
 # Optional. Send events to Logstash instead of Elasticsearch
 #output.logstash.hosts: ["YOUR_LOGSTASH_SERVER_IP:5000"]

--- a/roles/wazuh/ansible-filebeat/templates/filebeat.yml.j2
+++ b/roles/wazuh/ansible-filebeat/templates/filebeat.yml.j2
@@ -54,8 +54,8 @@ output.elasticsearch:
   indices:
     - index: 'wazuh-alerts-3.x-%{+yyyy.MM.dd}'
 {% if filebeat_xpack_security %}
-  username: {{ elasticsearch_user }}
-  password: {{ elasticsearch_password }}
+  username: {{ elasticsearch_xpack_security_user }}
+  password: {{ elasticsearch_xpack_security_password }}
   protocol: https
   ssl.certificate_authorities: 
     - {{node_certs_destination}}/ca.crt


### PR DESCRIPTION
Hello team,

This PR adds the ability to set up `xpack security` . All the new features can be explained with this playbook sample of a deployment of three nodes of Elasticsearch:

```
 - hosts: 172.16.0.162
   roles:
     - role: /etc/ansible/roles/wazuh-ansible/roles/wazuh/ansible-wazuh-manager

     - role: /etc/ansible/roles/wazuh-ansible/roles/wazuh/ansible-filebeat
       filebeat_output_elasticsearch_hosts: 172.16.0.161:9200
       filebeat_xpack_security: true
       filebeat_node_name: node-2
       node_certs_generator: false

     - role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-elasticsearch
       elasticsearch_network_host: 172.16.0.162
       node_name: node-2
       elasticsearch_bootstrap_node: false
       elasticsearch_master_candidate: true
       elasticsearch_discovery_nodes: 
         - 172.16.0.161
         - 172.16.0.162
       elasticsearch_xpack_security: true
       node_certs_generator: false


 - hosts: 172.16.0.163
   roles:
     - role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-kibana
       kibana_xpack_security: true
       kibana_user: elastic
       kibana_password: elastic_pass
       kibana_node_name: node-3
       elasticsearch_network_host: 172.16.0.161
       node_certs_generator: false
```

As it can be sawn above, the new added variables for supporting this feature are the following:
- `filebeat_xpack_security` *True/False* : Determines if the xpack security features are going to be configured on Filebeat.
- `kibana_xpack_security`: *True/False* : Determines if the xpack security features are going to be configured on Kibana.
- `filebeat_node_name` The name of the Elasticsearch node.
- `node_certs_generator`.  *True/False*. As the certificates should be generated only by one node of the cluster, it's indicated by this boolean variable. Set as `true` to the chosen node.
- `elasticsearch_xpack_security_password`: The `elastic` password to be set.

Cheers