### PR TITLE
Add config tag to the enable service task

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
@@ -185,6 +185,7 @@
     name: wazuh-agent
     enabled: true
     state: started
+  tags: config
 
 - import_tasks: "RMRedHat.yml"
   when: ansible_os_family == "RedHat"


### PR DESCRIPTION
In order to accomplish #149 there needs to be a way to skip all config tasks, there's already a `config` tag for this used in the whole role except in the enable service task.

This PR adds the `config` tag to the enable service task.