### PR TITLE
Removed duplicated block

### DIFF
--- a/roles/elastic-stack/ansible-elasticsearch/tasks/Debian.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/Debian.yml
@@ -18,16 +18,6 @@
     - ansible_distribution == "Ubuntu"
     - ansible_distribution_major_version | int == 14
 
-- name: Update and upgrade apt packages
-  become: true
-  apt:
-    upgrade: yes
-    update_cache: yes
-    cache_valid_time: 86400 #One day
-  when:
-    - ansible_distribution == "Ubuntu"
-    - ansible_distribution_major_version | int == 14
-
 - name: Debian/Ubuntu | Add Elasticsearch GPG key.
   apt_key:
     url: "{{ elasticrepo.gpg }}"

--- a/roles/elastic-stack/ansible-kibana/tasks/main.yml
+++ b/roles/elastic-stack/ansible-kibana/tasks/main.yml
@@ -166,17 +166,11 @@
     path: /usr/share/kibana/optimize/wazuh/config/
     state: directory
     recurse: yes
-    owner: kibana
-    group: kibana
-    mode: '0755'
 
 - name: Configure Wazuh Kibana Plugin
   template:
     src: wazuh.yml.j2
     dest: /usr/share/kibana/optimize/wazuh/config/wazuh.yml
-    owner: kibana
-    group: root
-    mode: 0644
 
 - name: Reload systemd configuration
   systemd:


### PR DESCRIPTION
Hi,

This PR removes a duplicated block detected on `Debian.yaml` tasks for the Elasticsearch deployment role.

Regards