### PR TITLE
Adds missing wazuh_agent_authd.groups arg to Windows authd agent registration task

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/tasks/Windows.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Windows.yml
@@ -61,6 +61,9 @@
     -p {{ wazuh_agent_authd.port }}
     {% if wazuh_agent_authd.agent_name is not none %}-A {{ wazuh_agent_authd.agent_name }} {% endif %}
     {% if authd_pass | length > 0 %} -P {{ authd_pass }}{% endif %}
+    {% if wazuh_agent_authd.groups is defined and wazuh_agent_authd.groups | length > 0 %}
+    -G "{{ wazuh_agent_authd.groups | join(',') }}"
+    {% endif %}
   register: agent_auth_output
   notify: Windows | Restart Wazuh Agent
   when:


### PR DESCRIPTION
This PR adds a missing `wazuh_agent_authd.groups` arg to the "Windows | Register agent" task. 
With this, any groups defined in `wazuh_agent_authd.groups` will be passed to the task and be used to set an agent's group, just like in the corresponding "Linux | Register agent (via authd)" task.