### PR TITLE
Removed deprecated option

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-shared-agent.conf.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-shared-agent.conf.j2
@@ -82,7 +82,6 @@
   {% if agent_config.rootcheck is defined %}
   <rootcheck>
     <disabled>no</disabled>
-    <check_unixaudit>yes</check_unixaudit>
     <check_files>yes</check_files>
     <check_trojans>yes</check_trojans>
     <check_dev>yes</check_dev>


### PR DESCRIPTION
Hi team,

This PR removes a deprecated option of the `rootcheck` component.

Regards