### PR TITLE
Fixes for Elasticsearch issue #184 -  Testing Elasticsearch functionality when network.host is not localhost.

### DIFF
--- a/molecule/elasticsearch/molecule.yml
+++ b/molecule/elasticsearch/molecule.yml
@@ -23,12 +23,12 @@ platforms:
     command: /sbin/init
     ulimits:
       - nofile:262144:262144
-#  - name: trusty
-#    image: ubuntu:trusty
-#    privileged: true
-#    memory_reservation: 2048m
-#    ulimits:
-#      - nofile:262144:262144
+        #- name: trusty
+        #image: ubuntu:trusty
+        #privileged: true
+        #memory_reservation: 2048m
+        #ulimits:
+        #- nofile:262144:262144
   - name: centos6
     image: centos:6
     privileged: true

--- a/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
@@ -3,7 +3,7 @@ elasticsearch_cluster_name: wazuh
 elasticsearch_node_name: node-1
 elasticsearch_http_port: 9200
 elasticsearch_network_host: 0.0.0.0
-elasticsearch_check_connection: 127.0.0.1
+elasticsearch_host: 127.0.0.1
 elasticsearch_jvm_xms: null
 elastic_stack_version: 7.2.0
 single_node: false

--- a/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
@@ -2,7 +2,7 @@
 elasticsearch_cluster_name: wazuh
 elasticsearch_node_name: node-1
 elasticsearch_http_port: 9200
-elasticsearch_network_host: 0.0.0.0
+elasticsearch_network_host: 127.0.0.1
 elasticsearch_host: 127.0.0.1
 elasticsearch_jvm_xms: null
 elastic_stack_version: 7.2.0

--- a/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
@@ -2,7 +2,8 @@
 elasticsearch_cluster_name: wazuh
 elasticsearch_node_name: node-1
 elasticsearch_http_port: 9200
-elasticsearch_network_host: 127.0.0.1
+elasticsearch_network_host: 0.0.0.0
+elasticsearch_check_connection: 127.0.0.1
 elasticsearch_jvm_xms: null
 elastic_stack_version: 7.2.0
 single_node: false

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/Debian.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/Debian.yml
@@ -26,7 +26,7 @@
 
 - name: Install Oracle Java 8
   become: true
-  apt: name=openjdk-8-jdk state=latest
+  apt: name=openjdk-8-jdk
 
   when:
     - ansible_distribution == "Ubuntu"

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
@@ -242,7 +242,7 @@
     state: started
 
 - name: Make sure Elasticsearch is running before proceeding
-  wait_for: host={{ elasticsearch_network_host }} port={{ elasticsearch_http_port }} delay=3 timeout=300
+  wait_for: host={{ elasticsearch_check_connection }} port={{ elasticsearch_http_port }} delay=3 timeout=400
   tags:
     - configure
     - init

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
@@ -65,7 +65,7 @@
 
 - name: Check if certificate exists locally
   stat:
-    path: "{{node_certs_destination}}/{{ elasticsearch_node_name }}.crt"
+    path: "{{ node_certs_destination }}/{{ elasticsearch_node_name }}.crt"
   register: certificate_file_exists
   when:
     - elasticsearch_xpack_security
@@ -73,7 +73,7 @@
 - name: Write the instances.yml file in the selected node (force = no)
   template:
     src: instances.yml.j2
-    dest: "{{node_certs_source}}/instances.yml"
+    dest: "{{ node_certs_source }}/instances.yml"
     force: no
   register: instances_file_exists
   tags:
@@ -86,23 +86,25 @@
 
 - name: Update instances.yml status after generation
   stat:
-    path: "{{node_certs_source}}/instances.yml"
+    path: "{{ node_certs_source }}/instances.yml"
   register: instances_file_exists
-  when: 
+  when:
     - node_certs_generator
     - elasticsearch_xpack_security
 
 - name: Check if the certificates ZIP file exists
   stat:
-    path: "{{node_certs_source}}/certs.zip"
+    path: "{{ node_certs_source }}/certs.zip"
   register: xpack_certs_zip
-  when: 
+  when:
     - node_certs_generator
     - elasticsearch_xpack_security
 
 - name: Generating certificates for Elasticsearch security
-  shell: "/usr/share/elasticsearch/bin/elasticsearch-certutil cert ca --pem --in {{node_certs_source}}/instances.yml --out {{node_certs_source}}/certs.zip"
-  when: 
+  command: >-
+     "/usr/share/elasticsearch/bin/elasticsearch-certutil cert ca --pem --in
+     {{ node_certs_source }}/instances.yml --out {{ node_certs_source }}/certs.zip"
+  when:
     - node_certs_generator
     - elasticsearch_xpack_security
     - not xpack_certs_zip.stat.exists
@@ -112,10 +114,10 @@
 
 - name: Unzip generated certs.zip
   unarchive:
-    src: "{{node_certs_source}}/certs.zip"
-    dest: "{{node_certs_source}}/"
+    src: "{{ node_certs_source }}/certs.zip"
+    dest: "{{ node_certs_source }}/"
     remote_src: yes
-  when: 
+  when:
     - node_certs_generator
     - elasticsearch_xpack_security
     - certs_file_generated is defined
@@ -124,35 +126,39 @@
 
 - name: Copy key & certificate files in generator node (locally)
   synchronize:
-    src: "{{node_certs_source}}/{{elasticsearch_node_name}}/"
-    dest: "{{node_certs_destination}}/"
+    src: "{{ node_certs_source }}/{{ elasticsearch_node_name }}/"
+    dest: "{{ node_certs_destination }}/"
   delegate_to: "{{ node_certs_generator_ip }}"
-  when: 
+  when:
     - node_certs_generator
     - elasticsearch_xpack_security
   tags: xpack-security
 
 - name: Copy ca certificate file in generator node (locally)
   synchronize:
-    src: "{{node_certs_source}}/ca/"
-    dest: "{{node_certs_destination}}/"
+    src: "{{ node_certs_source }}/ca/"
+    dest: "{{ node_certs_destination }}/"
   delegate_to: "{{ node_certs_generator_ip }}"
   register: check_certs_permissions
-  when: 
+  when:
     - node_certs_generator
     - elasticsearch_xpack_security
   tags: xpack-security
 
 - name: Importing key & certificate files from generator node
-  shell: "{{rsync_path}} {{rsync_extra_parameters}} {{rsync_user}}@{{node_certs_generator_ip}}:{{node_certs_source}}/{{elasticsearch_node_name}}/ {{node_certs_destination}}/"
+  command: >-
+    {{ rsync_path }} {{ rsync_extra_parameters }} {{ rsync_user }}@{{ node_certs_generator_ip }}:
+    {{ node_certs_source }}/{{ elasticsearch_node_name }}/ {{ node_certs_destination }}/
   when:
     - not node_certs_generator
     - elasticsearch_xpack_security
     - not certificate_file_exists.stat.exists
   tags: xpack-security
 
-- name: Importing ca certificate file from generator node 
-  shell: "{{rsync_path}} {{rsync_extra_parameters}} {{rsync_user}}@{{node_certs_generator_ip}}:{{node_certs_source}}/ca/ {{node_certs_destination}}/"
+- name: Importing ca certificate file from generator node
+  command: >-
+    {{ rsync_path }} {{ rsync_extra_parameters }} {{ rsync_user }}@{{ node_certs_generator_ip }}:
+    {{ node_certs_source }}/ca/ {{ node_certs_destination }}/
   when:
     - not node_certs_generator
     - elasticsearch_xpack_security
@@ -161,23 +167,32 @@
   tags: xpack-security
 
 - name: Ensuring certificates folder owner
-  shell: "chown -R elasticsearch: {{node_certs_destination}}/"
+  file:
+    path: "{{ node_certs_destination }}/"
+    state: directory
+    recurse: yes
+    owner: elasticsearch
+    group: elasticsearch
   when:
     - check_certs_permissions is defined
     - elasticsearch_xpack_security
   tags: xpack-security
 
 - name: Ensuring certificates folder owner
-  shell: "chmod -R 770 {{node_certs_destination}}/"
+  file:
+    path: "{{ node_certs_destination }}/"
+    mode: '0770'
+    recurse: yes
   when:
     - check_certs_permissions is defined
     - elasticsearch_xpack_security
   tags: xpack-security
-  
 
 - name: Remove generated certs file
-  shell: /bin/rm -f {{node_certs_source}}/certs.zip*
-  when: 
+  file:
+    state: absent
+    path: "{{ node_certs_source }}/certs.zip*"
+  when:
     - node_certs_generator
     - elasticsearch_xpack_security
   tags: xpack-security
@@ -193,10 +208,12 @@
   tags: configure
 
 - name: Set elasticsearch bootstrap password
-  shell: "echo '{{elasticsearch_xpack_security_password}}' | {{node_certs_source}}/bin/elasticsearch-keystore add -xf 'bootstrap.password'"
+  shell: |
+     set -o pipefail
+     "echo '{{ elasticsearch_xpack_security_password }}' | {{ node_certs_source }}/bin/elasticsearch-keystore add -xf 'bootstrap.password'"
   when:
     - elasticsearch_xpack_security
-  
+
 - name: Trusty | set MAX_LOCKED_MEMORY=unlimited in Elasticsearch in /etc/security/limits.conf
   lineinfile:
     path: /etc/security/limits.conf
@@ -242,7 +259,7 @@
     state: started
 
 - name: Make sure Elasticsearch is running before proceeding
-  wait_for: host={{ elasticsearch_check_connection }} port={{ elasticsearch_http_port }} delay=3 timeout=400
+  wait_for: host={{ elasticsearch_host }} port={{ elasticsearch_http_port }} delay=3 timeout=400
   tags:
     - configure
     - init
@@ -252,7 +269,7 @@
     url: "http://{{ elasticsearch_network_host }}:{{ elasticsearch_http_port }}/_template/wazuh"
     method: GET
     status_code: 200, 404
-  when: 
+  when:
     - elasticsearch_bootstrap_node or single_node
     - not elasticsearch_xpack_security
   poll: 30
@@ -267,7 +284,7 @@
     status_code: 200
     body_format: json
     body: "{{ lookup('template','wazuh-elastic7-template-alerts.json.j2') }}"
-  when: 
+  when:
     - wazuh_alerts_template_exits.status is defined
     - wazuh_alerts_template_exits.status != 200
     - not elasticsearch_xpack_security


### PR DESCRIPTION
Hi team!

In this PR, we resolved the error reported in the issue https://github.com/wazuh/wazuh-ansible/issues/184.

**As @kravietz reported**

> The test in roles/wazuh-ansible/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml line 87 only works if the elasticsearch_network_host is set to localhost but ElasticSearch uses this parameter to configure its bind address, so in many real-world instances it will be set to 0.0.0.0 or ::, in which case the test fails.

> - name: Make sure Elasticsearch is running before proceeding
  wait_for: host={{ elasticsearch_network_host }} port={{ elasticsearch_http_port }} delay=3 timeout=300
  tags:
    - configure
    - init  

To solve such issue it's needed to have 2 different variables, 1 for network.host and one for representing Elasticsearch host. In this case, we now have:

- `elasticsearch_network_host: 0.0.0.0` : Indicates the hosts which Elasticsearch API will accepts requests from.

>**network.host**
By default, Elasticsearch binds to loopback addresses only — e.g. 127.0.0.1 and [::1]. This is sufficient to run a single development node on a serve
- `elasticsearch_host: 127.0.0.1` : By now, it's used to check if Elasticsearch is running by checking if 127.0.0.1:9200 is available.

https://github.com/wazuh/wazuh-ansible/blob/fcb584ab2016a9d0e867b6748e1b13877067e3c8/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml#L261-L265

https://github.com/wazuh/wazuh-ansible/blob/fcb584ab2016a9d0e867b6748e1b13877067e3c8/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml#L4-L6

In this case, we set `elasticsearch_host` to `127.0.0.1` instead of  `0.0.0.0`  because `0.0.0.0` will not be considered as a valid IP, but will refer to the big-world domain. 

We also fixed some Ansible-Linting errors by refactoring Ansible tasks in the role of [`Elasticsearch`](https://github.com/wazuh/wazuh-ansible/tree/fcb584ab2016a9d0e867b6748e1b13877067e3c8/roles/elastic-stack/ansible-elasticsearch).

Kind regards,

Rshad