### PR TITLE
Added registration address var to default wazuh-agent playbook

### DIFF
--- a/playbooks/wazuh-agent.yml
+++ b/playbooks/wazuh-agent.yml
@@ -11,6 +11,7 @@
         api_proto: 'http'
         api_user: ansible
     wazuh_agent_authd:
+      registration_address: <registration IP>
       enable: true
       port: 1515
       ssl_agent_ca: null


### PR DESCRIPTION
Hi team, 

This PR adds a placeholder for the `registration_address` var on the default `wazuh-agent` playbook.

Greetings, 

JP Sáez