### PR TITLE
Set default user to "elastic" for the first API calls to ES

### DIFF
--- a/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/main.yml
@@ -123,7 +123,7 @@
 - name: Wait for Elasticsearch API
   uri:
     url: "https://{{ node_certs_generator_ip }}:{{ elasticsearch_http_port }}/_cluster/health/"
-    user: "{{ elasticsearch_xpack_security_user }}"
+    user: "elastic" # Default Elasticsearch user is always "elastic"
     password: "{{ elasticsearch_xpack_security_password }}"
     validate_certs: no
     status_code: 200,401
@@ -141,7 +141,7 @@
     url: "https://{{ node_certs_generator_ip }}:{{ elasticsearch_http_port }}/_security/user/{{ item.key }}"
     method: POST
     body_format: json
-    user: "{{ elasticsearch_xpack_security_user }}"
+    user: "elastic"
     password: "{{ elasticsearch_xpack_security_password }}"
     body: '{ "password" : "{{ item.value["password"] }}", "roles" : {{ item.value["roles"] }} }'
     validate_certs: no


### PR DESCRIPTION
Hi all,

According to [ES documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-security.html) the default username is "elastic". When setting the bootstrap password, we only modify the password, not the user.

The API calls that adds users requires to use the `elastic` user as no other user exists before this tasks.

Best regards

Jose