### PR TITLE
Add support for environments with low disk space

### DIFF
--- a/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
@@ -14,6 +14,7 @@ elasticsearch_cluster_nodes:
 elasticsearch_discovery_nodes:
   - 127.0.0.1
 
+elasticsearch_lower_disk_requirements: false
 # X-Pack Security 
 elasticsearch_xpack_security: false
 elasticsearch_xpack_security_user: elastic

--- a/roles/elastic-stack/ansible-elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/elastic-stack/ansible-elasticsearch/templates/elasticsearch.yml.j2
@@ -27,6 +27,13 @@ discovery.seed_hosts:
 {% endfor %}
 {% endif %}
 
+{% if elasticsearch_lower_disk_requirements %}
+cluster.routing.allocation.disk.threshold_enabled: true
+cluster.routing.allocation.disk.watermark.flood_stage: 200mb
+cluster.routing.allocation.disk.watermark.low: 500mb
+cluster.routing.allocation.disk.watermark.high: 300mb
+{% endif %}
+
 # XPACK Security
 
 {% if elasticsearch_xpack_security %}


### PR DESCRIPTION
This adds and option to bypass ES default disk-based shard allocation.

Fixes #280 