### PR TITLE
Fix Ansible elastic_stack-distributed template

### DIFF
--- a/playbooks/wazuh-elastic_stack-distributed.yml
+++ b/playbooks/wazuh-elastic_stack-distributed.yml
@@ -4,7 +4,7 @@
   roles:
     - role: /etc/ansible/roles/wazuh-ansible/roles/elastic-stack/ansible-elasticsearch
       elasticsearch_network_host: <node-1 IP>
-      node_name: node-1
+      elasticsearch_node_name: node-1
       elasticsearch_bootstrap_node: true
       elasticsearch_cluster_nodes:
         - <node-1 IP>


### PR DESCRIPTION
In the first host of the elastic cluster, the "node_name" property, will be  "elasticsearch_node_name"