### PR TITLE
Disable shared config by default

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/README.md
+++ b/roles/wazuh/ansible-wazuh-manager/README.md
@@ -20,7 +20,7 @@ This role has some variables which you can or need to override.
 ```
 wazuh_manager_fqdn: ~
 wazuh_manager_config: []
-wazuh_agent_configs: []
+shared_agent_config: []
 ```
 
 Vault variables
@@ -157,7 +157,7 @@ wazuh_manager_config:
       level: 6
       timeout: 600
 
-wazuh_agent_configs:
+shared_agent_config:
   - type: os
     type_value: linux
     frequency_check: 79200

--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -356,53 +356,53 @@ wazuh_manager_config:
       - key: Env
         value: Production
 
-wazuh_agent_configs:
-  - type: os
-    type_value: Linux
-    syscheck:
-      frequency: 43200
-      scan_on_start: 'yes'
-      alert_new_files: 'yes'
-      ignore:
-        - /etc/mtab
-        - /etc/mnttab
-        - /etc/hosts.deny
-        - /etc/mail/statistics
-        - /etc/svc/volatile
-      no_diff:
-        - /etc/ssl/private.key
-    rootcheck:
-      frequency: 43200
-      cis_distribution_filename: null
-    localfiles:
-      - format: 'syslog'
-        location: '/var/log/messages'
-      - format: 'syslog'
-        location: '/var/log/secure'
-      - format: 'syslog'
-        location: '/var/log/maillog'
-      - format: 'apache'
-        location: '/var/log/httpd/error_log'
-      - format: 'apache'
-        location: '/var/log/httpd/access_log'
-      - format: 'apache'
-        location: '/var/ossec/logs/active-responses.log'
-  - type: os
-    type_value: Windows
-    syscheck:
-      frequency: 43200
-      scan_on_start: 'yes'
-      auto_ignore: 'no'
-      alert_new_files: 'yes'
-      windows_registry:
-        - key: 'HKEY_LOCAL_MACHINE\Software\Classes\batfile'
-          arch: 'both'
-        - key: 'HKEY_LOCAL_MACHINE\Software\Classes\Folder'
-    localfiles:
-      - location: 'Security'
-        format: 'eventchannel'
-      - location: 'System'
-        format: 'eventlog'
+# shared_agent_config:
+  # - type: os
+  #   type_value: Linux
+  #   syscheck:
+  #     frequency: 43200
+  #     scan_on_start: 'yes'
+  #     alert_new_files: 'yes'
+  #     ignore:
+  #       - /etc/mtab
+  #       - /etc/mnttab
+  #       - /etc/hosts.deny
+  #       - /etc/mail/statistics
+  #       - /etc/svc/volatile
+  #     no_diff:
+  #       - /etc/ssl/private.key
+  #   rootcheck:
+  #     frequency: 43200
+  #     cis_distribution_filename: null
+  #   localfiles:
+  #     - format: 'syslog'
+  #       location: '/var/log/messages'
+  #     - format: 'syslog'
+  #       location: '/var/log/secure'
+  #     - format: 'syslog'
+  #       location: '/var/log/maillog'
+  #     - format: 'apache'
+  #       location: '/var/log/httpd/error_log'
+  #     - format: 'apache'
+  #       location: '/var/log/httpd/access_log'
+  #     - format: 'apache'
+  #       location: '/var/ossec/logs/active-responses.log'
+  # - type: os
+  #   type_value: Windows
+  #   syscheck:
+  #     frequency: 43200
+  #     scan_on_start: 'yes'
+  #     auto_ignore: 'no'
+  #     alert_new_files: 'yes'
+  #     windows_registry:
+  #       - key: 'HKEY_LOCAL_MACHINE\Software\Classes\batfile'
+  #         arch: 'both'
+  #       - key: 'HKEY_LOCAL_MACHINE\Software\Classes\Folder'
+  #   localfiles:
+  #     - location: 'Security'
+  #       format: 'eventchannel'
+  #     - location: 'System'
+  #       format: 'eventlog'
 
 nodejs:
   repo_dict:

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -158,6 +158,8 @@
   tags:
     - init
     - config
+  when:
+    - shared_agent_config is defined
 
 - name: Installing the config.js (api configuration)
   template: src=var-ossec-api-configuration-config.js.j2

--- a/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-shared-agent.conf.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-shared-agent.conf.j2
@@ -1,6 +1,6 @@
 #jinja2: trim_blocks: False
-{% if wazuh_agent_configs is defined %}
-{% for agent_config in wazuh_agent_configs %}
+{% if shared_agent_config is defined %}
+{% for agent_config in shared_agent_config %}
 <agent_config {{ agent_config.type }}="{{ agent_config.type_value }}">
   {% if agent_config.syscheck is defined %}
   <syscheck>


### PR DESCRIPTION
Hi team,

This PR implements required changes to set the `agent.conf` file to default configuration.

Default variable has been preserved as example.

Best regards,

Jose