### PR TITLE
Fix kibana optimization for debian 10

### DIFF
--- a/roles/elastic-stack/ansible-kibana/tasks/main.yml
+++ b/roles/elastic-stack/ansible-kibana/tasks/main.yml
@@ -132,7 +132,7 @@
     - not build_from_sources
 
 - name: Kibana optimization (can take a while)
-  shell: /usr/share/kibana/node/bin/node {{ node_options }} /usr/share/kibana/src/cli --optimize
+  shell: /usr/share/kibana/node/bin/node {{ node_options }} /usr/share/kibana/src/cli --optimize -c /etc/kibana/kibana.yml
   args:
     executable: /bin/bash
     creates: /usr/share/kibana/optimize/wazuh/


### PR DESCRIPTION
Fix for this issue:

https://discuss.elastic.co/t/kibana-upgrade-to-7-8-fatal-cli-error-error-enoent-no-such-file-or-directory/239885

in debian buster