### PR TITLE
Replacing root owner with ossec for local decoders/rules

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -106,7 +106,7 @@
 - name: Installing the local_rules.xml (default local_rules.xml)
   template: src=var-ossec-rules-local_rules.xml.j2
             dest=/var/ossec/etc/rules/local_rules.xml
-            owner=root
+            owner=ossec
             group=ossec
             mode=0640
   notify: restart wazuh-manager
@@ -118,7 +118,7 @@
 - name: Adding local rules files
   copy: src="{{ wazuh_manager_config.ruleset.rules_path }}"
         dest=/var/ossec/etc/rules/
-        owner=root
+        owner=ossec
         group=ossec
         mode=0640
   notify: restart wazuh-manager
@@ -130,7 +130,7 @@
 - name: Installing the local_decoder.xml
   template: src=var-ossec-rules-local_decoder.xml.j2
             dest=/var/ossec/etc/decoders/local_decoder.xml
-            owner=root
+            owner=ossec
             group=ossec
             mode=0640
   notify: restart wazuh-manager
@@ -142,7 +142,7 @@
 - name: Adding local decoders files
   copy: src="{{ wazuh_manager_config.ruleset.decoders_path }}"
         dest=/var/ossec/etc/decoders/
-        owner=root
+        owner=ossec
         group=ossec
         mode=0640
   notify: restart wazuh-manager


### PR DESCRIPTION
Hi team,

This PR sets ossec as the owner for local decoders and rules. It also sets ossec as owner for user custom decoders and rules.
Below the default permissions on fresh Wazuh manager package install:

**local_decoder.xml**
![image](https://user-images.githubusercontent.com/14923294/83250134-ee6db900-a1a7-11ea-9d21-35f5673cad2e.png)

**local_rules.xml**
![image](https://user-images.githubusercontent.com/14923294/83250251-207f1b00-a1a8-11ea-8876-fbae3c81e1aa.png)

Greetings,
JP