### PR TITLE
add localfile labels to agent ossec.conf template

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
+++ b/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
@@ -353,6 +353,11 @@
     {% endif %}
   {% else %}
     <location>{{ localfile.location }}</location>
+    {% if localfile.format == 'json' %}
+    {% for label in localfile.label %}
+    <label key="{{ label.key }}">{{ label.value }}</label>
+    {% endfor %}
+    {% endif %}
     {% endif %}
   </localfile>
   {% endfor %}
@@ -371,6 +376,11 @@
       {% endif %}
   {% else %}
       <location>{{ localfile.location }}</location>
+      {% if localfile.format == 'json' %}
+      {% for label in localfile.label %}
+      <label key="{{ label.key }}">{{ label.value }}</label>
+      {% endfor %}
+      {% endif %}
   {% endif %}
   </localfile>
   {% endfor %}
@@ -389,6 +399,11 @@
       {% endif %}
     {% else %}
       <location>{{ localfile.location }}</location>
+      {% if localfile.format == 'json' %}
+      {% for label in localfile.label %}
+      <label key="{{ label.key }}">{{ label.value }}</label>
+      {% endfor %}
+      {% endif %}
   {% endif %}
   </localfile>
   {% endfor %}
@@ -404,6 +419,11 @@
       <query>{{ localfile.query}}</query>
   {% else %}
       <location>{{ localfile.location }}</location>
+      {% if localfile.format == 'json' %}
+      {% for label in localfile.label %}
+      <label key="{{ label.key }}">{{ label.value }}</label>
+      {% endfor %}
+      {% endif %}
   {% endif %}
   </localfile>
   {% endfor %}


### PR DESCRIPTION
This change enables generating a stanza such as

```
<localfile>
  <location>/var/log/myapp/log.json</location>
  <log_format>json</log_format>
  <label key="@source">myapp</label>
  <label key="agent.type">webserver</label>
</localfile>
```

from the `wazuh_agent_config` snippet:

```
                - format: json
                  location: /var/log/myapp/log.json
                  label:
                    - key: "@source"
                      value: "myapp"    
                    - key: "agent.type"
                      value: "webserver"
```