### PR TITLE
roles/opendistro: add missing variable elasticsearch_node_master

### DIFF
--- a/roles/opendistro/opendistro-elasticsearch/defaults/main.yml
+++ b/roles/opendistro/opendistro-elasticsearch/defaults/main.yml
@@ -5,8 +5,11 @@ opendistro_version: 1.11.0
 single_node: false
 elasticsearch_node_name: node-1
 opendistro_cluster_name: wazuh
+
+elasticsearch_node_master: true
 elasticsearch_node_data: true
 elasticsearch_node_ingest: true
+
 elasticsearch_lower_disk_requirements: false
 elasticsearch_cluster_nodes:
   - 127.0.0.1


### PR DESCRIPTION
Reported by @sergiogp98 (thanks!). This PR adds the variable `elasticsearch_node_master` to role defaults