### PR TITLE
only execute kibana optimization during initial installation

### DIFF
--- a/roles/elastic-stack/ansible-kibana/tasks/main.yml
+++ b/roles/elastic-stack/ansible-kibana/tasks/main.yml
@@ -142,7 +142,6 @@
     creates: /usr/share/kibana/optimize/wazuh/
   become: yes
   become_user: kibana
-  changed_when: false
   tags:
     - skip_ansible_lint
 

--- a/roles/elastic-stack/ansible-kibana/tasks/main.yml
+++ b/roles/elastic-stack/ansible-kibana/tasks/main.yml
@@ -139,6 +139,7 @@
   shell: /usr/share/kibana/node/bin/node {{ node_options }} /usr/share/kibana/src/cli --optimize
   args:
     executable: /bin/bash
+    creates: /usr/share/kibana/optimize/wazuh/
   become: yes
   become_user: kibana
   changed_when: false


### PR DESCRIPTION
only execute the kibana optimization if folder `/usr/share/kibana/optimize/wazuh/` doesn't exists

I don't know much about kibana internals and the wazuh plugin so maybe the kibana optimization should be executed on every run of the playbook? If that's the case please discard this PR