### PR TITLE
opendistro-kibana role: replace default user

### DIFF
--- a/roles/opendistro/opendistro-kibana/defaults/main.yml
+++ b/roles/opendistro/opendistro-kibana/defaults/main.yml
@@ -41,7 +41,7 @@ kibana_telemetry_optin: "false"
 kibana_telemetry_enabled: "false"
 
 opendistro_admin_password: changeme
-opendistro_kibana_user: kibanaserver
+opendistro_kibana_user: admin
 opendistro_kibana_password: changeme
 local_certs_path: "{{ playbook_dir }}/opendistro/certificates"
 


### PR DESCRIPTION
Hi team,

This PR replaces the default value for `opendistro_kibana_user` to `admin`. The current permissions scope for `kibanaserver` leads to the following error when generating reports. ( _This error was originally reported in our community Slack channel by **grgo**_) :

![image](https://user-images.githubusercontent.com/14923294/103007450-bf4bda00-4533-11eb-8a4a-d02a0aa0e7fe.png)


Greetings,
JP