### PR TITLE
Remove Windows MD5 verification

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -60,7 +60,6 @@ wazuh_winagent_config:
   auth_path: C:\Program Files\ossec-agent\agent-auth.exe
   # Adding quotes to auth_path_x86 since win_shell outputs error otherwise
   auth_path_x86: C:\'Program Files (x86)'\ossec-agent\agent-auth.exe
-  md5: 87ce22038688efb44d95f9daff472056
 wazuh_winagent_config_url: https://packages.wazuh.com/3.x/windows/wazuh-agent-3.11.4-1.msi
 wazuh_winagent_package_name: wazuh-agent-3.11.4-1.msi
 wazuh_agent_config:

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Windows.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Windows.yml
@@ -30,15 +30,6 @@
   when:
     - not wazuh_package_downloaded.stat.exists
 
-- name: Windows | Verify the Wazuh Agent installer
-  win_stat:
-    path: "{{ wazuh_winagent_config.download_dir }}{{ wazuh_winagent_package_name }}"
-    get_checksum: true
-    checksum_algorithm: md5
-  register: wazuh_agent_status
-  failed_when:
-    - wazuh_agent_status.stat.checksum != wazuh_winagent_config.md5
-
 - name: Windows | Install Agent if not already installed
   win_package:
     path: "{{ wazuh_winagent_config.download_dir }}{{ wazuh_winagent_package_name }}"


### PR DESCRIPTION
Hi team,

This PR removes MD5 verification in Windows installation tasks to allow dynamic custom builds

Best regards,

Jose