### PR TITLE
fix override of var "filebeat_module_folder"

### DIFF
--- a/roles/wazuh/ansible-filebeat/tasks/main.yml
+++ b/roles/wazuh/ansible-filebeat/tasks/main.yml
@@ -84,7 +84,10 @@
         remote_src: yes
 
     - name: Setting 0755 permission for Filebeat module folder
-      file: dest={{ filebeat_module_folder }} mode=u=rwX,g=rwX,o=rwX recurse=yes
+      file:
+        path: "{{ filebeat_module_folder }}"
+        mode: 0755
+        recurse: yes
 
   when: not filebeat_module_folder_info.stat.exists
 

--- a/roles/wazuh/ansible-filebeat/tasks/main.yml
+++ b/roles/wazuh/ansible-filebeat/tasks/main.yml
@@ -67,25 +67,26 @@
 - name: Checking if Filebeat Module folder file exists
   stat:
     path: "{{ filebeat_module_folder }}"
-  register: filebeat_module_folder
+  register: filebeat_module_folder_info
 
+- name: Download, uncompress and apply permissions for Filebeat
+  block:
 
-- name: Download Filebeat module package
-  get_url:
-    url: "{{ filebeat_module_package_url }}/{{ filebeat_module_package_name }}"
-    dest: "{{ filebeat_module_package_path }}"
-  when: not filebeat_module_folder.stat.exists
+    - name: Download Filebeat module package
+      get_url:
+        url: "{{ filebeat_module_package_url }}/{{ filebeat_module_package_name }}"
+        dest: "{{ filebeat_module_package_path }}"
 
-- name: Unpakcing Filebeat module package
-  unarchive:
-    src: "{{ filebeat_module_package_path }}/{{ filebeat_module_package_name }}"
-    dest: "{{ filebeat_module_destination }}"
-    remote_src: yes
-  when: not filebeat_module_folder.stat.exists
+    - name: Unpacking Filebeat module package
+      unarchive:
+        src: "{{ filebeat_module_package_path }}/{{ filebeat_module_package_name }}"
+        dest: "{{ filebeat_module_destination }}"
+        remote_src: yes
 
-- name: Setting 0755 permission for Filebeat module folder
-  file: dest={{ filebeat_module_folder }} mode=u=rwX,g=rwX,o=rwX recurse=yes
-  when: not filebeat_module_folder.stat.exists
+    - name: Setting 0755 permission for Filebeat module folder
+      file: dest={{ filebeat_module_folder }} mode=u=rwX,g=rwX,o=rwX recurse=yes
+
+  when: not filebeat_module_folder_info.stat.exists
 
 - name: Checking if Filebeat Module package file exists
   stat:
@@ -99,6 +100,7 @@
     path: "{{ filebeat_module_package_path }}/{{ filebeat_module_package_name }}"
   when: filebeat_module_package.stat.exists
 
+- meta: end_play
 - import_tasks: config.yml
   when: filebeat_create_config
   notify: restart filebeat

--- a/roles/wazuh/ansible-filebeat/tasks/main.yml
+++ b/roles/wazuh/ansible-filebeat/tasks/main.yml
@@ -100,7 +100,6 @@
     path: "{{ filebeat_module_package_path }}/{{ filebeat_module_package_name }}"
   when: filebeat_module_package.stat.exists
 
-- meta: end_play
 - import_tasks: config.yml
   when: filebeat_create_config
   notify: restart filebeat


### PR DESCRIPTION
while deploying wazuh I realized that I was getting a weird folder in wazuh-manager machine named `{'failed': False, 'stat': {'exists': False}, 'changed': False}`

debugging it I realized that var `filebeat_module_folder` which is defined [here](https://github.com/wazuh/wazuh-ansible/blob/master/roles/wazuh/ansible-filebeat/defaults/main.yml#L35) to value `/usr/share/filebeat/module/wazuh` was being overwritten [here](https://github.com/wazuh/wazuh-ansible/blob/master/roles/wazuh/ansible-filebeat/tasks/main.yml#L70)

this patch should fix it by using a new var `filebeat_module_folder_info` instead of `filebeat_module_folder`.  I also added a block for easier reading and I fixed a typo. Changes are easier to read [here](https://github.com/wazuh/wazuh-ansible/blob/607387383790047d60e9ac5d63a309ccd73d0b2a/roles/wazuh/ansible-filebeat/tasks/main.yml#L67-L92)