### PR TITLE
change-template-ossec-agent

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
+++ b/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
@@ -81,12 +81,10 @@
     </content>
     {% elif ansible_distribution == 'Debian' %}
     {% if ansible_distribution_release == 'jessie' %}
-    {% if openscap_version_valid.stdout == "0" %}
     <content type="xccdf" path="ssg-debian-8-ds.xml">
       <profile>xccdf_org.ssgproject.content_profile_common</profile>
     </content>
     <content type="oval" path="cve-debian-8-oval.xml"/>
-    {% endif %}
     {% elif ansible_distribution_release == 'stretch' %}
     <content type="oval" path="cve-debian-9-oval.xml"/>
     {% endif %}


### PR DESCRIPTION
Hello
When I run playbook on Debian 8 (jessie) then role failed:
`TASK [../roles/wazuh-ansible/wazuh-ansible/roles/wazuh/ansible-wazuh-agent : Linux | Installing agent configuration (ossec.conf)] *********************************
Thursday 30 April 2020  15:16:20 +0300 (0:00:00.021)       0:00:10.704 ******** 
fatal: [stage8]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'stdout'"}
`
**AnsibleUndefinedVariable: 'dict object' has no attribute 'stdout'**   - variable  openscap_version_valid  undefined, because  task
`
- name: Debian/Ubuntu | Check OpenScap version
  shell: "dpkg --compare-versions '{{ openscap_version.stdout }}' '>=' '1.2'; echo $?"
  register: openscap_version_valid
  changed_when: false
  when: wazuh_agent_config.openscap.disable == 'no'
  tags:
    - config
`
because runs task only when: wazuh_agent_config.openscap.disable == 'no'
but by default variables wazuh_agent_config.openscap.disable == 'yes'  and template isn't work for Debian 8 (jessie)
