### PR TITLE
Adds missing hotfixes option for syscollector

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -184,7 +184,7 @@ wazuh_agent_syscollector:
   packages: 'yes'
   ports_no: 'yes'
   processes: 'yes'
-  hotfixes: 'no'
+  hotfixes: 'yes'
 
 ## SCA
 wazuh_agent_sca:

--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -184,6 +184,7 @@ wazuh_agent_syscollector:
   packages: 'yes'
   ports_no: 'yes'
   processes: 'yes'
+  hotfixes: 'no'
 
 ## SCA
 wazuh_agent_sca:

--- a/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
+++ b/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
@@ -217,6 +217,7 @@
     <packages>{{ wazuh_agent_config.syscollector.packages }}</packages>
     <ports all="no">{{ wazuh_agent_config.syscollector.ports_no }}</ports>
     <processes>{{ wazuh_agent_config.syscollector.processes }}</processes>
+    <hotfixes>{{ wazuh_agent_config.syscollector.hotfixes }}</hotfixes>
   </wodle>
 
   <sca>

--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -151,6 +151,7 @@ wazuh_manager_syscollector:
   packages: 'yes'
   ports_no: 'yes'
   processes: 'yes'
+  hotfixes: 'yes'
 
 wazuh_manager_monitor_aws:
   disabled: 'yes'

--- a/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
@@ -232,6 +232,7 @@
     <packages>{{ wazuh_manager_config.syscollector.packages }}</packages>
     <ports all="no">{{ wazuh_manager_config.syscollector.ports_no }}</ports>
     <processes>{{ wazuh_manager_config.syscollector.processes }}</processes>
+    <hotfixes>{{ wazuh_agent_config.syscollector.hotfixes }}</hotfixes>
   </wodle>
 
   <sca>


### PR DESCRIPTION
This PR adds a missing `hotfixes` option to the syscollector configs and related jinja templates.
The option was added in version 3.11.0: https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/wodle-syscollector.html#hotfixes