### PR TITLE
Rename daemons from ossec-* to wazuh-*

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -40,7 +40,7 @@ def test_wazuh_services_are_running(host):
     assert 'wazuh-remoted' in output
     assert 'wazuh-logcollector' in output
     assert 'wazuh-analysisd' in output
-    assert 'ossec-syscheckd' in output
+    assert 'wazuh-syscheckd' in output
 
 
 @pytest.mark.parametrize("wazuh_file, wazuh_owner, wazuh_group, wazuh_mode", [

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -38,7 +38,7 @@ def test_wazuh_services_are_running(host):
     assert 'wazuh-execd' in output
     assert 'ossec-monitord' in output
     assert 'ossec-remoted' in output
-    assert 'ossec-logcollector' in output
+    assert 'wazuh-logcollector' in output
     assert 'wazuh-analysisd' in output
     assert 'ossec-syscheckd' in output
 

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -39,7 +39,7 @@ def test_wazuh_services_are_running(host):
     assert 'ossec-monitord' in output
     assert 'ossec-remoted' in output
     assert 'ossec-logcollector' in output
-    assert 'ossec-analysisd' in output
+    assert 'wazuh-analysisd' in output
     assert 'ossec-syscheckd' in output
 
 

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -37,7 +37,7 @@ def test_wazuh_services_are_running(host):
     assert 'wazuh-db' in output
     assert 'wazuh-execd' in output
     assert 'wazuh-monitord' in output
-    assert 'ossec-remoted' in output
+    assert 'wazuh-remoted' in output
     assert 'wazuh-logcollector' in output
     assert 'wazuh-analysisd' in output
     assert 'ossec-syscheckd' in output

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -32,10 +32,10 @@ def test_wazuh_services_are_running(host):
     output = host.check_output(
         'ps aux | grep ossec | tr -s " " | cut -d" " -f11'
         )
-    assert 'ossec-authd' in output
+    assert 'wazuh-authd' in output
     assert 'wazuh-modulesd' in output
     assert 'wazuh-db' in output
-    assert 'ossec-execd' in output
+    assert 'wazuh-execd' in output
     assert 'ossec-monitord' in output
     assert 'ossec-remoted' in output
     assert 'ossec-logcollector' in output

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -36,7 +36,7 @@ def test_wazuh_services_are_running(host):
     assert 'wazuh-modulesd' in output
     assert 'wazuh-db' in output
     assert 'wazuh-execd' in output
-    assert 'ossec-monitord' in output
+    assert 'wazuh-monitord' in output
     assert 'ossec-remoted' in output
     assert 'wazuh-logcollector' in output
     assert 'wazuh-analysisd' in output

--- a/molecule/distributed-wazuh-elk-xpack/tests/test_default.py
+++ b/molecule/distributed-wazuh-elk-xpack/tests/test_default.py
@@ -40,7 +40,7 @@ def test_wazuh_services_are_running(host):
     assert 'wazuh-remoted' in output
     assert 'wazuh-logcollector' in output
     assert 'wazuh-analysisd' in output
-    assert 'ossec-syscheckd' in output
+    assert 'wazuh-syscheckd' in output
 
 
 @pytest.mark.parametrize("wazuh_file, wazuh_owner, wazuh_group, wazuh_mode", [

--- a/molecule/distributed-wazuh-elk-xpack/tests/test_default.py
+++ b/molecule/distributed-wazuh-elk-xpack/tests/test_default.py
@@ -38,7 +38,7 @@ def test_wazuh_services_are_running(host):
     assert 'wazuh-execd' in output
     assert 'ossec-monitord' in output
     assert 'ossec-remoted' in output
-    assert 'ossec-logcollector' in output
+    assert 'wazuh-logcollector' in output
     assert 'wazuh-analysisd' in output
     assert 'ossec-syscheckd' in output
 

--- a/molecule/distributed-wazuh-elk-xpack/tests/test_default.py
+++ b/molecule/distributed-wazuh-elk-xpack/tests/test_default.py
@@ -39,7 +39,7 @@ def test_wazuh_services_are_running(host):
     assert 'ossec-monitord' in output
     assert 'ossec-remoted' in output
     assert 'ossec-logcollector' in output
-    assert 'ossec-analysisd' in output
+    assert 'wazuh-analysisd' in output
     assert 'ossec-syscheckd' in output
 
 

--- a/molecule/distributed-wazuh-elk-xpack/tests/test_default.py
+++ b/molecule/distributed-wazuh-elk-xpack/tests/test_default.py
@@ -37,7 +37,7 @@ def test_wazuh_services_are_running(host):
     assert 'wazuh-db' in output
     assert 'wazuh-execd' in output
     assert 'wazuh-monitord' in output
-    assert 'ossec-remoted' in output
+    assert 'wazuh-remoted' in output
     assert 'wazuh-logcollector' in output
     assert 'wazuh-analysisd' in output
     assert 'ossec-syscheckd' in output

--- a/molecule/distributed-wazuh-elk-xpack/tests/test_default.py
+++ b/molecule/distributed-wazuh-elk-xpack/tests/test_default.py
@@ -32,10 +32,10 @@ def test_wazuh_services_are_running(host):
     output = host.check_output(
         'ps aux | grep ossec | tr -s " " | cut -d" " -f11'
         )
-    assert 'ossec-authd' in output
+    assert 'wazuh-authd' in output
     assert 'wazuh-modulesd' in output
     assert 'wazuh-db' in output
-    assert 'ossec-execd' in output
+    assert 'wazuh-execd' in output
     assert 'ossec-monitord' in output
     assert 'ossec-remoted' in output
     assert 'ossec-logcollector' in output

--- a/molecule/distributed-wazuh-elk-xpack/tests/test_default.py
+++ b/molecule/distributed-wazuh-elk-xpack/tests/test_default.py
@@ -36,7 +36,7 @@ def test_wazuh_services_are_running(host):
     assert 'wazuh-modulesd' in output
     assert 'wazuh-db' in output
     assert 'wazuh-execd' in output
-    assert 'ossec-monitord' in output
+    assert 'wazuh-monitord' in output
     assert 'ossec-remoted' in output
     assert 'wazuh-logcollector' in output
     assert 'wazuh-analysisd' in output

--- a/molecule/distributed-wazuh-elk/tests/test_default.py
+++ b/molecule/distributed-wazuh-elk/tests/test_default.py
@@ -40,7 +40,7 @@ def test_wazuh_services_are_running(host):
     assert 'wazuh-remoted' in output
     assert 'wazuh-logcollector' in output
     assert 'wazuh-analysisd' in output
-    assert 'ossec-syscheckd' in output
+    assert 'wazuh-syscheckd' in output
 
 
 @pytest.mark.parametrize("wazuh_file, wazuh_owner, wazuh_group, wazuh_mode", [

--- a/molecule/distributed-wazuh-elk/tests/test_default.py
+++ b/molecule/distributed-wazuh-elk/tests/test_default.py
@@ -38,7 +38,7 @@ def test_wazuh_services_are_running(host):
     assert 'wazuh-execd' in output
     assert 'ossec-monitord' in output
     assert 'ossec-remoted' in output
-    assert 'ossec-logcollector' in output
+    assert 'wazuh-logcollector' in output
     assert 'wazuh-analysisd' in output
     assert 'ossec-syscheckd' in output
 

--- a/molecule/distributed-wazuh-elk/tests/test_default.py
+++ b/molecule/distributed-wazuh-elk/tests/test_default.py
@@ -39,7 +39,7 @@ def test_wazuh_services_are_running(host):
     assert 'ossec-monitord' in output
     assert 'ossec-remoted' in output
     assert 'ossec-logcollector' in output
-    assert 'ossec-analysisd' in output
+    assert 'wazuh-analysisd' in output
     assert 'ossec-syscheckd' in output
 
 

--- a/molecule/distributed-wazuh-elk/tests/test_default.py
+++ b/molecule/distributed-wazuh-elk/tests/test_default.py
@@ -37,7 +37,7 @@ def test_wazuh_services_are_running(host):
     assert 'wazuh-db' in output
     assert 'wazuh-execd' in output
     assert 'wazuh-monitord' in output
-    assert 'ossec-remoted' in output
+    assert 'wazuh-remoted' in output
     assert 'wazuh-logcollector' in output
     assert 'wazuh-analysisd' in output
     assert 'ossec-syscheckd' in output

--- a/molecule/distributed-wazuh-elk/tests/test_default.py
+++ b/molecule/distributed-wazuh-elk/tests/test_default.py
@@ -32,10 +32,10 @@ def test_wazuh_services_are_running(host):
     output = host.check_output(
         'ps aux | grep ossec | tr -s " " | cut -d" " -f11'
         )
-    assert 'ossec-authd' in output
+    assert 'wazuh-authd' in output
     assert 'wazuh-modulesd' in output
     assert 'wazuh-db' in output
-    assert 'ossec-execd' in output
+    assert 'wazuh-execd' in output
     assert 'ossec-monitord' in output
     assert 'ossec-remoted' in output
     assert 'ossec-logcollector' in output

--- a/molecule/distributed-wazuh-elk/tests/test_default.py
+++ b/molecule/distributed-wazuh-elk/tests/test_default.py
@@ -36,7 +36,7 @@ def test_wazuh_services_are_running(host):
     assert 'wazuh-modulesd' in output
     assert 'wazuh-db' in output
     assert 'wazuh-execd' in output
-    assert 'ossec-monitord' in output
+    assert 'wazuh-monitord' in output
     assert 'ossec-remoted' in output
     assert 'wazuh-logcollector' in output
     assert 'wazuh-analysisd' in output

--- a/molecule/distributed-wazuh-odfe/tests/test_default.py
+++ b/molecule/distributed-wazuh-odfe/tests/test_default.py
@@ -40,7 +40,7 @@ def test_wazuh_services_are_running(host):
     assert 'wazuh-remoted' in output
     assert 'wazuh-logcollector' in output
     assert 'wazuh-analysisd' in output
-    assert 'ossec-syscheckd' in output
+    assert 'wazuh-syscheckd' in output
 
 
 @pytest.mark.parametrize("wazuh_file, wazuh_owner, wazuh_group, wazuh_mode", [

--- a/molecule/distributed-wazuh-odfe/tests/test_default.py
+++ b/molecule/distributed-wazuh-odfe/tests/test_default.py
@@ -38,7 +38,7 @@ def test_wazuh_services_are_running(host):
     assert 'wazuh-execd' in output
     assert 'ossec-monitord' in output
     assert 'ossec-remoted' in output
-    assert 'ossec-logcollector' in output
+    assert 'wazuh-logcollector' in output
     assert 'wazuh-analysisd' in output
     assert 'ossec-syscheckd' in output
 

--- a/molecule/distributed-wazuh-odfe/tests/test_default.py
+++ b/molecule/distributed-wazuh-odfe/tests/test_default.py
@@ -39,7 +39,7 @@ def test_wazuh_services_are_running(host):
     assert 'ossec-monitord' in output
     assert 'ossec-remoted' in output
     assert 'ossec-logcollector' in output
-    assert 'ossec-analysisd' in output
+    assert 'wazuh-analysisd' in output
     assert 'ossec-syscheckd' in output
 
 

--- a/molecule/distributed-wazuh-odfe/tests/test_default.py
+++ b/molecule/distributed-wazuh-odfe/tests/test_default.py
@@ -37,7 +37,7 @@ def test_wazuh_services_are_running(host):
     assert 'wazuh-db' in output
     assert 'wazuh-execd' in output
     assert 'wazuh-monitord' in output
-    assert 'ossec-remoted' in output
+    assert 'wazuh-remoted' in output
     assert 'wazuh-logcollector' in output
     assert 'wazuh-analysisd' in output
     assert 'ossec-syscheckd' in output

--- a/molecule/distributed-wazuh-odfe/tests/test_default.py
+++ b/molecule/distributed-wazuh-odfe/tests/test_default.py
@@ -32,10 +32,10 @@ def test_wazuh_services_are_running(host):
     output = host.check_output(
         'ps aux | grep ossec | tr -s " " | cut -d" " -f11'
         )
-    assert 'ossec-authd' in output
+    assert 'wazuh-authd' in output
     assert 'wazuh-modulesd' in output
     assert 'wazuh-db' in output
-    assert 'ossec-execd' in output
+    assert 'wazuh-execd' in output
     assert 'ossec-monitord' in output
     assert 'ossec-remoted' in output
     assert 'ossec-logcollector' in output

--- a/molecule/distributed-wazuh-odfe/tests/test_default.py
+++ b/molecule/distributed-wazuh-odfe/tests/test_default.py
@@ -36,7 +36,7 @@ def test_wazuh_services_are_running(host):
     assert 'wazuh-modulesd' in output
     assert 'wazuh-db' in output
     assert 'wazuh-execd' in output
-    assert 'ossec-monitord' in output
+    assert 'wazuh-monitord' in output
     assert 'ossec-remoted' in output
     assert 'wazuh-logcollector' in output
     assert 'wazuh-analysisd' in output

--- a/roles/wazuh/ansible-wazuh-manager/tasks/installation_from_sources.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/installation_from_sources.yml
@@ -2,8 +2,8 @@
 # Wazuh Manager
   - name: Check if Wazuh Manager is already installed
     stat:
-      path: /var/ossec/bin/ossec-control
-    register: wazuh_ossec_control
+      path: /var/ossec/bin/wazuh-control
+    register: wazuh_control_path
 
   - name: Installing Wazuh Manager from sources
     block:
@@ -114,7 +114,7 @@
           state: absent
 
     when:
-      - not wazuh_ossec_control.stat.exists
+      - not wazuh_control_path.stat.exists
       - wazuh_manager_sources_installation.enabled
     tags:
       - manager

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -186,7 +186,7 @@
 - name: Check if client-syslog is enabled
   shell: |
     set -o pipefail
-    "grep -c 'ossec-csyslogd' /var/ossec/bin/.process_list | xargs echo"
+    "grep -c 'wazuh-csyslogd' /var/ossec/bin/.process_list | xargs echo"
   args:
     removes: /var/ossec/bin/.process_list
     executable: /bin/bash

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -197,7 +197,7 @@
     - config
 
 - name: Enable client-syslog
-  command: /var/ossec/bin/ossec-control enable client-syslog
+  command: /var/ossec/bin/wazuh-control enable client-syslog
   notify: restart wazuh-manager
   when:
     - csyslog_enabled.stdout == '0' or "skipped" in csyslog_enabled.stdout
@@ -218,8 +218,7 @@
   tags:
     - config
 
-- name: Enable ossec-agentlessd
-  command: /var/ossec/bin/ossec-control enable agentless
+  command: /var/ossec/bin/wazuh-control enable agentless
   notify: restart wazuh-manager
   when:
     - agentlessd_enabled.stdout == '0' or "skipped" in agentlessd_enabled.stdout

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -248,7 +248,7 @@
     - init
     - config
 
-- name: Ossec-authd password
+- name: wazuh-authd password
   template:
     src: authd_pass.j2
     dest: "/var/ossec/etc/authd.pass"

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -205,23 +205,24 @@
   tags:
     - config
 
-- name: Check if ossec-agentlessd is enabled
+- name: Check if wazuh-agentlessd is enabled
   shell: |
     set -o pipefail
-    "grep -c 'ossec-agentlessd' /var/ossec/bin/.process_list | xargs echo"
+    "grep -c 'wazuh-agentlessd' /var/ossec/bin/.process_list | xargs echo"
   args:
     removes: /var/ossec/bin/.process_list
     executable: /bin/bash
   changed_when: false
   check_mode: false
-  register: agentlessd_enabled
+  register: wazuh_agentlessd_enabled
   tags:
     - config
 
+- name: Enable wazuh-agentlessd
   command: /var/ossec/bin/wazuh-control enable agentless
   notify: restart wazuh-manager
   when:
-    - agentlessd_enabled.stdout == '0' or "skipped" in agentlessd_enabled.stdout
+    - wazuh_agentlessd_enabled.stdout == '0' or "skipped" in wazuh_agentlessd_enabled.stdout
     - agentless_creds is defined
   tags:
     - config


### PR DESCRIPTION
For details, see issue #520.
Quickchecking the `wazuh-ansible` repo with ripgrep:

```shell
$  rg ossec-agentd
$  rg ossec-agentlessd
$  rg ossec-analysisd
$  rg ossec-authd
roles/wazuh/ansible-wazuh-manager/tasks/main.yml
55:  stat: path=/etc/init.d/ossec-authd
61:  stat: path=/lib/systemd/system/ossec-authd.service
66:- name: Ensure ossec-authd service is disabled
67:  service: name=ossec-authd enabled=no state=stopped
75:    - "/etc/init.d/ossec-authd"
76:    - "/lib/systemd/system/ossec-authd.service"
$  rg ossec-csyslogd
$  rg ossec-dbd
$  rg ossec-execd
$  rg ossec-integratord
$  rg ossec-logcollector
$  rg ossec-maild
$  rg ossec-monitord
$  rg ossec-remoted
$  rg ossec-reportd
$  rg ossec-syscheckd
$  rg ossec-agent.exe
$  rg ossec-agent-eventchannel.exe
$  rg ossec-rootcheck.exe
```

In the case of `ossec-authd`, it's still referenced because we have tasks to remove old ossec-authd.