### PR TITLE
Fix for Wazuh-API User skipped on debian

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -322,8 +322,7 @@
   notify: restart wazuh-api
   when:
     - wazuh_api_user is defined
-    - not (ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat' or ansible_distribution == 'Amazon')
-    - ansible_distribution_major_version|int < 6
+    - not (ansible_facts['os_family']|lower == 'redhat' and ansible_distribution_major_version|int < 6)
   tags:
     - config
 
@@ -379,8 +378,7 @@
   environment:
     LD_LIBRARY_PATH: "$LD_LIBRARY_PATH:/var/ossec/framework/lib"
   when:
-    - not (ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat' or ansible_distribution == 'Amazon')
-    - ansible_distribution_major_version|int < 6
+    - not (ansible_facts['os_family']|lower == 'redhat' and ansible_distribution_major_version|int < 6)
 
 - name: Ensure Wazuh Manager is started and enabled (EL5)
   service:

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -322,7 +322,6 @@
   notify: restart wazuh-api
   when:
     - wazuh_api_user is defined
-    - not (ansible_facts['os_family']|lower == 'redhat' and ansible_distribution_major_version|int < 6)
   tags:
     - config
 


### PR DESCRIPTION
This should fix that Wazuh-API User task is being skipped on debian > 6