### PR TITLE
Fixes for opendistro role

### DIFF
--- a/roles/opendistro/opendistro-elasticsearch/defaults/main.yml
+++ b/roles/opendistro/opendistro-elasticsearch/defaults/main.yml
@@ -46,7 +46,7 @@ es_nodes: |-
 # Security password
 opendistro_security_password: admin
 opendistro_custom_user: ""
-opendistro_cusom_user_role: "admin"
+opendistro_custom_user_role: "admin"
 
 # Set JVM memory limits
 opendistro_jvm_xms: null

--- a/roles/opendistro/opendistro-elasticsearch/tasks/security_actions.yml
+++ b/roles/opendistro/opendistro-elasticsearch/tasks/security_actions.yml
@@ -145,7 +145,7 @@
       return_content: yes
       timeout: 4
     when:
-      - opendistro_custom_user is defined
+      - opendistro_custom_user is defined and opendistro_custom_user
 
   tags:
     - security


### PR DESCRIPTION
This PR fixes a typo on opendistro role defaults and adds a check to only execute the custom user task when the variable is not null