### PR TITLE
Fix repository removal task condition

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/tasks/uninstall.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/uninstall.yml
@@ -5,7 +5,7 @@
     repo: deb https://packages.wazuh.com/apt {{ ansible_distribution_release }} main
     state: absent
   changed_when: false
-  when: not wazuh_manager_sources_installation.enabled
+  when: ansible_os_family == "Debian"
 
 - name: RedHat/CentOS/Fedora | Remove Wazuh repository (and clean up left-over metadata)
   yum_repository:


### PR DESCRIPTION
Hi team,

This PR fixes the condition for `Debian/Ubuntu | Remove Wazuh repository` task from `wazuh-manager`.

Greetings,
JP