### PR TITLE
randomly generated passwords must obey some constraints

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/files/create_user.py
+++ b/roles/wazuh/ansible-wazuh-manager/files/create_user.py
@@ -69,13 +69,20 @@ if __name__ == "__main__":
     # set a random password for all other users
     for name, id in initial_users.items():
         if name != username:
+            specials = "@$!%*?&-_"
             random_pass = "".join(
+                [
+                    random.choice(string.ascii_uppercase),
+                    random.choice(string.ascii_lowercase),
+                    random.choice(string.digits),
+                    random.choice(specials),
+                ] +
                 random.choices(
                     string.ascii_uppercase
                     + string.ascii_lowercase
                     + string.digits
-                    + "@$!%*?&-_",
-                    k=16,
+                    + specials,
+                    k=14,
                 )
             )
             update_user(


### PR DESCRIPTION
The password constraints of security.py require at least one digit,
one lower case, one upper case and one special character.

https://github.com/wazuh/wazuh/blob/master/framework/wazuh/security.py#L22

Fixes: https://github.com/wazuh/wazuh-ansible/issues/518

The generated passwords can be verified with

```
import random
import re
import string

_user_password = re.compile(r'^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$')

def t():
    specials = "@$!%*?&-_"
    random_pass = "".join(
        [
            random.choice(string.ascii_uppercase),
            random.choice(string.ascii_lowercase),        
            random.choice(string.digits),        
            random.choice(specials),
        ] +
        random.choices(
            string.ascii_uppercase
            + string.ascii_lowercase
            + string.digits
            + specials,
            k=16,
        )
    )
    if not _user_password.match(random_pass):
        print(random_pass)

while True:
    t()
```