### PR TITLE
Adding explicit registration address variable for wazuh-agent role

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/README.md
+++ b/roles/wazuh/ansible-wazuh-agent/README.md
@@ -37,11 +37,12 @@ The following is an example of how this role can be used:
              api_proto: 'http'
              api_user: 'ansible'
          wazuh_agent_authd:
+           registration_address: 127.0.0.1
            enable: true
            port: 1515
            ssl_agent_ca: null
            ssl_auto_negotiate: 'no'
-     
+
 
 License and copyright
 ---------------------

--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -43,6 +43,7 @@ wazuh_profile_centos: 'centos, centos7, centos7.6'
 wazuh_profile_ubuntu: 'ubuntu, ubuntu18, ubuntu18.04'
 wazuh_auto_restart: 'yes'
 wazuh_agent_authd:
+  registration_address: 127.0.0.1
   enable: false
   port: 1515
   agent_name: null

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
@@ -68,7 +68,7 @@
         {% if wazuh_agent_authd.agent_name is defined and wazuh_agent_authd.agent_name != None %}
         -A {{ wazuh_agent_authd.agent_name }}
         {% endif %}
-        -m {{ wazuh_managers.0.address }}
+        -m {{ wazuh_agent_authd.registration_address }}
         -p {{ wazuh_agent_authd.port }}
         {% if wazuh_agent_nat %} -I "any" {% endif %}
         {% if authd_pass is defined %} -P {{ authd_pass }} {% endif %}
@@ -88,13 +88,13 @@
         agent_name: "{% if single_agent_name is defined %}{{ single_agent_name }}{% else %}{{ ansible_hostname }}{% endif %}"
       when:
         - not check_keys.stat.exists or check_keys.stat.size == 0
-        - wazuh_managers.0.address is not none
+        - wazuh_agent_authd.registration_address is not none
 
     - name: Linux | Verify agent registration
       shell: echo {{ agent_auth_output }} | grep "Valid key created"
       when:
         - not check_keys.stat.exists or check_keys.stat.size == 0
-        - wazuh_managers.0.address is not none
+        - wazuh_agent_authd.registration_address is not none
 
   when: wazuh_agent_authd.enable
   tags:
@@ -109,7 +109,7 @@
 
     - name: Linux | Create the agent key via rest-API
       uri:
-        url: "{{ wazuh_managers.0.api_proto }}://{{ wazuh_managers.0.address }}:{{ wazuh_managers.0.api_port }}/agents/"
+        url: "{{ wazuh_managers.0.api_proto }}://{{ wazuh_agent_authd.registration_address }}:{{ wazuh_managers.0.api_port }}/agents/"
         validate_certs: false
         method: POST
         body: '{"name":"{{ agent_name }}"}'
@@ -126,13 +126,13 @@
         agent_name: "{% if single_agent_name is defined %}{{ single_agent_name }}{% else %}{{ inventory_hostname }}{% endif %}"
       when:
         - not check_keys.stat.exists or check_keys.stat.size == 0
-        - wazuh_managers.0.address is not none
+        - wazuh_agent_authd.registration_address is not none
       become: false
       ignore_errors: true
 
     - name: Linux | Retieve new agent data via rest-API
       uri:
-        url: "{{ wazuh_managers.0.api_proto }}://{{ wazuh_managers.0.address }}:{{ wazuh_managers.0.api_port }}/agents/{{ newagent_api.json.data.id }}"
+        url: "{{ wazuh_managers.0.api_proto }}://{{ wazuh_agent_authd.registration_address }}:{{ wazuh_managers.0.api_port }}/agents/{{ newagent_api.json.data.id }}"
         validate_certs: false
         method: GET
         return_content: true
@@ -140,7 +140,7 @@
         password: "{{ api_pass }}"
       when:
         - not check_keys.stat.exists or check_keys.stat.size == 0
-        - wazuh_managers.0.address is not none
+        - wazuh_agent_authd.registration_address is not none
         - newagent_api.json.error == 0
       register: newagentdata_api
       delegate_to: localhost
@@ -158,7 +158,7 @@
       register: manage_agents_output
       when:
         - not check_keys.stat.exists or check_keys.stat.size == 0
-        - wazuh_managers.0.address is not none
+        - wazuh_agent_authd.registration_address is not none
         - newagent_api.changed
       notify: restart wazuh-agent
 

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Windows.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Windows.yml
@@ -61,7 +61,7 @@
 - name: Windows | Register agent
   win_shell: >
     {{ wazuh_agent_win_auth_path }}
-    -m {{ wazuh_managers.0.address }}
+    -m {{ wazuh_agent_authd.registration_address }}
     -p {{ wazuh_agent_authd.port }}
     {% if wazuh_agent_authd.agent_name is defined %}-A {{ wazuh_agent_authd.agent_name }} {% endif %}
     {% if authd_pass is defined %} -P {{ authd_pass }}{% endif %}
@@ -70,7 +70,7 @@
   when:
     - wazuh_agent_authd.enable
     - not check_windows_key.stat.exists or check_windows_key.stat.size == 0
-    - wazuh_managers.0.address is not none
+    - wazuh_agent_authd.registration_address is not none
   tags:
     - config
 


### PR DESCRIPTION
Hi team,

this PR adds a new variable related to wazuh-agent role to explicitly specify the IP address where the agents should point its registration requests.

Greetings, JP Sáez