### PR TITLE
Fixes for opendistro deploys

### DIFF
--- a/roles/opendistro/opendistro-elasticsearch/tasks/local_actions.yml
+++ b/roles/opendistro/opendistro-elasticsearch/tasks/local_actions.yml
@@ -4,6 +4,7 @@
     path: "{{ local_certs_path }}"
   register: certificates_folder
   delegate_to: localhost
+  become: no
   tags:
     - generate-certs
 
@@ -77,6 +78,7 @@
 
   run_once: true
   delegate_to: localhost
+  become: no
   tags:
     - generate-certs
   when:

--- a/roles/opendistro/opendistro-kibana/defaults/main.yml
+++ b/roles/opendistro/opendistro-kibana/defaults/main.yml
@@ -20,7 +20,6 @@ wazuh_app_url: https://packages.wazuh.com/wazuhapp/wazuhapp
 
 # The OpenDistro package repository
 kibana_opendistro_version: -1.8.0-1 # Version includes the - for RedHat family compatibility, replace with = for Debian hosts
-kibana_opendistro_package: "opendistroforelasticsearch-kibana{{ kibana_opendistro_version }}"
 
 package_repos:
   yum:

--- a/roles/opendistro/opendistro-kibana/tasks/main.yml
+++ b/roles/opendistro/opendistro-kibana/tasks/main.yml
@@ -75,7 +75,7 @@
     - not build_from_sources
 
 - name: Kibana optimization (can take a while)
-  shell: /usr/share/kibana/node/bin/node {{ node_options }} /usr/share/kibana/src/cli --optimize
+  shell: /usr/share/kibana/node/bin/node {{ node_options }} /usr/share/kibana/src/cli --optimize -c {{ kibana_conf_path }}/kibana.yml
   args:
     executable: /bin/bash
   become: yes

--- a/roles/opendistro/opendistro-kibana/tasks/main.yml
+++ b/roles/opendistro/opendistro-kibana/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: Install Kibana
   package:
-    name: "{{ kibana_opendistro_package }}"
+    name: "opendistroforelasticsearch-kibana{{ kibana_opendistro_version }}"
     state: present
   register: install
   tags: install


### PR DESCRIPTION
This PR fixes several small quirks on Opendistro deploys

- Avoid sudo on local actions even when called with `become: yes`
- Specify explicit path for `kibana.yml` when runing optimization command
- Simplify Opendistro version variables