### PR TITLE
fix permission override and broken idempotence

### DIFF
--- a/roles/elastic-stack/ansible-elasticsearch/tasks/xpack_security.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/xpack_security.yml
@@ -184,7 +184,7 @@
     path: "{{ node_certs_destination }}/"
     owner: root
     group: elasticsearch
-    mode: 0774
+    mode: 0770
     state: directory
     recurse: no
   when:

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/xpack_security.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/xpack_security.yml
@@ -149,6 +149,8 @@
   copy:
     src: "{{ item }}"
     dest: "{{ node_certs_destination }}/"
+    owner: root
+    group: elasticsearch
     mode: 0440
   with_items:
     - "{{ master_certs_path }}/{{ elasticsearch_node_name }}/{{ elasticsearch_node_name }}.key"
@@ -164,6 +166,8 @@
   copy:
     src: "{{ item }}"
     dest: "{{ node_certs_destination }}/"
+    owner: root
+    group: elasticsearch
     mode: 0440
   with_items:
     - "{{ master_certs_path }}/{{ elasticsearch_node_name }}/{{ elasticsearch_node_name }}.key"
@@ -178,6 +182,8 @@
 - name: Ensuring folder permissions
   file:
     path: "{{ node_certs_destination }}/"
+    owner: root
+    group: elasticsearch
     mode: 0774
     state: directory
     recurse: no

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/xpack_security.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/xpack_security.yml
@@ -180,7 +180,7 @@
     path: "{{ node_certs_destination }}/"
     mode: 0774
     state: directory
-    recurse: yes
+    recurse: no
   when:
     - elasticsearch_xpack_security
     - generate_CA

--- a/roles/elastic-stack/ansible-kibana/tasks/main.yml
+++ b/roles/elastic-stack/ansible-kibana/tasks/main.yml
@@ -28,6 +28,8 @@
   copy:
     src: "{{ item }}"
     dest: "{{ node_certs_destination }}/"
+    owner: root
+    group: kibana
     mode: 0440
   with_items:
     - "{{ master_certs_path }}/{{ kibana_node_name }}/{{ kibana_node_name }}.key"
@@ -42,6 +44,8 @@
   copy:
     src: "{{ item }}"
     dest: "{{ node_certs_destination }}/"
+    owner: root
+    group: kibana
     mode: 0440
   with_items:
     - "{{ master_certs_path }}/{{ kibana_node_name }}/{{ kibana_node_name }}.key"

--- a/roles/elastic-stack/ansible-kibana/tasks/main.yml
+++ b/roles/elastic-stack/ansible-kibana/tasks/main.yml
@@ -56,7 +56,7 @@
   file:
     path: "{{ node_certs_destination }}/"
     state: directory
-    recurse: yes
+    recurse: no
     owner: kibana
     group: kibana
   when:
@@ -67,7 +67,7 @@
   file:
     path: "{{ node_certs_destination }}/"
     mode: 0770
-    recurse: yes
+    recurse: no
   when:
     - kibana_xpack_security
   notify: restart kibana

--- a/roles/elastic-stack/ansible-kibana/tasks/main.yml
+++ b/roles/elastic-stack/ansible-kibana/tasks/main.yml
@@ -56,13 +56,14 @@
     - not generate_CA
   tags: xpack-security
 
-- name: Ensuring certificates folder owner
+- name: Ensuring certificates folder owner and permissions
   file:
     path: "{{ node_certs_destination }}/"
     state: directory
     recurse: no
     owner: kibana
     group: kibana
+    mode: 0770
   when:
     - kibana_xpack_security
   tags: xpack-security
@@ -70,7 +71,6 @@
 - name: Ensuring certificates folder owner
   file:
     path: "{{ node_certs_destination }}/"
-    mode: 0770
     recurse: no
   when:
     - kibana_xpack_security

--- a/roles/elastic-stack/ansible-kibana/tasks/main.yml
+++ b/roles/elastic-stack/ansible-kibana/tasks/main.yml
@@ -66,14 +66,6 @@
     mode: 0770
   when:
     - kibana_xpack_security
-  tags: xpack-security
-
-- name: Ensuring certificates folder owner
-  file:
-    path: "{{ node_certs_destination }}/"
-    recurse: no
-  when:
-    - kibana_xpack_security
   notify: restart kibana
   tags: xpack-security
 

--- a/roles/wazuh/ansible-filebeat/tasks/main.yml
+++ b/roles/wazuh/ansible-filebeat/tasks/main.yml
@@ -59,7 +59,7 @@
     path: "{{ node_certs_destination }}/"
     mode: 0774
     state: directory
-    recurse: yes
+    recurse: no
   when:
     - filebeat_xpack_security
   tags: xpack-security

--- a/roles/wazuh/ansible-filebeat/tasks/main.yml
+++ b/roles/wazuh/ansible-filebeat/tasks/main.yml
@@ -30,6 +30,8 @@
   copy:
     src: "{{ item }}"
     dest: "{{ node_certs_destination }}/"
+    owner: root
+    group: root
     mode: 0440
   with_items:
     - "{{ master_certs_path }}/{{ filebeat_node_name }}/{{ filebeat_node_name }}.key"
@@ -44,6 +46,8 @@
   copy:
     src: "{{ item }}"
     dest: "{{ node_certs_destination }}/"
+    owner: root
+    group: root
     mode: 0440
   with_items:
     - "{{ master_certs_path }}/{{ filebeat_node_name }}/{{ filebeat_node_name }}.key"
@@ -57,7 +61,7 @@
 - name: Ensuring folder & certs permissions
   file:
     path: "{{ node_certs_destination }}/"
-    mode: 0774
+    mode: 0770
     state: directory
     recurse: no
   when:


### PR DESCRIPTION
while using this role to configure our wazuh instance with ssl enabled we noticed that these tasks were overriding the permissions `0440` that were being applied in the tasks above `Copying node's certificate from master` . 

Because  of this the private keys in `/etc/elasticsearch/certs/` had permissions `0774` and were readable by any user in the system. 

This was also breaking idempotence because on every run the permissions were modified to `0440` and then modified again to `0774`