### PR TITLE
opendistro: add elasticsearch_network_host to role defaults

### DIFF
--- a/roles/opendistro/opendistro-elasticsearch/defaults/main.yml
+++ b/roles/opendistro/opendistro-elasticsearch/defaults/main.yml
@@ -5,6 +5,7 @@ opendistro_version: 1.11.0
 single_node: false
 elasticsearch_node_name: node-1
 opendistro_cluster_name: wazuh
+elasticsearch_network_host: '0.0.0.0'
 
 elasticsearch_node_master: true
 elasticsearch_node_data: true


### PR DESCRIPTION
Variable should be declared, but it's missing. Add it with a relaxed default for listening on all interfaces.
