### PR TITLE
Elastic API check fix

### DIFF
--- a/roles/opendistro/opendistro-elasticsearch/tasks/main.yml
+++ b/roles/opendistro/opendistro-elasticsearch/tasks/main.yml
@@ -64,7 +64,7 @@
       return_content: yes
       timeout: 4
     register: _result
-    until: (  _result.json is defined) and (_result.json.status == "green")
+    until: (  _result.json is defined) and (_result.json.status == "green" or _result.json.status == "yellow" )
     retries: 24
     delay: 5
     tags: debug
@@ -82,7 +82,7 @@
       return_content: yes
       timeout: 4
     register: _result
-    until: (  _result.json is defined) and (_result.json.status == "green")
+    until: (  _result.json is defined) and (_result.json.status == "green" or _result.json.status == "yellow" )
     retries: 24
     delay: 5
     tags: debug

--- a/roles/opendistro/opendistro-elasticsearch/tasks/main.yml
+++ b/roles/opendistro/opendistro-elasticsearch/tasks/main.yml
@@ -64,13 +64,12 @@
       return_content: yes
       timeout: 4
     register: _result
-    until: (  _result.json is defined) and (_result.json.status == "green" or _result.json.status == "yellow" )
+    until: (  _result.json is defined) and (_result.json.status == "green" or ( _result.json.status == "yellow" and single_node ) )
     retries: 24
     delay: 5
     tags: debug
     when:
       - hostvars[inventory_hostname]['private_ip'] is not defined or not hostvars[inventory_hostname]['private_ip']
-      - single_node == false
 
   - name: Wait for Elasticsearch API (Private IP)
     uri:
@@ -82,13 +81,12 @@
       return_content: yes
       timeout: 4
     register: _result
-    until: (  _result.json is defined) and (_result.json.status == "green" or _result.json.status == "yellow" )
+    until: (  _result.json is defined) and (_result.json.status == "green" or ( _result.json.status == "yellow" and single_node ) )
     retries: 24
     delay: 5
     tags: debug
     when:
       - hostvars[inventory_hostname]['private_ip'] is defined and hostvars[inventory_hostname]['private_ip']
-      - single_node == false
 
   - import_tasks: "RMRedHat.yml"
     when: ansible_os_family == "RedHat"

--- a/roles/opendistro/opendistro-elasticsearch/tasks/main.yml
+++ b/roles/opendistro/opendistro-elasticsearch/tasks/main.yml
@@ -5,90 +5,91 @@
     - generate_certs
 
 - block:
+    - import_tasks: RedHat.yml
+      when: ansible_os_family == 'RedHat'
 
-  - import_tasks: RedHat.yml
-    when: ansible_os_family == 'RedHat'
+    - name: Install OpenDistro
+      package:
+        name: opendistroforelasticsearch-{{ opendistro_version }}
+        state: present
+      register: install
+      tags: install
 
+    - name: Remove elasticsearch configuration file
+      file:
+        path: "{{ opendistro_conf_path }}/elasticsearch.yml"
+        state: absent
+      when: install.changed
+      tags: install
 
-  - name: Install OpenDistro
-    package:
-      name: opendistroforelasticsearch-{{ opendistro_version }}
-      state: present
-    register: install
-    tags: install
+    - name: Copy Configuration File
+      blockinfile:
+        block: "{{ lookup('template', 'elasticsearch.yml.j2') }}"
+        dest: "{{ opendistro_conf_path }}/elasticsearch.yml"
+        create: true
+        group: elasticsearch
+        mode: 0640
+        marker: "## {mark} Opendistro general settings ##"
+      when: install.changed
+      tags: install
 
-  - name: Remove elasticsearch configuration file
-    file:
-      path: "{{ opendistro_conf_path }}/elasticsearch.yml"
-      state: absent
-    when: install.changed
-    tags: install
+    - import_tasks: security_actions.yml
 
-  - name: Copy Configuration File
-    blockinfile:
-      block: "{{ lookup('template', 'elasticsearch.yml.j2') }}"
-      dest: "{{ opendistro_conf_path }}/elasticsearch.yml"
-      create: true
-      group: elasticsearch
-      mode: 0640
-      marker: "## {mark} Opendistro general settings ##"
-    when: install.changed
-    tags: install
+    - name: Configure OpenDistro Elasticsearch JVM memmory.
+      template:
+        src: "templates/jvm.options.j2"
+        dest: /etc/elasticsearch/jvm.options
+        owner: root
+        group: elasticsearch
+        mode: 0644
+        force: yes
+      notify: restart elasticsearch
+      tags: install
 
-  - import_tasks: security_actions.yml
+    - name: Ensure Elasticsearch started and enabled
+      service:
+        name: elasticsearch
+        enabled: true
+        state: started
 
-  - name: Configure OpenDistro Elasticsearch JVM memmory.
-    template:
-      src: "templates/jvm.options.j2"
-      dest: /etc/elasticsearch/jvm.options
-      owner: root
-      group: elasticsearch
-      mode: 0644
-      force: yes
-    notify: restart elasticsearch
-    tags: install
+    - name: Wait for Elasticsearch API
+      uri:
+        url: "https://{{ inventory_hostname }}:{{ opendistro_http_port }}/_cluster/health/"
+        user: "admin" # Default OpenDistro user is always "admin"
+        password: "{{ opendistro_admin_password }}"
+        validate_certs: no
+        status_code: 200,401
+        return_content: yes
+        timeout: 4
+      register: _result
+      until:
+        - _result.json is defined
+        - _result.json.status == "green" or ( _result.json.status == "yellow" and single_node )
+      retries: 24
+      delay: 5
+      tags: debug
+      when:
+        - hostvars[inventory_hostname]['private_ip'] is not defined or not hostvars[inventory_hostname]['private_ip']
 
-  - name: Ensure Elasticsearch started and enabled
-    service:
-      name: elasticsearch
-      enabled: true
-      state: started
+    - name: Wait for Elasticsearch API (Private IP)
+      uri:
+        url: "https://{{ hostvars[inventory_hostname]['private_ip'] }}:{{ opendistro_http_port }}/_cluster/health/"
+        user: "admin" # Default OpenDistro user is always "admin"
+        password: "{{ opendistro_admin_password }}"
+        validate_certs: no
+        status_code: 200,401
+        return_content: yes
+        timeout: 4
+      register: _result
+      until:
+        - _result.json is defined
+        - _result.json.status == "green" or ( _result.json.status == "yellow" and single_node )
+      retries: 24
+      delay: 5
+      tags: debug
+      when:
+        - hostvars[inventory_hostname]['private_ip'] is defined and hostvars[inventory_hostname]['private_ip']
 
-  - name: Wait for Elasticsearch API
-    uri:
-      url: "https://{{ inventory_hostname }}:{{ opendistro_http_port }}/_cluster/health/"
-      user: "admin" # Default OpenDistro user is always "admin"
-      password: "{{ opendistro_admin_password }}"
-      validate_certs: no
-      status_code: 200,401
-      return_content: yes
-      timeout: 4
-    register: _result
-    until: (  _result.json is defined) and (_result.json.status == "green" or ( _result.json.status == "yellow" and single_node ) )
-    retries: 24
-    delay: 5
-    tags: debug
-    when:
-      - hostvars[inventory_hostname]['private_ip'] is not defined or not hostvars[inventory_hostname]['private_ip']
-
-  - name: Wait for Elasticsearch API (Private IP)
-    uri:
-      url: "https://{{ hostvars[inventory_hostname]['private_ip'] }}:{{ opendistro_http_port }}/_cluster/health/"
-      user: "admin" # Default OpenDistro user is always "admin"
-      password: "{{ opendistro_admin_password }}"
-      validate_certs: no
-      status_code: 200,401
-      return_content: yes
-      timeout: 4
-    register: _result
-    until: (  _result.json is defined) and (_result.json.status == "green" or ( _result.json.status == "yellow" and single_node ) )
-    retries: 24
-    delay: 5
-    tags: debug
-    when:
-      - hostvars[inventory_hostname]['private_ip'] is defined and hostvars[inventory_hostname]['private_ip']
-
-  - import_tasks: "RMRedHat.yml"
-    when: ansible_os_family == "RedHat"
-
+    - import_tasks: "RMRedHat.yml"
+      when: ansible_os_family == "RedHat"
   when: perform_installation


### PR DESCRIPTION
Hi team,

The current Elasticsearch API test after opendistro install fails on clusters with yellow status. This PR sets yellow status as a valid one for task success.

Greetings,

JP