### PR TITLE
Fix manager API verification

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -339,20 +339,6 @@
     - wazuh-api
   tags:
     - config
-  environment:
-    LD_LIBRARY_PATH: "$LD_LIBRARY_PATH:/var/ossec/framework/lib"
-  when:
-    - not (ansible_facts['os_family']|lower == 'redhat' and ansible_distribution_major_version|int < 6)
-
-- name: Ensure Wazuh Manager is started and enabled (EL5)
-  service:
-    name: wazuh-manager
-    enabled: true
-    state: started
-  tags:
-    - config
-  when:
-    - ansible_distribution in ['CentOS', 'RedHat', 'Amazon'] and ansible_distribution_major_version|int < 6
 
 - include_tasks: "RMRedHat.yml"
   when:


### PR DESCRIPTION
Hello team,

This PR sanitizes the Wazuh manager and API verification task. This task was split in two and contained checks that are no longer applicable.


Successful task launch on Debian 8, Debian 9 and CentOS7
```bash
192.168.33.48 ---> Debian8
192.168.33.49 ---> Debian9
192.168.33.107 --> CentOS7

2020-02-11 13:23:34,680 p=8016 u=vagrant |  TASK [../roles/wazuh/ansible-wazuh-manager : Ensure Wazuh Manager, wazuh API service is started and enabled] *********************************************************************************
2020-02-11 13:23:35,228 p=8016 u=vagrant |  ok: [192.168.33.49] => (item=wazuh-manager)
2020-02-11 13:23:35,278 p=8016 u=vagrant |  ok: [192.168.33.48] => (item=wazuh-manager)
2020-02-11 13:23:35,346 p=8016 u=vagrant |  ok: [192.168.33.107] => (item=wazuh-manager)
2020-02-11 13:23:35,520 p=8016 u=vagrant |  ok: [192.168.33.49] => (item=wazuh-api)
2020-02-11 13:23:35,591 p=8016 u=vagrant |  ok: [192.168.33.48] => (item=wazuh-api)
2020-02-11 13:23:35,705 p=8016 u=vagrant |  ok: [192.168.33.107] => (item=wazuh-api)
```

Greetings, JP Sáez