### PR TITLE
Support both IP and DNS when creating elastic cluster

### DIFF
--- a/roles/elastic-stack/ansible-elasticsearch/templates/instances.yml.j2
+++ b/roles/elastic-stack/ansible-elasticsearch/templates/instances.yml.j2
@@ -4,10 +4,14 @@
 
 {% if node_certs_generator %}
 instances:
-{% for (key,value) in instances.iteritems() %}
-- name: "{{ value.name }}" 
+{% for (key,value) in instances.items() %}
+- name: "{{ value.name }}"
+{% if value.ip %}
   ip:
    - "{{ value.ip }}"
+{% elif value.dns %}
+  dns:
+   - "{{ value.dns }}"
+{% endif %}
 {% endfor %}
-
 {% endif %}


### PR DESCRIPTION
This change allows the user to specify ip or dns (or a mixture of both) when defining nodes on the elastic cluster.

```
  vars:
    instances:
      node-1:
        name: node-1
        ip: "10.1.1.20"
      node-2:
        name: node-2
        dns: "node2.example.org"
```
