### PR TITLE
don't delete generated certificates on every run

### DIFF
--- a/roles/elastic-stack/ansible-elasticsearch/tasks/xpack_security.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/xpack_security.yml
@@ -126,19 +126,12 @@
     - xpack-security
     - molecule-idempotence-notest
 
-- name: Delete certs.zip in Generator node
-  file:
-    state: absent
-    path: "{{ node_certs_source }}/certs.zip"
-  when:
-    - node_certs_generator
-  tags: molecule-idempotence-notest
-
 - name: Unzip generated certs.zip
   unarchive:
     src: "{{ master_certs_path }}/certs.zip"
     dest: "{{ master_certs_path }}/"
   delegate_to: "127.0.0.1"
+  changed_when: false
   when:
     - node_certs_generator
   tags:


### PR DESCRIPTION
while deploying our wazuh instance with ssl enabled we realized that certificates were deleted and new certificates were created and deployed on every execution of the play. This was breaking our setup when rerunning the playbook

I verified that file `certs.zip` left in `/usr/share/elasticsearch/certs.zip` in the generator node is only readable by root user

I have also added a `changed_when: false` to the unarchive task so it doesn't change in every run