### PR TITLE
Add new options to agent role's default variables

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -39,6 +39,8 @@ wazuh_managers:
     api_port: 55000
     api_proto: 'http'
     api_user: null
+    max_retries: 5
+    retry_interval: 5
 wazuh_api_reachable_from_agent: false
 wazuh_profile_centos: 'centos, centos7, centos7.6'
 wazuh_profile_ubuntu: 'ubuntu, ubuntu18, ubuntu18.04'

--- a/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
+++ b/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
@@ -16,6 +16,8 @@
       {% endif %}
       {% if manager.protocol is defined %}
       <protocol>{{ manager.protocol }}</protocol>
+      {% endif %}
+      {% if manager.max_retries is defined and manager.retry_interval is defined %}
       <max_retries>{{ manager.max_retries }}</max_retries>
       <retry_interval>{{ manager.retry_interval }}</retry_interval>
       {% endif %}


### PR DESCRIPTION
Hi team,

This PR adds these two new options to the defaults vars, which is used in the agent's `ossec.conf` : `max_retries` , `retry_interval`

Cheers