### PR TITLE
Fix multi-tenant and performance analyzer

### DIFF
--- a/roles/elastic-stack/ansible-kibana/templates/kibana.yml.j2
+++ b/roles/elastic-stack/ansible-kibana/templates/kibana.yml.j2
@@ -117,3 +117,5 @@ elasticsearch.ssl.certificateAuthorities: ["{{ node_certs_destination }}/ca.crt"
 elasticsearch.ssl.certificateAuthorities: ["{{ node_certs_destination }}/{{ca_cert_name}}"]
 {% endif %}
 {% endif %}
+
+server.defaultRoute: /app/wazuh

--- a/roles/opendistro/opendistro-elasticsearch/tasks/main.yml
+++ b/roles/opendistro/opendistro-elasticsearch/tasks/main.yml
@@ -11,6 +11,9 @@
     - import_tasks: Debian.yml
       when: ansible_os_family == 'Debian'
 
+    - name: Remove Performance analyzer plugin
+      command: "/usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro-performance-analyzer"
+
     - name: Remove elasticsearch configuration file
       file:
         path: "{{ opendistro_conf_path }}/elasticsearch.yml"

--- a/roles/opendistro/opendistro-kibana/templates/opendistro_kibana.yml.j2
+++ b/roles/opendistro/opendistro-kibana/templates/opendistro_kibana.yml.j2
@@ -25,7 +25,7 @@ elasticsearch.hosts: "http://{{ elasticsearch_network_host }}:{{ elasticsearch_h
 {% endif %}
 
 elasticsearch.requestHeadersWhitelist: ["securitytenant","Authorization"]
-opendistro_security.multitenancy.enabled: false # FIXME: should be enabled starting with Wazuh App v3.13
+opendistro_security.multitenancy.enabled: true
 opendistro_security.multitenancy.tenants.preferred: ["Private", "Global"]
 opendistro_security.readonly_mode.roles: ["kibana_read_only"]
 
@@ -33,4 +33,4 @@ newsfeed.enabled: {{ kibana_newsfeed_enabled }}
 telemetry.optIn: {{ kibana_telemetry_optin }}
 telemetry.enabled: {{ kibana_telemetry_enabled }}
 
-
+server.defaultRoute: /app/wazuh?security_tenant=global


### PR DESCRIPTION
Hello team,

In this PR we solve the problem of multi-tenancy activation in OpenDistro/Kibana and the problem of the performance analyzer plugin. that comes by default inside the meta-package of Elasticsearch.

Regards.