### PR TITLE
Optimized manager role

### DIFF
--- a/roles/wazuh/ansible-filebeat/tasks/main.yml
+++ b/roles/wazuh/ansible-filebeat/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-- import_tasks: RedHat.yml
+- include_tasks: RedHat.yml
   when: ansible_os_family == 'RedHat'
 
-- import_tasks: Debian.yml
+- include_tasks: Debian.yml
   when: ansible_os_family == 'Debian'
 
 - name: CentOS/RedHat |  Install Filebeat.
@@ -116,8 +116,8 @@
     state: started
     enabled: true
 
-- import_tasks: "RMRedHat.yml"
+- include_tasks: "RMRedHat.yml"
   when: ansible_os_family == "RedHat"
 
-- import_tasks: "RMDebian.yml"
+- include_tasks: "RMDebian.yml"
   when: ansible_os_family == "Debian"

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
@@ -1,8 +1,8 @@
 ---
-- import_tasks: "RedHat.yml"
+- include_tasks: "RedHat.yml"
   when: ansible_os_family == "RedHat"
 
-- import_tasks: "Debian.yml"
+- include_tasks: "Debian.yml"
   when: ansible_os_family == "Debian"
 
 - name: Linux CentOS/RedHat | Install wazuh-agent
@@ -191,8 +191,8 @@
     state: started
   tags: config
 
-- import_tasks: "RMRedHat.yml"
+- include_tasks: "RMRedHat.yml"
   when: ansible_os_family == "RedHat"
 
-- import_tasks: "RMDebian.yml"
+- include_tasks: "RMDebian.yml"
   when: ansible_os_family == "Debian"

--- a/roles/wazuh/ansible-wazuh-agent/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-- import_tasks: "Windows.yml"
+- include_tasks: "Windows.yml"
   when: ansible_os_family == "Windows"
 
-- import_tasks: "Linux.yml"
+- include_tasks: "Linux.yml"
   when: ansible_system == "Linux"

--- a/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
@@ -7,6 +7,7 @@
       - gnupg
     state: present
     cache_valid_time: 3600
+    install_recommends: false
   register: wazuh_manager_https_packages_installed
   until: wazuh_manager_https_packages_installed is succeeded
 
@@ -91,6 +92,7 @@
       - xsltproc
     state: present
     cache_valid_time: 3600
+    install_recommends: false
   register: wazuh_manager_openscap_installed
   until: wazuh_manager_openscap_installed is succeeded
   when: wazuh_manager_config.openscap.disable == 'no'
@@ -118,6 +120,7 @@
     name: "{{ item }}={{ wazuh_manager_version }}"
     state: present
     cache_valid_time: 3600
+    install_recommends: false
   with_items:
     - wazuh-manager
     - wazuh-api

--- a/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
@@ -117,13 +117,12 @@
 
 - name: Debian/Ubuntu | Install wazuh-manager, wazuh-api
   apt:
-    name: "{{ item }}={{ wazuh_manager_version }}"
+    name:
+      - "wazuh-manager={{ wazuh_manager_version }}"
+      - "wazuh-api={{ wazuh_manager_version }}"
     state: present
     cache_valid_time: 3600
     install_recommends: false
-  with_items:
-    - wazuh-manager
-    - wazuh-api
   register: wazuh_manager_main_packages_installed
   until: wazuh_manager_main_packages_installed is succeeded
   tags: init

--- a/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
@@ -85,16 +85,15 @@
     - init
 
 - name: Debian/Ubuntu | Install OpenScap
-  package:
-    name: "{{ item }}"
+  apt:
+    name:
+      - libopenscap8
+      - xsltproc
     state: present
     cache_valid_time: 3600
   register: wazuh_manager_openscap_installed
   until: wazuh_manager_openscap_installed is succeeded
   when: wazuh_manager_config.openscap.disable == 'no'
-  with_items:
-    - libopenscap8
-    - xsltproc
   tags:
     - init
 

--- a/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
@@ -112,3 +112,15 @@
   changed_when: false
   tags:
     - config
+
+- name: Debian/Ubuntu | Install wazuh-manager, wazuh-api
+  apt:
+    name: "{{ item }}={{ wazuh_manager_version }}"
+    state: present
+    cache_valid_time: 3600
+  with_items:
+    - wazuh-manager
+    - wazuh-api
+  register: wazuh_manager_main_packages_installed
+  until: wazuh_manager_main_packages_installed is succeeded
+  tags: init

--- a/roles/wazuh/ansible-wazuh-manager/tasks/RedHat.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/RedHat.yml
@@ -137,3 +137,40 @@
     cis_distribution_filename: cis_rhel7_linux_rcl.txt
   when:
     - ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA"
+
+- name: CentOS/RedHat/Amazon | Install wazuh-manager, wazuh-api
+  package:
+    name: "{{ item }}-{{ wazuh_manager_version }}"
+    state: "{{ wazuh_manager_package_state }}"
+  with_items:
+    - wazuh-manager
+    - wazuh-api
+  register: wazuh_manager_main_packages_installed
+  until: wazuh_manager_main_packages_installed is succeeded
+  when:
+    - ansible_os_family|lower == "redhat"
+  tags:
+    - init
+
+- name: CentOS/RedHat 6 | Enabling python2.7 and sqlite3
+  replace:
+    path: /etc/init.d/wazuh-manager
+    regexp: 'echo -n "Starting Wazuh-manager: "'
+    replace: 'echo -n "Starting Wazuh-manager (EL6): "; source /opt/rh/python27/enable; export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/var/ossec/framework/lib'
+  when:
+    - ansible_distribution in ['CentOS', 'RedHat', 'Amazon'] and ansible_distribution_major_version|int == 6
+    - wazuh_manager_config.cluster.disable != 'yes'
+
+- name: Install expect (EL5)
+  package:
+    name: "{{ item }}"
+    state: "{{ wazuh_manager_package_state }}"
+  with_items:
+    - expect
+  register: wazuh_manager_main_packages_installed
+  until: wazuh_manager_main_packages_installed is succeeded
+  when:
+    - ansible_os_family|lower == "RedHat"
+    - ansible_distribution_major_version|int < 6
+  tags:
+    - init

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -13,34 +13,6 @@
 - import_tasks: "Debian.yml"
   when: ansible_os_family == "Debian"
 
-- name: CentOS/RedHat/Amazon | Install wazuh-manager, wazuh-api
-  package:
-    name: "{{ item }}-{{ wazuh_manager_version }}"
-    state: "{{ wazuh_manager_package_state }}"
-  with_items:
-    - wazuh-manager
-    - wazuh-api
-  register: wazuh_manager_main_packages_installed
-  until: wazuh_manager_main_packages_installed is succeeded
-  when:
-    - ansible_os_family|lower == "redhat"
-  tags:
-    - init
-
-- name: Debian/Ubuntu | Install wazuh-manager, wazuh-api
-  apt:
-    name: "{{ item }}={{ wazuh_manager_version }}"
-    state: present
-    cache_valid_time: 3600
-  with_items:
-    - wazuh-manager
-    - wazuh-api
-  register: wazuh_manager_main_packages_installed
-  until: wazuh_manager_main_packages_installed is succeeded
-  when:
-  - not (ansible_os_family|lower == "redhat")
-  tags: init
-
 - name: Install expect
   package:
     name: expect
@@ -48,29 +20,6 @@
   when:
     - not (ansible_os_family|lower == "redhat" and ansible_distribution_major_version|int < 6)
   tags: init
-
-- name: CentOS/RedHat 6 | Enabling python2.7 and sqlite3
-  replace:
-    path: /etc/init.d/wazuh-manager
-    regexp: 'echo -n "Starting Wazuh-manager: "'
-    replace: 'echo -n "Starting Wazuh-manager (EL6): "; source /opt/rh/python27/enable; export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/var/ossec/framework/lib'
-  when:
-    - ansible_distribution in ['CentOS', 'RedHat', 'Amazon'] and ansible_distribution_major_version|int == 6
-    - wazuh_manager_config.cluster.disable != 'yes'
-
-- name: Install expect (EL5)
-  package:
-    name: "{{ item }}"
-    state: "{{ wazuh_manager_package_state }}"
-  with_items:
-    - expect
-  register: wazuh_manager_main_packages_installed
-  until: wazuh_manager_main_packages_installed is succeeded
-  when:
-    - ansible_os_family|lower == "RedHat"
-    - ansible_distribution_major_version|int < 6
-  tags:
-    - init
 
 - name: Generate SSL files for authd
   command: "openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:1825 -keyout sslmanager.key -out sslmanager.cert -subj /CN={{ wazuh_manager_fqdn }}/"

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -7,10 +7,10 @@
       - tar
     state: present
 
-- import_tasks: "RedHat.yml"
+- include_tasks: "RedHat.yml"
   when: (ansible_os_family == "RedHat" and ansible_distribution_major_version|int > 5) or (ansible_os_family  == "RedHat" and ansible_distribution == "Amazon")
 
-- import_tasks: "Debian.yml"
+- include_tasks: "Debian.yml"
   when: ansible_os_family == "Debian"
 
 - name: Install expect
@@ -353,8 +353,8 @@
   when:
     - ansible_distribution in ['CentOS', 'RedHat', 'Amazon'] and ansible_distribution_major_version|int < 6
 
-- import_tasks: "RMRedHat.yml"
+- include_tasks: "RMRedHat.yml"
   when: ansible_os_family == "RedHat" or ansible_os_family == "Amazon"
 
-- import_tasks: "RMDebian.yml"
+- include_tasks: "RMDebian.yml"
   when: ansible_os_family == "Debian"


### PR DESCRIPTION
This PR fixes #317, the changes were:

- OS specific tasks were moved to its own file
- Switched `import_tasks` to `include_tasks` to evaluate os-conditionals only once per include. This also reduces output noise. [Ansible docs on this subject](https://docs.ansible.com/ansible/latest/user_guide/playbooks_conditionals.html#applying-when-to-roles-imports-and-includes).
- Removed deprecation warnings on `apt` module





