### PR TITLE
Feature lint roles configurations

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,15 @@
 ---
+use_default_rules: true
+parseable: true
+quiet: true
+verbosity: 1
+
+# State that naming for now should be a warning
+# 106: ansible role name does not conform to pattern [a-z][a-z0-9_]+$
 warn_list:
   - '106'
-  - '303'
+
+# This is for false positives
+# 504: Do not use 'local_action', use 'delegate_to: localhost'
+skip_list:
+  - '504'

--- a/roles/elastic-stack/ansible-kibana/tasks/main.yml
+++ b/roles/elastic-stack/ansible-kibana/tasks/main.yml
@@ -100,6 +100,7 @@
 
 - name: Ensuring Kibana directory owner
   file:
+    # noqa 208
     path: "/usr/share/kibana"
     state: directory
     owner: kibana


### PR DESCRIPTION
For more information see issue #490

Adds `.ansible-lint` settings for parse-ability and a single rule exclusion for kibana role.
