### PR TITLE
Fix invalid Jinja2 syntax

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-shared-agent.conf.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-shared-agent.conf.j2
@@ -66,8 +66,8 @@
        {% endif %}
        {% endif %}
        {% if localfile.format == 'json' and localfile.labels is defined %}
-       {% for key, value in localfile.labels.items() %}
-       <label key="{{ key }}">{{ value }}</label>
+       {% for item in localfile.labels %}
+       <label key="{{ item.key }}">{{ item.value }}</label>
        {% endfor %}
        {% endif %}
        {% if localfile.target is defined %}
@@ -93,7 +93,7 @@
     <!-- Frequency that rootcheck is executed - every 12 hours -->
     <frequency>{{ agent_config.rootcheck.frequency }}</frequency>
 
-    {% if agent_config.rootcheck.cis_distribution_filename is not none %}
+    {% if agent_config.rootcheck.cis_distribution_filename is defined %}
     <system_audit>/var/ossec/etc/shared/default/{{ agent_config.rootcheck.cis_distribution_filename }}</system_audit>
     {% endif %}
     <skip_nfs>yes</skip_nfs>


### PR DESCRIPTION
_This PR was [originally](https://github.com/wazuh/wazuh-ansible/pull/526) opened by @kravietz_

### Description
`localfiles` blocks with `format = json` and labels were not correctly rendered. The following settings led to error:
```yaml
      - format: 'json'
        location: '/path/to/logs/test.log'
        labels: 
          - key: '@source'
            value: myapp
          - key: '@source2'
            value: myapp2
```
Related Ansible error:
```
TASK [../roles/wazuh/ansible-wazuh-manager : Configure the shared-agent.conf] *******************************************************************************************************************
fatal: [test]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'list object' has no attribute 'items'"}
```
-----
After adding the @kravietz fix, the `Configure the shared-agent.conf` task ends successfully and the `localfile` configuration block is rendered as expected:

```
TASK [../roles/wazuh/ansible-wazuh-manager : Configure the shared-agent.conf] *******************************************************************************************************************
changed: [test]
```
Correct output localfile block inside `agent.conf `file
```xml
    <localfile>
       <log_format>json</log_format>
       <location>/path/to/logs/test.log</location>
       <label key="@source">myapp</label>
       <label key="@source2">myapp2</label>
    </localfile>
```


