### PR TITLE
Bump NodeJS version to 10.x

### DIFF
--- a/roles/elastic-stack/ansible-kibana/defaults/main.yml
+++ b/roles/elastic-stack/ansible-kibana/defaults/main.yml
@@ -43,7 +43,7 @@ nodejs:
   repo_dict:
       debian: "deb"
       redhat: "rpm"
-  repo_url_ext: "nodesource.com/setup_8.x" 
+  repo_url_ext: "nodesource.com/setup_10.x"
 
 # Build from sources
 build_from_sources: false


### PR DESCRIPTION
Hi,

This tiny PR just updates the Node.JS version to 10.x, due to  v8 is End Of Life and lost support. 
An upgraded is mandatory to ensure up to date security and support. Our Docker images are already shipping with v10.

### Tasks
- [x] Upgrade NodeJS to v10 83aa5de
- [x] Pass tests