### PR TITLE
Fix auth path for 64bits Windows

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/tasks/Windows.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Windows.yml
@@ -14,7 +14,7 @@
 - name: Windows | Set Win Path (x64)
   set_fact:
     wazuh_agent_win_path: "{{ wazuh_winagent_config.install_dir }}"
-    wazuh_agent_win_auth_path: "{{ wazuh_winagent_config.auth_path_x86 }}"
+    wazuh_agent_win_auth_path: "{{ wazuh_winagent_config.auth_path }}"
   when:
     - not check_path.stat.exists
 


### PR DESCRIPTION
This PR fixes a bug when deploying the agent to 64bits Windows hosts.