### PR TITLE
example playbooks: add missing become clause

### DIFF
--- a/playbooks/wazuh-agent.yml
+++ b/playbooks/wazuh-agent.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: <your wazuh agents hosts>
+  become: yes
   roles:
     - ../roles/wazuh/ansible-wazuh-agent
   vars:

--- a/playbooks/wazuh-elastic.yml
+++ b/playbooks/wazuh-elastic.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: <YOUR_ELASTICSEARCH_IP>
+  become: yes
   roles:
     - role: ../roles/elastic-stack/ansible-elasticsearch
       elasticsearch_network_host: '<YOUR_ELASTICSEARCH_IP>'

--- a/playbooks/wazuh-elastic_stack-distributed.yml
+++ b/playbooks/wazuh-elastic_stack-distributed.yml
@@ -1,6 +1,7 @@
 ---
 
 - hosts: <node-1 IP>
+  become: yes
   roles:
     - role: ../roles/elastic-stack/ansible-elasticsearch
       elasticsearch_network_host: <node-1 IP>
@@ -32,6 +33,7 @@
         ip: <node-3 IP>
 
 - hosts: <node-2 IP>
+  become: yes
   roles:
     - role: ../roles/elastic-stack/ansible-elasticsearch
       elasticsearch_network_host: <node-2 IP>
@@ -45,6 +47,7 @@
         - <node-3 IP>
 
 - hosts: <node-3 IP>
+  become: yes
   roles:
     - role: ../roles/elastic-stack/ansible-elasticsearch
       elasticsearch_network_host: <node-3 IP>

--- a/playbooks/wazuh-elastic_stack-single.yml
+++ b/playbooks/wazuh-elastic_stack-single.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: <your server host>
+  become: yes
   roles:
     - {role: ../roles/wazuh/ansible-wazuh-manager}
     - role: ../roles/wazuh/ansible-filebeat

--- a/playbooks/wazuh-kibana.yml
+++ b/playbooks/wazuh-kibana.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: <KIBANA_HOST>
+  become: yes
   roles:
     - role: ../roles/elastic-stack/ansible-kibana
       elasticsearch_network_host: <YOUR_ELASTICSEARCH_IP>

--- a/playbooks/wazuh-manager-oss.yml
+++ b/playbooks/wazuh-manager-oss.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: managers
+  become: yes
   roles:
     - role: ../roles/wazuh/ansible-wazuh-manager
     - role: ../roles/wazuh/ansible-filebeat-oss

--- a/playbooks/wazuh-manager.yml
+++ b/playbooks/wazuh-manager.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: <WAZUH_MANAGER_HOST>
+  become: yes
   roles:
     - role: ../roles/wazuh/ansible-wazuh-manager
     - role: ../roles/wazuh/ansible-filebeat

--- a/playbooks/wazuh-opendistro-kibana.yml
+++ b/playbooks/wazuh-opendistro-kibana.yml
@@ -1,4 +1,5 @@
 ---
 - hosts: es1
+  become: yes
   roles:
     - role: ../roles/opendistro/opendistro-kibana

--- a/playbooks/wazuh-opendistro.yml
+++ b/playbooks/wazuh-opendistro.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: es_cluster
+  become: yes
   roles:
     - role: ../roles/opendistro/opendistro-elasticsearch
 


### PR DESCRIPTION
As pointed out in linked issue, the `become` clause requirement is not very clearly stated from distributed example playbooks (though it's ok in the README). 

This PR adds the missing become clause to these playbooks.