### PR TITLE
Permit OpenSCAP content file choice through variables

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -198,6 +198,12 @@ wazuh_agent_config:
     timeout: 1800
     interval: '1d'
     scan_on_start: 'yes'
+    user_defined_content: 'no'
+    content_type: 'xccdf'
+    content_path: 'ssg-ubuntu-1604-ds.xml'
+    content_profile: 
+      - profs: 'xccdf_org.ssgproject.content_profile_common'
+      - profs: 'xccdf_org.ssgproject.content_profile_anssi_np_nt28_high'
   osquery:
     disable: 'yes'
     run_daemon: 'yes'

--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -193,6 +193,10 @@ wazuh_agent_config:
         type: "sregex"
   rootcheck:
     frequency: 43200
+    system_audit_enable: 'no'
+    system_audit:
+      - system_audit_rcl.txt
+      - system_audit_ssh.txt
   openscap:
     disable: 'yes'
     timeout: 1800

--- a/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
+++ b/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
@@ -75,6 +75,17 @@
     <timeout>{{ wazuh_agent_config.openscap.timeout }}</timeout>
     <interval>{{ wazuh_agent_config.openscap.interval }}</interval>
     <scan-on-start>{{ wazuh_agent_config.openscap.scan_on_start }}</scan-on-start>
+    {% if wazuh_agent_config.openscap.user_defined_content == 'yes' %}
+    {% if wazuh_agent_config.openscap.content_type == 'xccdf' %}
+    <content type="xccdf" path="{{ wazuh_agent_config.openscap.content_path }}">
+    {% for content_profile in wazuh_agent_config.openscap.content_profile %}
+      <profile>{{ content_profile.profs }}</profile>
+    {% endfor %}
+    </content>
+    {% elif wazuh_agent_config.openscap.content_type == 'oval' %}
+    <content type="oval" path="{{ wazuh_agent_config.openscap.content_path }}"/>
+    {% endif %}
+    {% elif wazuh_agent_config.openscap.user_defined_content == 'no' %}
     {% if ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'xenial' %}
     <content type="xccdf" path="ssg-ubuntu-1604-ds.xml">
       <profile>xccdf_org.ssgproject.content_profile_common</profile>
@@ -128,6 +139,7 @@
         <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
         <profile>xccdf_org.ssgproject.content_profile_common</profile>
       </content>
+    {% endif %}
     {% endif %}
   </wodle>
   {% endif %}

--- a/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
+++ b/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
@@ -65,6 +65,12 @@
     <windows_malware>./shared/win_malware_rcl.txt</windows_malware>
     {% endif %}
 
+    {% if wazuh_agent_config.rootcheck.system_audit_enable == 'yes' %}
+    {% for audit_file in wazuh_agent_config.rootcheck.system_audit %}
+    <system_audit>/var/ossec/etc/shared/{{ audit_file }}</system_audit>
+    {% endfor %}
+    {% endif %}
+
   </rootcheck>
   {% endif %}
 

--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -195,6 +195,12 @@ wazuh_manager_config:
     timeout: 1800
     interval: '1d'
     scan_on_start: 'yes'
+    user_defined_content: 'no'
+    content_type: 'xccdf'
+    content_path: 'ssg-ubuntu-1604-ds.xml'
+    content_profile: 
+      - profs: 'xccdf_org.ssgproject.content_profile_common'
+      - profs: 'xccdf_org.ssgproject.content_profile_anssi_np_nt28_high'
   cis_cat:
     disable: 'yes'
     install_java: 'yes'

--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -190,6 +190,10 @@ wazuh_manager_config:
     sync_max_eps: 10
   rootcheck:
     frequency: 43200
+    system_audit_enable: 'no'
+    system_audit:
+      - system_audit_rcl.txt
+      - system_audit_ssh.txt
   openscap:
     disable: 'yes'
     timeout: 1800

--- a/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
@@ -140,6 +140,17 @@
     <timeout>{{ wazuh_manager_config.openscap.timeout }}</timeout>
     <interval>{{ wazuh_manager_config.openscap.interval }}</interval>
     <scan-on-start>{{ wazuh_manager_config.openscap.scan_on_start }}</scan-on-start>
+    {% if wazuh_manager_config.openscap.user_defined_content == 'yes' %}
+    {% if wazuh_manager_config.openscap.content_type == 'xccdf' %}
+    <content type="xccdf" path="{{ wazuh_manager_config.openscap.content_path }}">
+    {% for content_profile in wazuh_manager_config.openscap.content_profile %}
+      <profile>{{ content_profile.profs }}</profile>
+    {% endfor %}
+    </content>
+    {% elif wazuh_manager_config.openscap.content_type == 'oval' %}
+    <content type="oval" path="{{ wazuh_manager_config.openscap.content_path }}"/>
+    {% endif %}
+    {% elif wazuh_agent_config.openscap.user_defined_content == 'no' %}
     {% if ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'xenial' %}
     <content type="xccdf" path="ssg-ubuntu-1604-ds.xml">
       <profile>xccdf_org.ssgproject.content_profile_common</profile>
@@ -193,6 +204,7 @@
         <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
         <profile>xccdf_org.ssgproject.content_profile_common</profile>
       </content>
+    {% endif %}
     {% endif %}
   </wodle>
   {% endif %}

--- a/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
@@ -150,7 +150,7 @@
     {% elif wazuh_manager_config.openscap.content_type == 'oval' %}
     <content type="oval" path="{{ wazuh_manager_config.openscap.content_path }}"/>
     {% endif %}
-    {% elif wazuh_agent_config.openscap.user_defined_content == 'no' %}
+    {% elif wazuh_manager_config.openscap.user_defined_content == 'no' %}
     {% if ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'xenial' %}
     <content type="xccdf" path="ssg-ubuntu-1604-ds.xml">
       <profile>xccdf_org.ssgproject.content_profile_common</profile>

--- a/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
@@ -132,6 +132,13 @@
     <rootkit_trojans>/var/ossec/etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    {% if wazuh_manager_config.rootcheck.system_audit_enable == 'yes' %}
+    {% for audit_file in wazuh_manager_config.rootcheck.system_audit %}
+    <system_audit>/var/ossec/etc/shared/default/{{ audit_file }}</system_audit>
+    {% endfor %}
+    {% endif %}
+
   </rootcheck>
 
     {% if ansible_system == "Linux" and wazuh_manager_config.openscap.disable == 'no' %}


### PR DESCRIPTION
This will allow the user the option to define a different OpenSCAP OVAL/XCCDF file in both agent and manager ossec.conf templates through variables as opposed to the template pre-selecting OpenSCAP content based on OS distribution.

Option would still remain to have the OpenSCAP wodle pre-configured in ossec.conf template based on detected OS distribution, however this update would enable additional content files to be used for users on different OS distributions. 