### PR TITLE
Adjusting Kibana plugin optimization max memory 

### DIFF
--- a/roles/elastic-stack/ansible-kibana/defaults/main.yml
+++ b/roles/elastic-stack/ansible-kibana/defaults/main.yml
@@ -50,4 +50,4 @@ build_from_sources: false
 wazuh_plugin_branch: 3.12-7.6
 
 #Nodejs NODE_OPTIONS
-node_options: --max-old-space-size=4096
+node_options: --max-old-space-size=2048


### PR DESCRIPTION
Hi team, 

This PR sets the `--max-old-space-size` default value used during the kibana plugin optimization to 2048.

Greetings, 

JP