### PR TITLE
Rename tools from ossec-* to wazuh-*

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/tasks/installation_from_sources.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/installation_from_sources.yml
@@ -2,8 +2,8 @@
 # Wazuh Manager
   - name: Check if Wazuh Manager is already installed
     stat:
-      path: /var/ossec/bin/ossec-control
-    register: wazuh_ossec_control
+      path: /var/ossec/bin/wazuh-control
+    register: wazuh_control_path
 
   - name: Installing Wazuh Manager from sources
     block:
@@ -114,7 +114,7 @@
           state: absent
 
     when:
-      - not wazuh_ossec_control.stat.exists
+      - not wazuh_control_path.stat.exists
       - wazuh_manager_sources_installation.enabled
     tags:
       - manager

--- a/roles/wazuh/ansible-wazuh-manager/tasks/installation_from_sources.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/installation_from_sources.yml
@@ -2,7 +2,7 @@
 # Wazuh Manager
   - name: Check if Wazuh Manager is already installed
     stat:
-      path: "{{ wazuh_dir }}"/bin/wazuh-control
+      path: "{{ wazuh_dir }}/bin/wazuh-control"
     register: wazuh_control_path
 
   - name: Installing Wazuh Manager from sources

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -197,7 +197,7 @@
     - config
 
 - name: Enable client-syslog
-  command: /var/ossec/bin/ossec-control enable client-syslog
+  command: /var/ossec/bin/wazuh-control enable client-syslog
   notify: restart wazuh-manager
   when:
     - csyslog_enabled.stdout == '0' or "skipped" in csyslog_enabled.stdout
@@ -219,7 +219,7 @@
     - config
 
 - name: Enable ossec-agentlessd
-  command: /var/ossec/bin/ossec-control enable agentless
+  command: /var/ossec/bin/wazuh-control enable agentless
   notify: restart wazuh-manager
   when:
     - agentlessd_enabled.stdout == '0' or "skipped" in agentlessd_enabled.stdout

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -197,7 +197,7 @@
     - config
 
 - name: Enable client-syslog
-  command: "{{ wazuh_dir }}"/bin/wazuh-control enable client-syslog
+  command: "{{ wazuh_dir }}/bin/wazuh-control enable client-syslog"
   notify: restart wazuh-manager
   when:
     - csyslog_enabled.stdout == '0' or "skipped" in csyslog_enabled.stdout


### PR DESCRIPTION
For details see #516. A quick search for references:

```bash
rg ossec-control
rg ossec-regex
rg rootcheck_control
rg syscheck_control
rg syscheck_update
rg ossec-logtest
rg ossec-makelists
```

Shows no output. A greedier search with `rg ossec-` shows items from PR#522 and unrelated items. 

