### PR TITLE
Update templates for Python 3 compatibility

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
@@ -502,7 +502,7 @@
      {% endif %}
      {% endif %}
      {% if localfile.format == 'json' and localfile.labels is defined %}
-     {% for key, value in localfile.labels.iteritems() %}
+     {% for key, value in localfile.labels.items() %}
      <label key="{{ key }}">{{ value }}</label>
      {% endfor %}
      {% endif %}
@@ -540,7 +540,7 @@
      {% endif %}
      {% endif %}
      {% if localfile.format == 'json' and localfile.labels is defined %}
-     {% for key, value in localfile.labels.iteritems() %}
+     {% for key, value in localfile.labels.items() %}
      <label key="{{ key }}">{{ value }}</label>
      {% endfor %}
      {% endif %}
@@ -579,7 +579,7 @@
      {% endif %}
      {% endif %}
      {% if localfile.format == 'json' and localfile.labels is defined %}
-     {% for key, value in localfile.labels.iteritems() %}
+     {% for key, value in localfile.labels.items() %}
      <label key="{{ key }}">{{ value }}</label>
      {% endfor %}
      {% endif %}

--- a/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-shared-agent.conf.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-shared-agent.conf.j2
@@ -68,7 +68,7 @@
        {% endif %}
        {% endif %}
        {% if localfile.format == 'json' and localfile.labels is defined %}
-       {% for key, value in localfile.labels.iteritems() %}
+       {% for key, value in localfile.labels.items() %}
        <label key="{{ key }}">{{ value }}</label>
        {% endfor %}
        {% endif %}


### PR DESCRIPTION
Upgrade Jinja2 templates for Python 3 compatibility

`iteritems()` only works on Python 2, `items()` works on both.