### PR TITLE
added extra ssl option for kibana

### DIFF
--- a/roles/elastic-stack/ansible-kibana/defaults/main.yml
+++ b/roles/elastic-stack/ansible-kibana/defaults/main.yml
@@ -25,6 +25,7 @@ wazuh_api_credentials:
 
 # Xpack Security
 kibana_xpack_security: false
+kibana_ssl_verification_mode: "full"
 
 elasticsearch_xpack_security_user: elastic
 elasticsearch_xpack_security_password: elastic_pass

--- a/roles/elastic-stack/ansible-kibana/templates/kibana.yml.j2
+++ b/roles/elastic-stack/ansible-kibana/templates/kibana.yml.j2
@@ -110,6 +110,7 @@ elasticsearch.password: "{{ elasticsearch_xpack_security_password }}"
 server.ssl.enabled: true
 server.ssl.key: "{{node_certs_destination}}/{{ kibana_node_name }}.key"
 server.ssl.certificate: "{{node_certs_destination}}/{{ kibana_node_name }}.crt"
+elasticsearch.ssl.verificationMode: certificate
 {% if generate_CA == true %}
 elasticsearch.ssl.certificateAuthorities: ["{{ node_certs_destination }}/ca.crt"]
 {% elif generate_CA == false %}

--- a/roles/elastic-stack/ansible-kibana/templates/kibana.yml.j2
+++ b/roles/elastic-stack/ansible-kibana/templates/kibana.yml.j2
@@ -110,7 +110,7 @@ elasticsearch.password: "{{ elasticsearch_xpack_security_password }}"
 server.ssl.enabled: true
 server.ssl.key: "{{node_certs_destination}}/{{ kibana_node_name }}.key"
 server.ssl.certificate: "{{node_certs_destination}}/{{ kibana_node_name }}.crt"
-elasticsearch.ssl.verificationMode: certificate
+elasticsearch.ssl.verificationMode: "{{ kibana_ssl_verification_mode }}"
 {% if generate_CA == true %}
 elasticsearch.ssl.certificateAuthorities: ["{{ node_certs_destination }}/ca.crt"]
 {% elif generate_CA == false %}


### PR DESCRIPTION
while using this role to deploy wazuh with ssl enabled we found error message `Kibana server is not ready yet` when trying to access the kibana webui in `https://kibana-host.com:5601/`

We enabled the kibana logs and found these error messages:

```
"type":"log","@timestamp":"2020-05-22T17:06:55Z","tags":["error","elasticsearch","data"],"pid":27536,"message":"Request error, retrying\nGET https://elastic-host.com:9200/_xpack => Hostname/IP does not match certificate's altnames: Host: elastic-host.com. is not in the cert's altnames: IP Address:192.168.1.200"}
```

After some googling we found [this post](https://github.com/elastic/kibana/issues/5305#issuecomment-451352008) and we fixed it by adding option `elasticsearch.ssl.verificationMode: certificate` to `/etc/kibana/kibana.yml` . This PR should add the fix to the default installation