### PR TITLE
Rename users and group according to Wazuh standard

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -46,8 +46,8 @@ def test_wazuh_services_are_running(host):
 @pytest.mark.parametrize("wazuh_file, wazuh_owner, wazuh_group, wazuh_mode", [
     ("/var/ossec/etc/sslmanager.cert", "root", "root", 0o640),
     ("/var/ossec/etc/sslmanager.key", "root", "root", 0o640),
-    ("/var/ossec/etc/rules/local_rules.xml", "ossec", "ossec", 0o640),
-    ("/var/ossec/etc/lists/audit-keys", "ossec", "ossec", 0o660),
+    ("/var/ossec/etc/rules/local_rules.xml", "wazuh", "wazuh", 0o640),
+    ("/var/ossec/etc/lists/audit-keys", "wazuh", "wazuh", 0o660),
 ])
 def test_wazuh_files(host, wazuh_file, wazuh_owner, wazuh_group, wazuh_mode):
     """Test Wazuh related files exist and have proper owners and mode."""

--- a/molecule/distributed-wazuh-elk-xpack/tests/test_default.py
+++ b/molecule/distributed-wazuh-elk-xpack/tests/test_default.py
@@ -46,8 +46,8 @@ def test_wazuh_services_are_running(host):
 @pytest.mark.parametrize("wazuh_file, wazuh_owner, wazuh_group, wazuh_mode", [
     ("/var/ossec/etc/sslmanager.cert", "root", "root", 0o640),
     ("/var/ossec/etc/sslmanager.key", "root", "root", 0o640),
-    ("/var/ossec/etc/rules/local_rules.xml", "ossec", "ossec", 0o640),
-    ("/var/ossec/etc/lists/audit-keys", "ossec", "ossec", 0o660),
+    ("/var/ossec/etc/rules/local_rules.xml", "wazuh", "wazuh", 0o640),
+    ("/var/ossec/etc/lists/audit-keys", "wazuh", "wazuh", 0o660),
 ])
 def test_wazuh_files(host, wazuh_file, wazuh_owner, wazuh_group, wazuh_mode):
     """Test Wazuh related files exist and have proper owners and mode."""

--- a/molecule/distributed-wazuh-elk/tests/test_default.py
+++ b/molecule/distributed-wazuh-elk/tests/test_default.py
@@ -46,8 +46,8 @@ def test_wazuh_services_are_running(host):
 @pytest.mark.parametrize("wazuh_file, wazuh_owner, wazuh_group, wazuh_mode", [
     ("/var/ossec/etc/sslmanager.cert", "root", "root", 0o640),
     ("/var/ossec/etc/sslmanager.key", "root", "root", 0o640),
-    ("/var/ossec/etc/rules/local_rules.xml", "ossec", "ossec", 0o640),
-    ("/var/ossec/etc/lists/audit-keys", "ossec", "ossec", 0o660),
+    ("/var/ossec/etc/rules/local_rules.xml", "wazuh", "wazuh", 0o640),
+    ("/var/ossec/etc/lists/audit-keys", "wazuh", "wazuh", 0o660),
 ])
 def test_wazuh_files(host, wazuh_file, wazuh_owner, wazuh_group, wazuh_mode):
     """Test Wazuh related files exist and have proper owners and mode."""

--- a/molecule/distributed-wazuh-odfe/tests/test_default.py
+++ b/molecule/distributed-wazuh-odfe/tests/test_default.py
@@ -46,8 +46,8 @@ def test_wazuh_services_are_running(host):
 @pytest.mark.parametrize("wazuh_file, wazuh_owner, wazuh_group, wazuh_mode", [
     ("/var/ossec/etc/sslmanager.cert", "root", "root", 0o640),
     ("/var/ossec/etc/sslmanager.key", "root", "root", 0o640),
-    ("/var/ossec/etc/rules/local_rules.xml", "ossec", "ossec", 0o640),
-    ("/var/ossec/etc/lists/audit-keys", "ossec", "ossec", 0o660),
+    ("/var/ossec/etc/rules/local_rules.xml", "wazuh", "wazuh", 0o640),
+    ("/var/ossec/etc/lists/audit-keys", "wazuh", "wazuh", 0o660),
 ])
 def test_wazuh_files(host, wazuh_file, wazuh_owner, wazuh_group, wazuh_mode):
     """Test Wazuh related files exist and have proper owners and mode."""

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
@@ -223,7 +223,7 @@
     src: var-ossec-etc-ossec-agent.conf.j2
     dest: "{{ wazuh_dir }}/etc/ossec.conf"
     owner: root
-    group: ossec
+    group: wazuh
     mode: 0644
   notify: restart wazuh-agent
   tags:
@@ -235,7 +235,7 @@
     src: var-ossec-etc-local-internal-options.conf.j2
     dest: "{{ wazuh_dir }}/etc/local_internal_options.conf"
     owner: root
-    group: ossec
+    group: wazuh
     mode: 0640
   notify: restart wazuh-agent
   tags:
@@ -246,8 +246,8 @@
   template:
     src: authd_pass.j2
     dest: "{{ wazuh_dir }}/etc/authd.pass"
-    owner: ossec
-    group: ossec
+    owner: wazuh
+    group: wazuh
     mode: 0640
   when:
     - wazuh_agent_config.enrollment.enabled == 'yes'

--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -61,7 +61,7 @@ wazuh_manager_mailto:
   - 'admin@example.net'
 
 wazuh_manager_email_smtp_server: smtp.example.wazuh.com
-wazuh_manager_email_from: ossecm@example.wazuh.com
+wazuh_manager_email_from: wazuh@example.wazuh.com
 wazuh_manager_email_maxperhour: 12
 wazuh_manager_email_queue_size: 131072
 wazuh_manager_email_log_source: 'alerts.log'

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -81,8 +81,8 @@
 - name: Installing the local_rules.xml (default local_rules.xml)
   template: src=var-ossec-rules-local_rules.xml.j2
             dest="{{ wazuh_dir }}/etc/rules/local_rules.xml"
-            owner=ossec
-            group=ossec
+            owner=wazuh
+            group=wazuh
             mode=0640
   notify: restart wazuh-manager
   tags:
@@ -93,8 +93,8 @@
 - name: Adding local rules files
   copy: src="{{ wazuh_manager_config.ruleset.rules_path }}"
         dest="{{ wazuh_dir }}/etc/rules/"
-        owner=ossec
-        group=ossec
+        owner=wazuh
+        group=wazuh
         mode=0640
   notify: restart wazuh-manager
   tags:
@@ -105,8 +105,8 @@
 - name: Installing the local_decoder.xml
   template: src=var-ossec-rules-local_decoder.xml.j2
             dest="{{ wazuh_dir }}/etc/decoders/local_decoder.xml"
-            owner=ossec
-            group=ossec
+            owner=wazuh
+            group=wazuh
             mode=0640
   notify: restart wazuh-manager
   tags:
@@ -117,8 +117,8 @@
 - name: Adding local decoders files
   copy: src="{{ wazuh_manager_config.ruleset.decoders_path }}"
         dest="{{ wazuh_dir }}/etc/decoders/"
-        owner=ossec
-        group=ossec
+        owner=wazuh
+        group=wazuh
         mode=0640
   notify: restart wazuh-manager
   tags:
@@ -130,8 +130,8 @@
   template:
     src: var-ossec-etc-shared-agent.conf.j2
     dest: "{{ wazuh_dir }}/etc/shared/default/agent.conf"
-    owner: ossec
-    group: ossec
+    owner: wazuh
+    group: wazuh
     mode: 0640
     validate: "{{ wazuh_dir }}/bin/verify-agent-conf -f %s"
   notify: restart wazuh-manager
@@ -145,7 +145,7 @@
   template: src=var-ossec-etc-local-internal-options.conf.j2
             dest="{{ wazuh_dir }}/etc/local_internal_options.conf"
             owner=root
-            group=ossec
+            group=wazuh
             mode=0640
   notify: restart wazuh-manager
   tags:
@@ -228,7 +228,7 @@
     src: var-ossec-etc-ossec-server.conf.j2
     dest: "{{ wazuh_dir }}/etc/ossec.conf"
     owner: root
-    group: ossec
+    group: wazuh
     mode: 0644
   notify: restart wazuh-manager
   tags:
@@ -239,8 +239,8 @@
   template:
     src: authd_pass.j2
     dest: "{{ wazuh_dir }}/etc/authd.pass"
-    owner: ossec
-    group: ossec
+    owner: wazuh
+    group: wazuh
     mode: 0640
   no_log: true
   notify: restart wazuh-manager
@@ -257,7 +257,7 @@
         src: create_user.py
         dest: "{{ wazuh_dir }}/framework/scripts/create_user.py"
         owner: root
-        group: ossec
+        group: wazuh
         mode: 0644
 
     - name: Execute create_user script


### PR DESCRIPTION
Hi team,
This PR closes #546, changes `ossec`, `ossecr` and `ossecm` users and groups to `wazuh`.

Greetings,
Víctor.