### PR TITLE
Explicit authd IP address on wazuh-agent role

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/README.md
+++ b/roles/wazuh/ansible-wazuh-agent/README.md
@@ -17,7 +17,7 @@ This role is compatible with:
 Role Variables
 --------------
 
-* `wazuh_managers`: Collection of Wazuh Managers' IP address, port, and protocol used by the agent
+* `wazuh_manager`: Wazuh Manager IP address, port, and protocol used in the agent-manager communication.
 * `wazuh_agent_authd`: Collection with the settings to register an agent using authd.
 
 Playbook example
@@ -29,19 +29,20 @@ The following is an example of how this role can be used:
        roles:
          - ansible-wazuh-agent
        vars:
-         wazuh_managers:
-           - address: 127.0.0.1
-             port: 1514
-             protocol: tcp
-             api_port: 55000
-             api_proto: 'http'
-             api_user: 'ansible'
+         wazuh_manager:
+          address: 127.0.0.1
+          port: 1514
+          protocol: tcp
+          api_port: 55000
+          api_proto: 'http'
+          api_user: 'ansible'
          wazuh_agent_authd:
-           enable: true
-           port: 1515
-           ssl_agent_ca: null
-           ssl_auto_negotiate: 'no'
-     
+          authd_address: 127.0.0.1
+          enable: true
+          port: 1515
+          ssl_agent_ca: null
+          ssl_auto_negotiate: 'no'
+
 
 License and copyright
 ---------------------

--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -33,7 +33,7 @@ wazuh_agent_sources_installation:
   user_ca_store: "/var/ossec/wpk_root.pem"
 
 wazuh_managers:
-  - address: 127.0.0.1
+    address: 127.0.0.1
     port: 1514
     protocol: udp
     api_port: 55000
@@ -43,6 +43,7 @@ wazuh_profile_centos: 'centos, centos7, centos7.6'
 wazuh_profile_ubuntu: 'ubuntu, ubuntu18, ubuntu18.04'
 wazuh_auto_restart: 'yes'
 wazuh_agent_authd:
+  authd_address: 127.0.0.1
   enable: false
   port: 1515
   agent_name: null

--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -32,13 +32,13 @@ wazuh_agent_sources_installation:
   user_agent_config_profile: null
   user_ca_store: "/var/ossec/wpk_root.pem"
 
-wazuh_managers:
-    address: 127.0.0.1
-    port: 1514
-    protocol: udp
-    api_port: 55000
-    api_proto: 'http'
-    api_user: null
+wazuh_manager:
+  address: 127.0.0.1
+  port: 1514
+  protocol: udp
+  api_port: 55000
+  api_proto: 'http'
+  api_user: null
 wazuh_profile_centos: 'centos, centos7, centos7.6'
 wazuh_profile_ubuntu: 'ubuntu, ubuntu18, ubuntu18.04'
 wazuh_auto_restart: 'yes'

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
@@ -68,7 +68,7 @@
         {% if wazuh_agent_authd.agent_name is defined and wazuh_agent_authd.agent_name != None %}
         -A {{ wazuh_agent_authd.agent_name }}
         {% endif %}
-        -m {{ wazuh_managers.0.address }}
+        -m {{ wazuh_agent_authd.authd_address }}
         -p {{ wazuh_agent_authd.port }}
         {% if wazuh_agent_nat %} -I "any" {% endif %}
         {% if authd_pass is defined %} -P {{ authd_pass }} {% endif %}
@@ -88,13 +88,13 @@
         agent_name: "{% if single_agent_name is defined %}{{ single_agent_name }}{% else %}{{ ansible_hostname }}{% endif %}"
       when:
         - not check_keys.stat.exists or check_keys.stat.size == 0
-        - wazuh_managers.0.address is not none
+        - wazuh_agent_authd.authd_address is not none
 
     - name: Linux | Verify agent registration
       shell: echo {{ agent_auth_output }} | grep "Valid key created"
       when:
         - not check_keys.stat.exists or check_keys.stat.size == 0
-        - wazuh_managers.0.address is not none
+        - wazuh_agent_authd.authd_address is not none
 
   when: wazuh_agent_authd.enable
   tags:
@@ -109,7 +109,7 @@
 
     - name: Linux | Create the agent key via rest-API
       uri:
-        url: "{{ wazuh_managers.0.api_proto }}://{{ wazuh_managers.0.address }}:{{ wazuh_managers.0.api_port }}/agents/"
+        url: "{{ wazuh_manager.api_proto }}://{{ wazuh_agent_authd.authd_address }}:{{ wazuh_manager.api_port }}/agents/"
         validate_certs: false
         method: POST
         body: '{"name":"{{ agent_name }}"}'
@@ -117,7 +117,7 @@
         status_code: 200
         headers:
           Content-Type: "application/json"
-        user: "{{ wazuh_managers.0.api_user }}"
+        user: "{{ wazuh_manager.api_user }}"
         password: "{{ api_pass }}"
       register: newagent_api
       notify: restart wazuh-agent
@@ -126,21 +126,21 @@
         agent_name: "{% if single_agent_name is defined %}{{ single_agent_name }}{% else %}{{ inventory_hostname }}{% endif %}"
       when:
         - not check_keys.stat.exists or check_keys.stat.size == 0
-        - wazuh_managers.0.address is not none
+        - wazuh_agent_authd.authd_address is not none
       become: false
       ignore_errors: true
 
     - name: Linux | Retieve new agent data via rest-API
       uri:
-        url: "{{ wazuh_managers.0.api_proto }}://{{ wazuh_managers.0.address }}:{{ wazuh_managers.0.api_port }}/agents/{{ newagent_api.json.data.id }}"
+        url: "{{ wazuh_manager.api_proto }}://{{ wazuh_agent_authd.authd_address }}:{{ wazuh_manager.api_port }}/agents/{{ newagent_api.json.data.id }}"
         validate_certs: false
         method: GET
         return_content: true
-        user: "{{ wazuh_managers.0.api_user }}"
+        user: "{{ wazuh_manager.api_user }}"
         password: "{{ api_pass }}"
       when:
         - not check_keys.stat.exists or check_keys.stat.size == 0
-        - wazuh_managers.0.address is not none
+        - wazuh_agent_authd.authd_address is not none
         - newagent_api.json.error == 0
       register: newagentdata_api
       delegate_to: localhost
@@ -158,7 +158,7 @@
       register: manage_agents_output
       when:
         - not check_keys.stat.exists or check_keys.stat.size == 0
-        - wazuh_managers.0.address is not none
+        - wazuh_agent_authd.authd_address is not none
         - newagent_api.changed
       notify: restart wazuh-agent
 

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Windows.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Windows.yml
@@ -61,7 +61,7 @@
 - name: Windows | Register agent
   win_shell: >
     {{ wazuh_agent_win_auth_path }}
-    -m {{ wazuh_managers.0.address }}
+    -m {{ wazuh_agent_authd.authd_address }}
     -p {{ wazuh_agent_authd.port }}
     {% if wazuh_agent_authd.agent_name is defined %}-A {{ wazuh_agent_authd.agent_name }} {% endif %}
     {% if authd_pass is defined %} -P {{ authd_pass }}{% endif %}
@@ -70,7 +70,7 @@
   when:
     - wazuh_agent_authd.enable
     - not check_windows_key.stat.exists or check_windows_key.stat.size == 0
-    - wazuh_managers.0.address is not none
+    - wazuh_agent_authd.authd_address is not none
   tags:
     - config
 

--- a/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
+++ b/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
@@ -8,17 +8,15 @@
 
 <ossec_config>
   <client>
-    {% for manager in wazuh_managers  %}
     <server>
-      <address>{{ manager.address }}</address>
-      {% if manager.port is defined %}
-      <port>{{ manager.port }}</port>
+      <address>{{ wazuh_manager.address }}</address>
+      {% if wazuh_manager.port is defined %}
+      <port>{{ wazuh_manager.port }}</port>
       {% endif %}
-      {% if manager.protocol is defined %}
-      <protocol>{{ manager.protocol }}</protocol>
+      {% if wazuh_manager.protocol is defined %}
+      <protocol>{{ wazuh_manager.protocol }}</protocol>
       {% endif %}
     </server>
-    {% endfor %}
     {% if wazuh_profile_centos is not none or wazuh_profile_ubuntu is not none %}
     {% if ansible_distribution == 'CentOS' %}
     <config-profile>{{ wazuh_profile_centos }}</config-profile>
@@ -186,13 +184,13 @@
   {% if wazuh_agent_config.sca.skip_nfs | length > 0 %}
     <skip_nfs>yes</skip_nfs>
   {% endif %}
-  {% if wazuh_agent_config.sca.day | length > 0 %}  
+  {% if wazuh_agent_config.sca.day | length > 0 %}
     <day>yes</day>
   {% endif %}
-  {% if wazuh_agent_config.sca.wday | length > 0 %}  
+  {% if wazuh_agent_config.sca.wday | length > 0 %}
     <wday>yes</wday>
   {% endif %}
-  {% if wazuh_agent_config.sca.time | length > 0 %}  
+  {% if wazuh_agent_config.sca.time | length > 0 %}
     <time>yes</time>
   {% endif %}
   </sca>
@@ -247,7 +245,7 @@
     {% for no_diff in wazuh_agent_config.syscheck.no_diff %}
     <nodiff>{{ no_diff }}</nodiff>
     {% endfor %}
-    
+
     <skip_nfs>{{ wazuh_agent_config.syscheck.skip_nfs }}</skip_nfs>
     {% endif %}
 
@@ -293,7 +291,7 @@
   <!-- Files to monitor (localfiles) -->
   {% if ansible_system == "Linux" %}
   {% for localfile in wazuh_agent_config.localfiles.linux %}
-  
+
   <localfile>
     <log_format>{{ localfile.format }}</log_format>
     {% if localfile.format == 'command' or localfile.format == 'full_command' %}


### PR DESCRIPTION
Hi team,

this PR adds a new variable related to wazuh-agent role to explicitly specify the IP address where the agents should point its registration requests.

It also introduces minor changes to the structure for wazuh manager details vars.

Greetings, JP Sáez