### PR TITLE
Fix skipped occurrences in Wazuh Redhat repo tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## [v3.xx.x_x.x.x]
 
-## Changed
+### Changed
 
 - Make Wazuh repositories installation flexible [@jm404](https://github.com/jm404) [#288](https://github.com/wazuh/wazuh-ansible/pull/288)
+
+### Fixed
+
 - Fix Wazuh repository and installation conditionals  [@jm404](https://github.com/jm404) [#299](https://github.com/wazuh/wazuh-ansible/pull/299)
 
 ## [v3.10.2_7.3.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## Changed
 
 - Make Wazuh repositories installation flexible [@jm404](https://github.com/jm404) [#288](https://github.com/wazuh/wazuh-ansible/pull/288)
+- Fix Wazuh repository and installation conditionals  [@jm404](https://github.com/jm404) [#299](https://github.com/wazuh/wazuh-ansible/pull/299)
 
 ## [v3.10.2_7.3.2]
 

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
@@ -10,7 +10,7 @@
   async: 90
   poll: 30
   when:
-    - ansible_distribution in ['CentOS','RedHat']
+    - {{ ansible_os_family|lower == "redhat" }}
   tags:
     - init
 
@@ -20,7 +20,7 @@
     state: present
     cache_valid_time: 3600
   when:
-    - not (ansible_distribution in ['CentOS','RedHat'])
+    - {{ ansible_os_family|lower != "redhat" }}
   tags:
     - init
 

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
@@ -10,7 +10,7 @@
   async: 90
   poll: 30
   when:
-    - {{ ansible_os_family|lower == "redhat" }}
+    - ansible_os_family|lower == "redhat"
   tags:
     - init
 
@@ -20,7 +20,7 @@
     state: present
     cache_valid_time: 3600
   when:
-    - {{ ansible_os_family|lower != "redhat" }}
+    - ansible_os_family|lower != "redhat"
   tags:
     - init
 

--- a/roles/wazuh/ansible-wazuh-agent/tasks/RedHat.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/RedHat.yml
@@ -8,7 +8,7 @@
     gpgcheck: true
   changed_when: false
   when:
-    - (ansible_facts['os_family']|lower == 'redhat')
+    - (ansible_facts['os_family']|lower == 'redhat') and (ansible_distribution|lower != 'amazon')
     - (ansible_distribution_major_version|int <= 5)
   register: repo_v5_installed
 

--- a/roles/wazuh/ansible-wazuh-agent/tasks/RedHat.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/RedHat.yml
@@ -21,7 +21,7 @@
     gpgcheck: true
   changed_when: false
   when:
-    - repo_v5_installed.skipped
+    - repo_v5_installed is skipped
     
 - name: RedHat/CentOS/Fedora | download Oracle Java RPM
   get_url:

--- a/roles/wazuh/ansible-wazuh-manager/tasks/RedHat.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/RedHat.yml
@@ -52,7 +52,7 @@
     gpgcheck: true
   changed_when: false
   when:
-    - repo_v5_manager_installed|skipped
+    - repo_v5_manager_installed is skipped
 
 - name: RedHat/CentOS/Fedora | Install openscap
   package: name={{ item }} state=present


### PR DESCRIPTION
Hi team,

This PR fixes a syntax error in the repo_v5 conditionals. Also updates the previous conditional with `|skipped`to `is skipped` as suggested by Ansible warning messages.

Best regards

Jose