### PR TITLE
Replace hardcoded rootcheck/syscheck settings with vars

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -144,6 +144,7 @@ wazuh_agent_client_buffer:
 
 ## Rootcheck
 wazuh_agent_rootcheck:
+  disable: 'no'
   frequency: 43200
 
 ## Wodles
@@ -197,6 +198,7 @@ wazuh_agent_sca:
 
 ## Syscheck
 wazuh_agent_syscheck:
+  disable: 'no'
   frequency: 43200
   scan_on_start: 'yes'
   auto_ignore: 'no'

--- a/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
+++ b/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
@@ -90,7 +90,7 @@
 
   {% if wazuh_agent_config.rootcheck is defined %}
   <rootcheck>
-    <disabled>no</disabled>
+    <disabled>{{ wazuh_agent_config.rootcheck.disable }}</disabled>
     {% if ansible_system == "Linux" %}
     <check_files>yes</check_files>
     <check_trojans>yes</check_trojans>
@@ -247,7 +247,7 @@
   <!-- Directories to check  (perform all possible verifications) -->
   {% if wazuh_agent_config.syscheck is defined %}
   <syscheck>
-    <disabled>no</disabled>
+    <disabled>{{ wazuh_agent_config.syscheck.disable }}</disabled>
     <frequency>{{ wazuh_agent_config.syscheck.frequency }}</frequency>
     {% if ansible_system == "Linux" %}
     <scan_on_start>{{ wazuh_agent_config.syscheck.scan_on_start }}</scan_on_start>

--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -117,6 +117,7 @@ wazuh_manager_reports:
 
 ## Woodles
 wazuh_manager_rootcheck:
+  disable: 'no'
   frequency: 43200
 
 wazuh_manager_openscap:

--- a/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
@@ -118,7 +118,7 @@
 
   <!-- Policy monitoring -->
   <rootcheck>
-    <disabled>no</disabled>
+    <disabled>{{ wazuh_agent_config.rootcheck.disable }}</disabled>
     <check_files>yes</check_files>
     <check_trojans>yes</check_trojans>
     <check_dev>yes</check_dev>


### PR DESCRIPTION
The `disabled` settings for the Syscheck/Rootcheck modules in ossec.conf are currently hardcoded; this PR replaces them with vars defined in the respective role's defaults/main.yml.