### PR TITLE
Added AWS S3 block to template

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -366,7 +366,7 @@ wazuh_manager_config:
       api_key: '<api_key>'
       alert_level: 12
   monitor_aws:
-    disable: 'no'
+    disabled: 'yes'
     interval: '10m'
     run_on_start: 'yes'
     skip_on_error: 'yes'

--- a/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
@@ -570,10 +570,10 @@
 {% endfor %}
 {% endif %}
 
-{% if monitor_aws is defined %}
+{% if monitor_aws is defined and monitor_aws.disabled == "no" %}
   <!-- S3 -->
   <wodle name="aws-s3">
-    <disabled>{{ monitor_aws.disable }}</disabled>
+    <disabled>{{ monitor_aws.disabled }}</disabled>
     <interval>{{ monitor_aws.interval }}</interval>
     <run_on_start>{{ monitor_aws.run_on_start }}</run_on_start>
     <skip_on_error>{{ monitor_aws.skip_on_error }}</skip_on_error>


### PR DESCRIPTION
Hi team,

This PR is inherited from #276 by @limitup. It just renames the `enable` variable to `enabled` within the `S3 AWS` wodle block, and modifies the rendering logic as well, from:
```
if monitor_aws is defined
```

to:

```
 if monitor_aws is defined and monitor_aws.disabled == "no" 
```

Also, a CI pipeline will take this PR for testing purposes.
Regards