### PR TITLE
Fix error in Kibana config

### DIFF
--- a/roles/opendistro/opendistro-kibana/tasks/main.yml
+++ b/roles/opendistro/opendistro-kibana/tasks/main.yml
@@ -19,7 +19,6 @@
     # noqa 503
     path: "{{ kibana_conf_path }}/kibana.yml"
     state: absent
-  when: install.changed
   tags: install
 
 - import_tasks: security_actions.yml

--- a/roles/opendistro/opendistro-kibana/tasks/security_actions.yml
+++ b/roles/opendistro/opendistro-kibana/tasks/security_actions.yml
@@ -11,4 +11,3 @@
       - "{{ kibana_node_name }}_http.pem"
   tags:
   - security
-  when: install.changed


### PR DESCRIPTION
closes wazuh-automation issue: https://github.com/wazuh/wazuh-automation/issues/514. 
Extra: Elasticsearch certificates were not placed in `/usr/share/kibana` folder due to same problem. Fixes aswell.

Greetings,
Víctor.