### PR TITLE
Replacing Oracle Java with OpenJDK 1.8

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/tasks/RedHat.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/RedHat.yml
@@ -27,27 +27,11 @@
     - not wazuh_agent_sources_installation.enabled
     - not wazuh_custom_packages_installation_agent_enabled
 
-- name: RedHat/CentOS/Fedora | download Oracle Java RPM
-  get_url:
-    url: https://download.oracle.com/otn-pub/java/jdk/8u202-b08/1961070e4c9b4e26a04e7f5a083f551e/jre-8u202-linux-x64.rpm
-    dest: /tmp/jre-8-linux-x64.rpm
-    headers: 'Cookie:oraclelicense=accept-securebackup-cookie'
-  register: oracle_java_task_rpm_download
-  until: oracle_java_task_rpm_download is succeeded
+- name: RedHat/CentOS/Fedora | Install OpenJDK 1.8
+  yum: name=java-1.8.0-openjdk state=present
   when:
     - wazuh_agent_config.cis_cat.disable == 'no'
     - wazuh_agent_config.cis_cat.install_java == 'yes'
-  tags:
-    - init
-
-- name: RedHat/CentOS/Fedora | Install Oracle Java RPM
-  package: name=/tmp/jre-8-linux-x64.rpm state=present
-  register: wazuh_agent_java_package_install
-  until: wazuh_agent_java_package_install is succeeded
-  when:
-    - wazuh_agent_config.cis_cat.disable == 'no'
-    - wazuh_agent_config.cis_cat.install_java == 'yes'
-    - oracle_java_task_rpm_download is defined
   tags:
     - init
 


### PR DESCRIPTION
Hi team,

This PR replaces the Oracle Java install with the OpenJDK 1.8 version on the `wazuh-agent` role. It closes #345. 

Greetings,
JP 