### PR TITLE
Upgrade to NodeJS v10

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -395,4 +395,4 @@ nodejs:
   repo_dict:
       debian: "deb"
       redhat: "rpm"
-  repo_url_ext: "nodesource.com/setup_8.x"
+  repo_url_ext: "nodesource.com/setup_10.x"


### PR DESCRIPTION
This PR fixes #357 

Switched node from V8 (EOL since Jan 1st 2020) to v10 which will be supported until April 2021.