### PR TITLE
Feature lint remove unused variables

### DIFF
--- a/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
+++ b/roles/elastic-stack/ansible-elasticsearch/defaults/main.yml
@@ -27,9 +27,8 @@ elasticsearch_discovery_nodes:
 elasticsearch_node_data: true
 elasticsearch_node_ingest: true
 
-# X-Pack Security 
+# X-Pack Security
 elasticsearch_xpack_security: false
-elasticsearch_xpack_security_user: elastic
 elasticsearch_xpack_security_password: elastic_pass
 
 node_certs_generator: false

--- a/roles/elastic-stack/ansible-kibana/defaults/main.yml
+++ b/roles/elastic-stack/ansible-kibana/defaults/main.yml
@@ -31,8 +31,6 @@ kibana_ssl_verification_mode: "full"
 elasticsearch_xpack_security_user: elastic
 elasticsearch_xpack_security_password: elastic_pass
 
-node_certs_generator: false
-node_certs_source: /usr/share/elasticsearch
 node_certs_destination: /etc/kibana/certs
 
 # CA Generation

--- a/roles/opendistro/opendistro-elasticsearch/defaults/main.yml
+++ b/roles/opendistro/opendistro-elasticsearch/defaults/main.yml
@@ -35,10 +35,6 @@ package_repos:
 opendistro_sec_plugin_conf_path: /usr/share/elasticsearch/plugins/opendistro_security/securityconfig
 opendistro_sec_plugin_tools_path: /usr/share/elasticsearch/plugins/opendistro_security/tools
 opendistro_conf_path: /etc/elasticsearch/
-es_nodes: |-
-        {% for item in groups['es_cluster'] -%}
-          {{ hostvars[item]['ip'] }}{% if not loop.last %}","{% endif %}
-        {%- endfor %}
 
 # Security password
 opendistro_custom_user: ""

--- a/roles/opendistro/opendistro-elasticsearch/defaults/main.yml
+++ b/roles/opendistro/opendistro-elasticsearch/defaults/main.yml
@@ -1,8 +1,5 @@
 ---
 # Cluster Settings
-es_version: "7.9.1"
-es_major_version: "7.x"
-
 opendistro_version: 1.10.1
 
 single_node: false
@@ -44,7 +41,6 @@ es_nodes: |-
         {%- endfor %}
 
 # Security password
-opendistro_security_password: admin
 opendistro_custom_user: ""
 opendistro_custom_user_role: "admin"
 

--- a/roles/opendistro/opendistro-elasticsearch/defaults/main.yml
+++ b/roles/opendistro/opendistro-elasticsearch/defaults/main.yml
@@ -54,11 +54,6 @@ certs_gen_tool_version: 1.8
 # Url of Search Guard certificates generator tool
 certs_gen_tool_url: "https://search.maven.org/remotecontent?filepath=com/floragunn/search-guard-tlstool/{{ certs_gen_tool_version }}/search-guard-tlstool-{{ certs_gen_tool_version }}.zip"
 
-elasticrepo:
-  apt: 'https://artifacts.elastic.co/packages/7.x/apt'
-  yum: 'https://artifacts.elastic.co/packages/7.x/yum'
-  gpg: 'https://artifacts.elastic.co/GPG-KEY-opendistro'
-  key_id: '46095ACC8548582C1A2699A9D27D666CD88E42B4'
 
 opendistro_admin_password: changeme
 opendistro_kibana_password: changeme

--- a/roles/opendistro/opendistro-kibana/defaults/main.yml
+++ b/roles/opendistro/opendistro-kibana/defaults/main.yml
@@ -44,7 +44,6 @@ kibana_newsfeed_enabled: "false"
 kibana_telemetry_optin: "false"
 kibana_telemetry_enabled: "false"
 
-opendistro_security_user: elastic
 opendistro_admin_password: changeme
 opendistro_kibana_user: kibanaserver
 opendistro_kibana_password: changeme

--- a/roles/opendistro/opendistro-kibana/defaults/main.yml
+++ b/roles/opendistro/opendistro-kibana/defaults/main.yml
@@ -2,10 +2,6 @@
 
 # Kibana configuration
 elasticsearch_http_port: 9200
-elasticsearch_nodes: |-
-        {% for item in groups['es_cluster'] -%}
-          {{ hostvars[item]['ip'] }}{% if not loop.last %}","{% endif %}
-        {%- endfor %}
 elastic_api_protocol: https
 kibana_conf_path: /etc/kibana
 kibana_node_name: node-1

--- a/roles/wazuh/ansible-filebeat-oss/README.md
+++ b/roles/wazuh/ansible-filebeat-oss/README.md
@@ -19,7 +19,6 @@ Role Variables
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
 ```
-  filebeat_output_elasticsearch_enabled: false
   filebeat_output_elasticsearch_hosts:
     - "localhost:9200"
 

--- a/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
+++ b/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
@@ -15,8 +15,6 @@ elasticsearch_security_user: admin
 elasticsearch_security_password: changeme
 # Security plugin
 filebeat_security: true
-filebeat_security_user: admin
-filebeat_security_password: changeme
 filebeat_ssl_dir: /etc/pki/filebeat
 
 # Local path to store the generated certificates (OpenDistro security plugin)

--- a/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
+++ b/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
@@ -3,9 +3,6 @@ filebeat_version: 7.9.1
 
 wazuh_template_branch: v4.0.0
 
-filebeat_create_config: true
-
-filebeat_output_elasticsearch_enabled: false
 filebeat_output_elasticsearch_hosts:
   - "localhost:9200"
 

--- a/roles/wazuh/ansible-filebeat/README.md
+++ b/roles/wazuh/ansible-filebeat/README.md
@@ -19,7 +19,6 @@ Role Variables
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
 ```
-  filebeat_output_elasticsearch_enabled: false
   filebeat_output_elasticsearch_hosts:
     - "localhost:9200"
 

--- a/roles/wazuh/ansible-filebeat/defaults/main.yml
+++ b/roles/wazuh/ansible-filebeat/defaults/main.yml
@@ -5,28 +5,12 @@ wazuh_template_branch: v4.0.0
 
 filebeat_create_config: true
 
-filebeat_prospectors:
-  - input_type: log
-    paths:
-      - "/var/ossec/logs/alerts/alerts.json"
-    document_type: json
-    json.message_key: log
-    json.keys_under_root: true
-    json.overwrite_keys: true
-
 filebeat_node_name: node-1
 
-filebeat_output_elasticsearch_enabled: false
 filebeat_output_elasticsearch_hosts:
   - "localhost:9200"
 
-filebeat_enable_logging: true
-filebeat_log_level: debug
-filebeat_log_dir: /var/log/mybeat
-filebeat_log_filename: mybeat.log
 filebeat_ssl_dir: /etc/pki/filebeat
-filebeat_ssl_certificate_file: ""
-filebeat_ssl_insecure: "false"
 
 filebeat_module_package_url: https://packages.wazuh.com/4.x/filebeat
 filebeat_module_package_name: wazuh-filebeat-0.1.tar.gz
@@ -40,7 +24,7 @@ filebeat_xpack_security: false
 elasticsearch_xpack_security_user: elastic
 elasticsearch_xpack_security_password: elastic_pass
 
-node_certs_generator : false
+node_certs_generator: false
 node_certs_source: /usr/share/elasticsearch
 node_certs_destination: /etc/filebeat/certs
 

--- a/roles/wazuh/ansible-filebeat/defaults/main.yml
+++ b/roles/wazuh/ansible-filebeat/defaults/main.yml
@@ -10,8 +10,6 @@ filebeat_node_name: node-1
 filebeat_output_elasticsearch_hosts:
   - "localhost:9200"
 
-filebeat_ssl_dir: /etc/pki/filebeat
-
 filebeat_module_package_url: https://packages.wazuh.com/4.x/filebeat
 filebeat_module_package_name: wazuh-filebeat-0.1.tar.gz
 filebeat_module_package_path: /tmp/

--- a/roles/wazuh/ansible-filebeat/defaults/main.yml
+++ b/roles/wazuh/ansible-filebeat/defaults/main.yml
@@ -24,10 +24,7 @@ filebeat_xpack_security: false
 elasticsearch_xpack_security_user: elastic
 elasticsearch_xpack_security_password: elastic_pass
 
-node_certs_generator: false
-node_certs_source: /usr/share/elasticsearch
 node_certs_destination: /etc/filebeat/certs
-
 
 # CA Generation
 master_certs_path: "{{ playbook_dir }}/es_certs"


### PR DESCRIPTION
For more information see #470. I got a couple extra unused variables by quick playing with shell scripting and yq/jq tools to parse each roles `defaults.yml` and extract variables for a later grep and count.