### PR TITLE
Handle dynamic feeds for vulnerability-detector

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -161,15 +161,16 @@ wazuh_manager_config:
     interval: '5m'
     ignore_time: '6h'
     run_on_start: 'yes'
-    ubuntu:
-      disable: 'yes'
-      update_interval: '1h'
-    redhat:
-      disable: 'yes'
-      update_interval: '1h'
-    debian:
-      disable: 'yes'
-      update_interval: '1h'
+    feeds:
+      ubuntu-18:
+        disable: 'yes'
+        update_interval: '1h'
+      redhat:
+        disable: 'yes'
+        update_interval: '1h'
+      debian-9:
+        disable: 'yes'
+        update_interval: '1h'
   vuls:
     disable: 'yes'
     interval: '1d'

--- a/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
@@ -227,18 +227,12 @@
     <interval>{{ wazuh_manager_config.vul_detector.interval }}</interval>
     <ignore_time>{{ wazuh_manager_config.vul_detector.ignore_time }}</ignore_time>
     <run_on_start>{{ wazuh_manager_config.vul_detector.run_on_start }}</run_on_start>
-    <feed name="ubuntu-18">
-      <disabled>{{ wazuh_manager_config.vul_detector.ubuntu.disable }}</disabled>
-      <update_interval>{{ wazuh_manager_config.vul_detector.ubuntu.update_interval }}</update_interval>
+    {%- for feed, config in wazuh_manager_config.vul_detector.feeds | dictsort %}
+    <feed name="{{ feed }}">
+      <disabled>{{ config.disable }}</disabled>
+      <update_interval>{{ config.update_interval }}</update_interval>
     </feed>
-    <feed name="redhat">
-      <disabled>{{ wazuh_manager_config.vul_detector.redhat.disable }}</disabled>
-      <update_interval>{{ wazuh_manager_config.vul_detector.redhat.update_interval }}</update_interval>
-    </feed>
-    <feed name="debian-9">
-      <disabled>{{ wazuh_manager_config.vul_detector.debian.disable }}</disabled>
-      <update_interval>{{ wazuh_manager_config.vul_detector.debian.update_interval }}</update_interval>
-    </feed>
+    {%- endfor %}
   </wodle>
 
   <!-- File integrity monitoring -->


### PR DESCRIPTION
This PR allows dynamic feeds to be presented for vulnerability-detector. The previous behavior only allowed turning off/on redhat, ubuntu-18, and debian-9. This method still keeps the same defaults, but allows users to easily pass in other feeds such as ubuntu-16 when deploying managers.