### PR TITLE
Fix check_mode condition

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
@@ -35,9 +35,9 @@
     - ansible_os_family|lower != "redhat"
     - not wazuh_agent_sources_installation.enabled
     - not wazuh_custom_packages_installation_agent_enabled
+    - not ansible_check_mode
   tags:
     - init
-  when: not ansible_check_mode
 
 - name: Linux | Check if client.keys exists
   stat: path=/var/ossec/etc/client.keys


### PR DESCRIPTION
Hi folks,

This PR fixes a `when` statement wrong condition in the `Install wazuh-agent` task for Debian systems.

Regards