### PR TITLE
Manager: lower agentless and authd credentials variable precedence

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/README.md
+++ b/roles/wazuh/ansible-wazuh-manager/README.md
@@ -23,37 +23,6 @@ wazuh_manager_config: []
 shared_agent_config: []
 ```
 
-Vault variables
-----------------
-
-### vars/agentless_creds.yml
-This file has the agenless credentials.
-```
----
- agentless_creds:
- - type: ssh_integrity_check_linux
-   frequency: 3600
-   host: root@example.net
-   state: periodic
-   arguments: '/bin /etc/ /sbin'
-   passwd: qwerty
-```
-
-### vars/wazuh_api_creds.yml
-This file has user and password created in httpasswd format.
-```
----
-wazuh_api_user:
-  - "foo:$apr1$/axqZYWQ$Xo/nz/IG3PdwV82EnfYKh/"
-```
-
-### vars/authd_pass.yml
-This file has the password to be used for the authd daemon.
-```
----
-authd_pass: foobar
-```
-
 Default config
 --------------
 

--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -42,8 +42,11 @@ wazuh_manager_repo:
   key_id: '0DCFCA5547B19D2A6099506096B3EE5F29111145'
 
 # We recommend the use of ansible-vault to protect Wazuh, api, agentless and authd credentials.
+
+# Deprecated, see wazuh_manager_authd
 authd_pass: foobar
 
+# Deprecated, see wazuh_manager_agentless
 agentless_creds: []
 # - type: ssh_integrity_check_linux
 #   frequency: 3600
@@ -374,6 +377,7 @@ wazuh_manager_authd:
   force_insert: 'yes'
   force_time: 0
   purge: 'yes'
+  password: '{{ authd_pass }}'
   use_password: 'no'
   limit_maxagents: 'yes'
   ciphers: 'HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH'
@@ -382,6 +386,9 @@ wazuh_manager_authd:
   ssl_manager_cert: 'sslmanager.cert'
   ssl_manager_key: 'sslmanager.key'
   ssl_auto_negotiate: 'no'
+
+# Agentless
+wazuh_manager_agentless: '{{ agentless_creds }}'
 
 ## Cluster
 wazuh_manager_cluster:

--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -41,6 +41,17 @@ wazuh_manager_repo:
   gpg: 'https://packages.wazuh.com/key/GPG-KEY-WAZUH'
   key_id: '0DCFCA5547B19D2A6099506096B3EE5F29111145'
 
+# We recommend the use of ansible-vault to protect Wazuh, api, agentless and authd credentials.
+authd_pass: foobar
+
+agentless_creds: []
+# - type: ssh_integrity_check_linux
+#   frequency: 3600
+#   host: root@example.net
+#   state: periodic
+#   arguments: '/bin /etc/ /sbin'
+#   passwd: qwerty
+
 
 ##########################################
 ### Wazuh-OSSEC

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -165,16 +165,6 @@
     - init
     - config
 
-- name: Retrieving Agentless Credentials
-  include_vars: agentless_creds.yml
-  tags:
-    - config
-
-- name: Retrieving authd Credentials
-  include_vars: authd_pass.yml
-  tags:
-    - config
-
 - name: Check if syslog output is enabled
   set_fact: syslog_output=true
   when: item.server is not none

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -278,20 +278,14 @@
     - wazuh_manager_config.cluster.node_type == "master"
 
 - name: Agentless Hosts & Passwd
-  template:
-    src: agentless.j2
-    dest: "/var/ossec/agentless/.passlist_tmp"
+  copy:
+    content: "{{ lookup('template', 'templates/agentless.j2') | b64encode }}"
+    dest: /var/ossec/agentless/.passlist
     owner: root
     group: root
     mode: 0644
   no_log: true
-  when: agentless_creds is defined
-  tags:
-    - config
-
-- name: Encode the secret
-  shell: /usr/bin/base64 /var/ossec/agentless/.passlist_tmp > /var/ossec/agentless/.passlist && rm /var/ossec/agentless/.passlist_tmp
-  when: agentless_creds is defined
+  when: wazuh_manager_agentless | length > 0
   tags:
     - config
 

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -213,7 +213,7 @@
   notify: restart wazuh-manager
   when:
     - agentlessd_enabled.stdout == '0' or "skipped" in agentlessd_enabled.stdout
-    - agentless_creds is defined
+    - wazuh_manager_agentless | length > 0
   tags:
     - config
 

--- a/roles/wazuh/ansible-wazuh-manager/templates/agentless.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/agentless.j2
@@ -1,3 +1,3 @@
-{% for agentless in agentless_creds %}
+{% for agentless in wazuh_manager_agentless %}
 {{ agentless.host }}|{{ agentless.passwd }}
 {% endfor %}

--- a/roles/wazuh/ansible-wazuh-manager/templates/agentless.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/agentless.j2
@@ -1,3 +1,3 @@
 {% for agentless in wazuh_manager_agentless %}
-{{ agentless.host }}|{{ agentless.passwd }}
+{{ agentless.host }}|{{ agentless.passwd }}|{{ agentless.passwd_additional | default('') }}
 {% endfor %}

--- a/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
@@ -374,8 +374,7 @@
   </command>
 {% endfor %}
 
-{% if agentless_creds is defined %}
-{% for agentless in agentless_creds %}
+{% for agentless in wazuh_manager_agentless %}
   <agentless>
     <type>{{ agentless.type }}</type>
     <frequency>{{ agentless.frequency }}</frequency>
@@ -386,7 +385,6 @@
     {% endif %}
   </agentless>
 {% endfor %}
-{% endif -%}
 
 {% if wazuh_manager_config.active_responses is defined %}
   {% for response in wazuh_manager_config.active_responses %}

--- a/roles/wazuh/ansible-wazuh-manager/vars/agentless_creds.yml
+++ b/roles/wazuh/ansible-wazuh-manager/vars/agentless_creds.yml
@@ -1,8 +1,0 @@
----
-# agentless_creds:
-# - type: ssh_integrity_check_linux
-#   frequency: 3600
-#   host: root@example.net
-#   state: periodic
-#   arguments: '/bin /etc/ /sbin'
-#   passwd: qwerty

--- a/roles/wazuh/ansible-wazuh-manager/vars/authd_pass.yml
+++ b/roles/wazuh/ansible-wazuh-manager/vars/authd_pass.yml
@@ -1,2 +1,0 @@
----
-# authd_pass: foobar


### PR DESCRIPTION
Similarly to issue 498 (which is for wazuh-agent), this PR lowers the precedence of credential variables to make more options available regarding where to override them in the [Ansible precedence chain](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable). This PR is a draft because I was not able to build a lab to properly test the changes.
