### PR TITLE
Avoid to install Wazuh API in worker nodes

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
@@ -132,3 +132,4 @@
   when:
     - not wazuh_api_sources_installation.enabled
     - not wazuh_custom_packages_installation_manager_enabled
+    - wazuh_manager_config.cluster.node_type == "master"

--- a/roles/wazuh/ansible-wazuh-manager/tasks/RedHat.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/RedHat.yml
@@ -142,6 +142,7 @@
     - ansible_os_family|lower == "redhat"
     - not wazuh_api_sources_installation.enabled
     - not wazuh_custom_packages_installation_api_enabled
+    - wazuh_manager_config.cluster.node_type == "master"
   tags:
     - init
 

--- a/roles/wazuh/ansible-wazuh-manager/tasks/installation_from_custom_packages.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/installation_from_custom_packages.yml
@@ -13,6 +13,8 @@
           state: present
         when:
           - wazuh_custom_packages_installation_api_enabled
+          - wazuh_manager_config.cluster.node_type == "master"
+
     when:
       - ansible_os_family|lower == "debian"
 
@@ -30,5 +32,6 @@
         state: present
       when:
         - wazuh_custom_packages_installation_api_enabled
+        - wazuh_manager_config.cluster.node_type == "master"
     when:
       - ansible_os_family|lower == "redhat"

--- a/roles/wazuh/ansible-wazuh-manager/tasks/installation_from_sources.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/installation_from_sources.yml
@@ -122,7 +122,7 @@
     stat:
       path: /var/ossec/api/app.js
     register: wazuh_api
-    when:       
+    when:
       - wazuh_manager_config.cluster.node_type == "master"
 
   - name: Install Wazuh API from sources

--- a/roles/wazuh/ansible-wazuh-manager/tasks/installation_from_sources.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/installation_from_sources.yml
@@ -122,6 +122,8 @@
     stat:
       path: /var/ossec/api/app.js
     register: wazuh_api
+    when:       
+      - wazuh_manager_config.cluster.node_type == "master"
 
   - name: Install Wazuh API from sources
     block:
@@ -178,5 +180,6 @@
     when:
       - not wazuh_api.stat.exists
       - wazuh_api_sources_installation.enabled
+      - wazuh_manager_config.cluster.node_type == "master"
     tags:
       - api

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -11,7 +11,7 @@
   stat:
     path: /usr/bin/node
   register: node_service_status
-  when: 
+  when:
     - wazuh_manager_config.cluster.node_type == "master"
 
 - name: Install NodeJS repository
@@ -27,7 +27,7 @@
       command: sh /etc/nodejs.sh
       register: nodejs_script
       changed_when: nodejs_script.rc == 0
-  when: 
+  when:
     - not node_service_status.stat.exists
     - wazuh_manager_config.cluster.node_type == "master"
 
@@ -37,7 +37,7 @@
     state: present
   register: nodejs_service_is_installed
   until: nodejs_service_is_installed is succeeded
-  when: 
+  when:
     - wazuh_manager_config.cluster.node_type == "master"
 
   tags: init
@@ -175,7 +175,7 @@
             group=ossec
             mode=0740
   notify: restart wazuh-api
-  when: 
+  when:
     - wazuh_manager_config.cluster.node_type == "master"
 
   tags:

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -11,6 +11,8 @@
   stat:
     path: /usr/bin/node
   register: node_service_status
+  when: 
+    - wazuh_manager_config.cluster.node_type == "master"
 
 - name: Install NodeJS repository
   block:
@@ -25,7 +27,9 @@
       command: sh /etc/nodejs.sh
       register: nodejs_script
       changed_when: nodejs_script.rc == 0
-  when: not node_service_status.stat.exists
+  when: 
+    - not node_service_status.stat.exists
+    - wazuh_manager_config.cluster.node_type == "master"
 
 - name: Installing NodeJS
   package:
@@ -33,6 +37,9 @@
     state: present
   register: nodejs_service_is_installed
   until: nodejs_service_is_installed is succeeded
+  when: 
+    - wazuh_manager_config.cluster.node_type == "master"
+
   tags: init
 
 - include_tasks: "RedHat.yml"
@@ -168,6 +175,9 @@
             group=ossec
             mode=0740
   notify: restart wazuh-api
+  when: 
+    - wazuh_manager_config.cluster.node_type == "master"
+
   tags:
     - init
     - config
@@ -304,6 +314,7 @@
   notify: restart wazuh-api
   when:
     - wazuh_api_user is defined
+    - wazuh_manager_config.cluster.node_type == "master"
   tags:
     - config
 
@@ -325,14 +336,20 @@
   tags:
     - config
 
-- name: Ensure Wazuh Manager, wazuh API service is started and enabled
+- name: Ensure Wazuh Manager service is started and enabled.
   service:
-    name: "{{ item }}"
+    name: "wazuh-manager"
     enabled: true
     state: started
-  with_items:
-    - wazuh-manager
-    - wazuh-api
+  tags:
+    - config
+
+- name: Ensure Wazuh API service is started and enabled.
+  service:
+    name: "wazuh-api"
+    enabled: true
+    state: started
+  when: wazuh_manager_config.cluster.node_type == "master"
   tags:
     - config
 


### PR DESCRIPTION
Hola team,

This PR fixes #370, and it involves changes related to the Wazuh API tasks. A quick summary of the modifications:

- Installation from custom packages.
- Installation from sources.
- Wazuh API dependencies (Node.JS)

Automated tests will be launched by our CI and this will be shipped once they pass. 

Cheers