### PR TITLE
Fix Wazuh-API User task conditionals. Removed exclusion of OS's

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -336,8 +336,6 @@
   notify: restart wazuh-api
   when:
     - wazuh_api_user is defined
-    - not (ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat' or ansible_distribution == 'Amazon')
-    - ansible_distribution_major_version|int < 6
   tags:
     - config
 


### PR DESCRIPTION
Hi team,

This PR fixes the task that renders the Wazuh API users. Previously it was excluding Centos, Redhat, and Amazon. This exclusion makes no sense as the file `/var/ossec/api/configuration/auth/user` is present in almost every Linux installation of Wazuh Manager.

Best regards

Jose