### PR TITLE
Add support to configure path.repo option in ES. Required for backups/snapshots

### DIFF
--- a/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
@@ -6,6 +6,7 @@ elasticsearch_reachable_host: 127.0.0.1
 elasticsearch_jvm_xms: null
 elastic_stack_version: 7.6.2
 elasticsearch_lower_disk_requirements: false
+elasticsearch_path_repo: []
 
 elasticrepo:
   apt: 'https://artifacts.elastic.co/packages/7.x/apt'

--- a/roles/elastic-stack/ansible-elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/elastic-stack/ansible-elasticsearch/templates/elasticsearch.yml.j2
@@ -6,6 +6,12 @@ path.data: /var/lib/elasticsearch
 path.logs: /var/log/elasticsearch
 bootstrap.memory_lock: true
 network.host: {{ elasticsearch_network_host }}
+{% if elasticsearch_path_repo | length>0 %}
+path.repo:
+{% for item in elasticsearch_path_repo %}
+  - {{ item }}
+{% endfor %}
+{% endif %}
 
 {% if single_node %}
 discovery.type: single-node


### PR DESCRIPTION
We need to configure option `path.repo` in our elasticsearch instance to do snapshots and backups. e.g.
```
elasticsearch_path_repo:
  - /data/backups
```

This PR should not change the current default behaviour of the role. Using the default value `elasticsearch_path_repo: []` just won't add anything to the ES config 

The paths defined in `elasticsearch_path_repo` should exist and be writable by the ES daemon but the role is not taking care of creating them. Is ok like that or should I extend the PR to create the folders with the right permissions? Please let me know what you prefer.