### PR TITLE
In ansible-wazuh-agent, ask if ssl_agent_cert and ssl_agent_key are defined instead of none

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
@@ -67,8 +67,8 @@
         - "{{ wazuh_agent_authd.ssl_agent_cert }}"
         - "{{ wazuh_agent_authd.ssl_agent_key }}"
       when:
-        - wazuh_agent_authd.ssl_agent_cert is not none
-        - wazuh_agent_authd.ssl_agent_key is not none
+        - wazuh_agent_authd.ssl_agent_cert is defined
+        - wazuh_agent_authd.ssl_agent_key is defined
 
     - name: Linux | Register agent (via authd)
       shell: >


### PR DESCRIPTION
In ansible-wazuh-agent, ask if ssl_agent_cert and ssl_agent_key are defined instead of none

This avoids the following issue on my machine:
```
TASK [roles/wazuh-ansible/roles/wazuh/ansible-wazuh-agent : Copy TLS/SSL certificate for agent verification] ********************************************************************************************************************
fatal: [wazuh-agent-test1]: FAILED! => {"msg": "'dict object' has no attribute 'ssl_agent_cert'"}

PLAY RECAP **********************************************************************************************************************************************************************************************************************
wazuh-agent-test1          : ok=10   changed=0    unreachable=0    failed=1    skipped=12   rescued=0    ignored=0  
```