### PR TITLE
Add filebeat role to wazuh-elastic_stack-single.yml playbook

### DIFF
--- a/playbooks/wazuh-elastic_stack-single.yml
+++ b/playbooks/wazuh-elastic_stack-single.yml
@@ -2,5 +2,7 @@
 - hosts: <your server host>
   roles:
       - {role: ../roles/wazuh/ansible-wazuh-manager}
+      - role: ../roles/wazuh/ansible-filebeat
+        filebeat_output_elasticsearch_hosts: localhost:9200
       - {role: ../roles/elastic-stack/ansible-elasticsearch, elasticsearch_network_host: '0.0.0.0', single_node: true}
       - { role: ../roles/elastic-stack/ansible-kibana, elasticsearch_network_host: 'localhost' }


### PR DESCRIPTION
Hello team,
this PR adds the missing filebeat role in `wazuh-elastic_stack-single.yml`.

Regards,
Javier.