### PR TITLE
Use relative path for xpack certificates

### DIFF
--- a/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
@@ -36,7 +36,7 @@ node_certs_source: /usr/share/elasticsearch
 node_certs_destination: /etc/elasticsearch/certs
 
 # CA generation
-master_certs_path: /es_certs
+master_certs_path: "{{ playbook_dir }}/es_certs"
 generate_CA: true
 ca_key_name: ""
 ca_cert_name: ""

--- a/roles/elastic-stack/ansible-elasticsearch/tasks/xpack_security.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/tasks/xpack_security.yml
@@ -102,6 +102,7 @@
     state: directory
     mode: 0700
   delegate_to: "127.0.0.1"
+  become: no
   when:
     - node_certs_generator
 
@@ -111,6 +112,7 @@
     state: directory
     mode: 0700
   delegate_to: "127.0.0.1"
+  become: no
   when:
     - node_certs_generator
 
@@ -139,6 +141,7 @@
     src: "{{ master_certs_path }}/certs.zip"
     dest: "{{ master_certs_path }}/"
   delegate_to: "127.0.0.1"
+  become: no
   when:
     - node_certs_generator
   tags:

--- a/roles/elastic-stack/ansible-kibana/defaults/main.yml
+++ b/roles/elastic-stack/ansible-kibana/defaults/main.yml
@@ -34,7 +34,7 @@ node_certs_source: /usr/share/elasticsearch
 node_certs_destination: /etc/kibana/certs
 
 # CA Generation
-master_certs_path: /es_certs
+master_certs_path: "{{ playbook_dir }}/es_certs"
 generate_CA: true
 ca_cert_name: ""
 

--- a/roles/wazuh/ansible-filebeat/defaults/main.yml
+++ b/roles/wazuh/ansible-filebeat/defaults/main.yml
@@ -46,7 +46,7 @@ node_certs_destination: /etc/filebeat/certs
 
 
 # CA Generation
-master_certs_path: /es_certs
+master_certs_path: "{{ playbook_dir }}/es_certs"
 generate_CA: true
 ca_cert_name: ""
 


### PR DESCRIPTION
This PR fixes #431 

Now we're using `"{{ playbook_dir }}/es_certs"` as the default path for generating certificates.