### PR TITLE
Add support to Wazuh manager install from sources 4.2.0

### DIFF
--- a/molecule/distributed-wazuh-odfe/group_vars/all.yml
+++ b/molecule/distributed-wazuh-odfe/group_vars/all.yml
@@ -37,7 +37,7 @@ filebeat_node_name: '{{ ansible_hostname }}'
 elastic_stack_version: 7.10.0
 opendistro_version: 1.12.0
 filebeat_version: 7.10.0
-kibana_opendistro_version: 1.12.0-1
+kibana_opendistro_version: 1.12.0
 
 # Debian packages need the ${VERSION}-1
 wazuh_manager_version: 4.1.4-1

--- a/roles/opendistro/opendistro-elasticsearch/defaults/main.yml
+++ b/roles/opendistro/opendistro-elasticsearch/defaults/main.yml
@@ -32,6 +32,12 @@ package_repos:
     opendistro:
       baseurl: 'https://packages.wazuh.com/4.x/yum/'
       gpg: 'https://packages.wazuh.com/key/GPG-KEY-WAZUH'
+  apt:
+    opendistro:
+      baseurl: 'deb https://packages.wazuh.com/4.x/apt/ stable main'
+      gpg: 'https://packages.wazuh.com/key/GPG-KEY-WAZUH'
+    openjdk:
+      baseurl: 'deb http://deb.debian.org/debian stretch-backports main'
       
 opendistro_sec_plugin_conf_path: /usr/share/elasticsearch/plugins/opendistro_security/securityconfig
 opendistro_sec_plugin_tools_path: /usr/share/elasticsearch/plugins/opendistro_security/tools

--- a/roles/opendistro/opendistro-elasticsearch/tasks/Debian.yml
+++ b/roles/opendistro/opendistro-elasticsearch/tasks/Debian.yml
@@ -1,0 +1,42 @@
+---
+
+- name: Install OpenDistro dependencies
+  apt:
+    name: [
+      'unzip', 'wget', 'curl',
+      'apt-transport-https', software-properties-common
+    ]
+    state: present
+
+- name: Add openjdk repository
+  apt_repository:
+    repo: "{{ package_repos.apt.openjdk.baseurl }}"
+    state: present
+    update_cache: yes
+
+- name: Install openjdk-11-jdk
+  apt:
+    name: openjdk-11-jdk
+    state: present
+  environment:
+    JAVA_HOME: /usr
+
+- name: Add Opendistro repository
+  block:
+    - name: Add apt repository signing key
+      apt_key:
+        url: "{{ package_repos.apt.opendistro.gpg }}"
+        state: present
+
+    - name: Add Opendistro repository
+      apt_repository:
+        repo: "{{ package_repos.apt.opendistro.baseurl }}"
+        state: present
+        update_cache: yes
+
+- name: Install OpenDistro
+  apt:
+    name: opendistroforelasticsearch={{ opendistro_version }}-1
+    state: present
+  register: install
+  tags: install

--- a/roles/opendistro/opendistro-elasticsearch/tasks/RedHat.yml
+++ b/roles/opendistro/opendistro-elasticsearch/tasks/RedHat.yml
@@ -15,6 +15,8 @@
     yum:
       name: java-11-openjdk-devel
       state: present
+    environment:
+      JAVA_HOME: /usr/
     when:
       - ansible_distribution != 'Amazon'
 
@@ -24,6 +26,8 @@
         yum:
           name: amazon-linux-extras
           state: present
+        environment:
+          JAVA_HOME: /usr/
 
       - name: Install OpenJDK 11
         shell: amazon-linux-extras install java-openjdk11 -y
@@ -38,6 +42,13 @@
       packages:
       - wget
       - unzip
+      
+  - name: Install OpenDistro
+    yum:
+      name: opendistroforelasticsearch-{{ opendistro_version }}
+      state: present
+    register: install
+    tags: install
 
   tags:
   - install

--- a/roles/opendistro/opendistro-elasticsearch/tasks/local_actions.yml
+++ b/roles/opendistro/opendistro-elasticsearch/tasks/local_actions.yml
@@ -63,6 +63,8 @@
       -ca -crt
       -t {{ local_certs_path }}/certs/
       -f -o
+    environment:
+      JAVA_HOME: /usr/
     when:
       - not root_ca_file.stat.exists
       - tlsconfig_template.changed
@@ -74,6 +76,8 @@
      -crt
      -t {{ local_certs_path }}/certs/
      -f
+    environment:
+      JAVA_HOME: /usr/
     when:
       - root_ca_file.stat.exists
       - tlsconfig_template.changed

--- a/roles/opendistro/opendistro-elasticsearch/tasks/main.yml
+++ b/roles/opendistro/opendistro-elasticsearch/tasks/main.yml
@@ -1,20 +1,16 @@
 ---
 
+- import_tasks: RedHat.yml
+  when: ansible_os_family == 'RedHat'
+
+- import_tasks: Debian.yml
+  when: ansible_os_family == 'Debian'
+
 - import_tasks: local_actions.yml
   when:
     - generate_certs
 
 - block:
-    - import_tasks: RedHat.yml
-      when: ansible_os_family == 'RedHat'
-
-    - name: Install OpenDistro
-      package:
-        name: opendistroforelasticsearch-{{ opendistro_version }}
-        state: present
-      register: install
-      tags: install
-
     - name: Remove elasticsearch configuration file
       file:
         path: "{{ opendistro_conf_path }}/elasticsearch.yml"

--- a/roles/opendistro/opendistro-kibana/defaults/main.yml
+++ b/roles/opendistro/opendistro-kibana/defaults/main.yml
@@ -14,12 +14,16 @@ wazuh_version: 4.1.4
 wazuh_app_url: https://packages.wazuh.com/4.x/ui/kibana/wazuh_kibana
 
 # The OpenDistro package repository
-kibana_opendistro_version: 1.12.0-1 # Version includes the - for RedHat family compatibility, replace with = for Debian hosts
+kibana_opendistro_version: 1.12.0 # Version includes the - for RedHat family compatibility, replace with = for Debian hosts
 
 package_repos:
   yum:
     opendistro:
       baseurl: 'https://packages.wazuh.com/4.x/yum/'
+      gpg: 'https://packages.wazuh.com/key/GPG-KEY-WAZUH'
+  apt:
+    opendistro:
+      baseurl: 'deb https://packages.wazuh.com/4.x/apt/ stable main'
       gpg: 'https://packages.wazuh.com/key/GPG-KEY-WAZUH'
 
 

--- a/roles/opendistro/opendistro-kibana/tasks/Debian.yml
+++ b/roles/opendistro/opendistro-kibana/tasks/Debian.yml
@@ -1,0 +1,22 @@
+---
+- block:
+
+  - name: Add apt repository signing key
+    apt_key:
+      url: "{{ package_repos.apt.opendistro.gpg }}"
+      state: present
+
+  - name: Debian systems | Add OpenDistro repo
+    apt_repository:
+      repo: "{{ package_repos.apt.opendistro.baseurl }}"
+      state: present
+      update_cache: yes
+
+  - name: Install Kibana
+    package:
+      name: "opendistroforelasticsearch-kibana={{ kibana_opendistro_version }}"
+      state: present
+    register: install
+    
+  tags:
+    - install

--- a/roles/opendistro/opendistro-kibana/tasks/RedHat.yml
+++ b/roles/opendistro/opendistro-kibana/tasks/RedHat.yml
@@ -10,5 +10,11 @@
       gpgkey: "{{ package_repos.yum.opendistro.gpg }}"
       gpgcheck: true
 
+  - name: Install Kibana
+    package:
+      name: "opendistroforelasticsearch-kibana-{{ kibana_opendistro_version }}"
+      state: present
+    register: install
+    
   tags:
     - install

--- a/roles/opendistro/opendistro-kibana/tasks/main.yml
+++ b/roles/opendistro/opendistro-kibana/tasks/main.yml
@@ -11,12 +11,8 @@
 - import_tasks: RedHat.yml
   when: ansible_os_family == 'RedHat'
 
-- name: Install Kibana
-  package:
-    name: "opendistroforelasticsearch-kibana-{{ kibana_opendistro_version }}"
-    state: present
-  register: install
-  tags: install
+- import_tasks: Debian.yml
+  when: ansible_os_family == 'Debian'
 
 - name: Remove Kibana configuration file
   file:

--- a/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
@@ -11,6 +11,17 @@
   register: wazuh_manager_https_packages_installed
   until: wazuh_manager_https_packages_installed is succeeded
 
+- name: "Install dependencies"
+  apt:
+    name: ['unzip', 'openssl', 'tar']
+    state: present
+
+- name: Install dependencies to build from sources
+  apt:
+    name: ['make', 'gcc', 'automake', 'autoconf', 'libtool', 'tar', 'libssl-dev', 'g++']
+    state: present
+  when: wazuh_manager_sources_installation.enabled
+
 - name: Debian/Ubuntu | Installing Wazuh repository key (Ubuntu 14)
   become: true
   shell: |

--- a/roles/wazuh/ansible-wazuh-manager/tasks/RedHat.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/RedHat.yml
@@ -135,3 +135,14 @@
     - ansible_distribution_major_version|int < 6
   tags:
     - init
+
+- name: "Install dependencies"
+  yum:
+    name: ['unzip', 'openssl', 'tar']
+    state: present
+
+- name: Install dependencies to build from sources
+  yum:
+    name: ['make', 'gcc', 'automake', 'autoconf', 'libtool', 'tar', 'openssl-devel', 'gcc-c++']
+    state: present
+  when: wazuh_manager_sources_installation.enabled

--- a/roles/wazuh/ansible-wazuh-manager/tasks/install_cmake.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/install_cmake.yml
@@ -1,0 +1,41 @@
+---
+
+# Vars
+# cmake_download_url: http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz
+# cmake_version: 3.18.3
+#
+  - name: Include CMake install vars 
+    include_vars: install_cmake.yml
+
+  - name: Download CMake sources
+    get_url:
+      url: "{{ cmake_download_url }}"
+      dest: "/tmp/cmake-{{ cmake_version }}.tar.gz"
+    register: cmake_download
+
+  - name: Unpack CMake
+    unarchive:
+      copy: no
+      dest: /tmp/
+      src: "{{ cmake_download.dest }}"
+    when: cmake_download.changed
+    register: cmake_unpack
+
+  - name: Configure CMake
+    command: "./bootstrap"
+    args:
+      chdir: "/tmp/cmake-{{ cmake_version }}"
+    when: cmake_unpack.changed
+    register: cmake_configure
+
+  - name: Install CMake
+    shell: make && make install
+    args:
+      chdir: "/tmp/cmake-{{ cmake_version }}"
+    when: cmake_configure.changed
+
+  - name: Delete installation files
+    file:
+      state: absent
+      path: "/tmp/cmake-{{ cmake_version }}"
+

--- a/roles/wazuh/ansible-wazuh-manager/tasks/install_gcc.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/install_gcc.yml
@@ -1,0 +1,59 @@
+---
+
+# Vars
+# gcc_download_url: http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz
+# gcc_version: 5.5.0
+#
+  - name: Include GCC install vars 
+    include_vars: install_gcc.yml
+
+  - name: Download GCC sources
+    get_url:
+      url: "{{ gcc_download_url }}"
+      dest: "/tmp/gcc-{{ gcc_version }}.tar.gz"
+    register: gcc_download
+
+  - name: Unpack GCC 
+    unarchive:
+      copy: no
+      dest: /tmp/
+      src: "{{ gcc_download.dest }}"
+    when: gcc_download.changed
+    register: gcc_unpack
+
+  - name: Download prerequisites
+    command: "./contrib/download_prerequisites"
+    args:
+      chdir: "/tmp/gcc-{{ gcc_version }}"
+    when: gcc_unpack.changed
+    register: gcc_requisites
+
+  - name: Configure GCC
+    command: >- 
+      ./configure 
+        --prefix=/usr/local/gcc-{{ gcc_version }}
+        --enable-languages=c,c++
+        --disable-multilib 
+        --disable-libsanitizer
+        --disable-bootstrap
+    when: gcc_requisites.changed 
+    register: gcc_configure
+
+  - name: Install GCC 
+    shell: make -j$(nproc) && make install
+    args:
+      chdir: "/tmp/gcc-{{ gcc_version }}"
+    when: gcc_configure.changed
+    register: gcc_install 
+
+  - name: Create a symbolic link
+    file:
+      src: "/usr/local/gcc-{{ gcc_version }}/bin/g++"
+      dest: /usr/bin/c++
+      state: link
+    when: gcc_install.changed
+
+  - name: Delete installlation files
+    file:
+      state: absent
+      path: "/tmp/gcc-{{ gcc_version }}" 

--- a/roles/wazuh/ansible-wazuh-manager/tasks/installation_from_sources.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/installation_from_sources.yml
@@ -2,21 +2,13 @@
 # Wazuh Manager
   - name: Check if Wazuh Manager is already installed
     stat:
-      path: "{{ wazuh_dir }}/bin/ossec-control"
-    register: wazuh_ossec_control
+      path: "{{ wazuh_dir }}/bin/wazuh-control"
+    register: wazuh_control_path
 
   - name: Installing Wazuh Manager from sources
     block:
-      - name: Install dependencies to build Wazuh packages
-        package:
-          name:
-            - make
-            - gcc
-            - automake
-            - autoconf
-            - libtool
-            - tar
-          state: present
+      - name: Install CMake 
+        include_tasks: install_cmake.yml
 
       - name: Removing old files
         file:
@@ -102,6 +94,8 @@
         changed_when: installation_result == 0
         args:
           chdir: "/tmp/wazuh-{{ wazuh_manager_sources_installation.branch }}"
+        environment:
+          PATH: /usr/local/bin:{{ ansible_env.PATH }}
 
       - name: Cleanup downloaded files
         file:
@@ -114,7 +108,7 @@
           state: absent
 
     when:
-      - not wazuh_ossec_control.stat.exists
+      - not wazuh_control_path.stat.exists
       - wazuh_manager_sources_installation.enabled
     tags:
       - manager

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -7,14 +7,6 @@
     config_layer: '{{ wazuh_manager_config | default({}) }}'
   when: wazuh_manager_config_overlay | bool
 
-- name: "Install dependencies"
-  package:
-    name:
-      - unzip
-      - openssl
-      - tar
-    state: present
-
 - include_tasks: "RedHat.yml"
   when: (ansible_os_family == "RedHat" and ansible_distribution_major_version|int > 5) or (ansible_os_family  == "RedHat" and ansible_distribution == "Amazon")
 
@@ -141,19 +133,6 @@
   when:
     - shared_agent_config is defined
 
-- name: Installing the api.yaml (api configuration)
-  template: src=api.yaml.j2
-            dest="{{ wazuh_dir }}/api/configuration/api.yaml"
-            owner=root
-            group=ossec
-            mode=0640
-  notify: restart wazuh-manager
-  when:
-    - wazuh_manager_config.cluster.node_type == "master"
-  tags:
-    - init
-    - config
-
 - name: Installing the local_internal_options.conf
   template: src=var-ossec-etc-local-internal-options.conf.j2
             dest="{{ wazuh_dir }}/etc/local_internal_options.conf"
@@ -197,7 +176,7 @@
     - config
 
 - name: Enable client-syslog
-  command: "{{ wazuh_dir }}/bin/ossec-control enable client-syslog"
+  command: "{{ wazuh_dir }}/bin/wazuh-control enable client-syslog"
   notify: restart wazuh-manager
   when:
     - csyslog_enabled.stdout == '0' or "skipped" in csyslog_enabled.stdout
@@ -219,7 +198,7 @@
     - config
 
 - name: Enable ossec-agentlessd
-  command: "{{ wazuh_dir }}/bin/ossec-control enable agentless"
+  command: "{{ wazuh_dir }}/bin/wazuh-control enable agentless"
   notify: restart wazuh-manager
   when:
     - agentlessd_enabled.stdout == '0' or "skipped" in agentlessd_enabled.stdout

--- a/roles/wazuh/ansible-wazuh-manager/vars/install_cmake.yml
+++ b/roles/wazuh/ansible-wazuh-manager/vars/install_cmake.yml
@@ -1,0 +1,4 @@
+# Install cmake vars
+
+cmake_version: 3.18.3
+cmake_download_url: "http://packages.wazuh.com/utils/cmake/cmake-{{ cmake_version }}.tar.gz"

--- a/roles/wazuh/ansible-wazuh-manager/vars/install_gcc.yml
+++ b/roles/wazuh/ansible-wazuh-manager/vars/install_gcc.yml
@@ -1,0 +1,4 @@
+# Install gcc vars
+
+gcc_version: 5.5.0
+gcc_download_url: "http://packages.wazuh.com/utils/gcc/gcc-{{ gcc_version }}.tar.gz"


### PR DESCRIPTION
Hi team,
This PR adds the necessary to execute an installation from sources of Wazuh manager > v4.2.0.
Cmake is added as dependency as other minor changes.

Regards,
Víctor.