### PR TITLE
Use kibana path for elastic-kibana role

### DIFF
--- a/roles/elastic-stack/ansible-kibana/defaults/main.yml
+++ b/roles/elastic-stack/ansible-kibana/defaults/main.yml
@@ -5,6 +5,7 @@ elasticsearch_http_port: "9200"
 elasticsearch_network_host: "127.0.0.1"
 kibana_server_host: "0.0.0.0"
 kibana_server_port: "5601"
+kibana_conf_path: /etc/kibana
 elastic_stack_version: 7.8.0
 wazuh_version: 3.13.1
 wazuh_app_url: https://packages.wazuh.com/wazuhapp/wazuhapp

--- a/roles/elastic-stack/ansible-kibana/tasks/main.yml
+++ b/roles/elastic-stack/ansible-kibana/tasks/main.yml
@@ -132,7 +132,7 @@
     - not build_from_sources
 
 - name: Kibana optimization (can take a while)
-  shell: /usr/share/kibana/node/bin/node {{ node_options }} /usr/share/kibana/src/cli --optimize
+  shell: /usr/share/kibana/node/bin/node {{ node_options }} /usr/share/kibana/src/cli --optimize -c /etc/kibana/kibana.yml
   args:
     executable: /bin/bash
     creates: /usr/share/kibana/optimize/wazuh/

--- a/roles/elastic-stack/ansible-kibana/tasks/main.yml
+++ b/roles/elastic-stack/ansible-kibana/tasks/main.yml
@@ -132,7 +132,7 @@
     - not build_from_sources
 
 - name: Kibana optimization (can take a while)
-  shell: /usr/share/kibana/node/bin/node {{ node_options }} /usr/share/kibana/src/cli --optimize -c /etc/kibana/kibana.yml
+  shell: /usr/share/kibana/node/bin/node {{ node_options }} /usr/share/kibana/src/cli --optimize -c {{ kibana_conf_path }}/kibana.yml
   args:
     executable: /bin/bash
     creates: /usr/share/kibana/optimize/wazuh/


### PR DESCRIPTION
This PR includes #447 and creates the variable `kibana_conf_path` on the Elastic Kibana role like we did on Opendistro role.