### PR TITLE
Hotfix wazuh-agent role:  jwt token task delegation

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -38,7 +38,7 @@ wazuh_agent_yum_lock_timeout: 30
 api_pass: wazuh
 authd_pass: ''
 
-wazuh_api_reachable_from_agent: false
+wazuh_api_reachable_from_agent: yes
 wazuh_profile_centos: 'centos, centos7, centos7.6'
 wazuh_profile_ubuntu: 'ubuntu, ubuntu18, ubuntu18.04'
 wazuh_auto_restart: 'yes'

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
@@ -157,7 +157,7 @@
         validate_certs: '{{ target_manager.validate_certs | default(false) }}'
       become: no
       no_log: '{{ wazuh_agent_nolog_sensible | bool }}'
-      delegate_to: "{{ 'localhost' if not wazuh_api_reachable_from_agent else inventory_hostname }}"
+      delegate_to: '{{ inventory_hostname if wazuh_api_reachable_from_agent else "localhost" }}'
       changed_when: api_agent_post.json.error == 0
       register: api_agent_post
       vars:
@@ -178,7 +178,7 @@
         validate_certs: '{{ target_manager.validate_certs | default(false) }}'
       become: no
       no_log: '{{ wazuh_agent_nolog_sensible | bool }}'
-      delegate_to: "{{ 'localhost' if not wazuh_api_reachable_from_agent else inventory_hostname }}"
+      delegate_to: '{{ inventory_hostname if wazuh_api_reachable_from_agent else "localhost" }}'
       register: api_agent_validation
       vars:
         agent_id: '{{ api_agent_post.json.data.id }}'

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
@@ -133,7 +133,7 @@
         force_basic_auth: yes
         validate_certs: '{{ target_manager.validate_certs | default(false) }}'
       no_log: '{{ wazuh_agent_nolog_sensible | bool }}'
-      delegate_to: '{{ ansible_host if wazuh_api_reachable_from_agent else "localhost"  }}'
+      delegate_to: '{{ inventory_hostname if wazuh_api_reachable_from_agent else "localhost" }}'
       changed_when: api_jwt_result.json.error == 0
       register: api_jwt_result
       become: no


### PR DESCRIPTION
This PR is a hotfix for a typo (`ansible_host` in one of the tasks, instead of `inventory_hostname`) that causes REST enrollment error when you connect to remote networks (such as AWS in a private network), this didn't show up on testing because containers are on the same host. I've also updated the default for `wazuh_api_reachable_from_agent`.