### PR TITLE
Fix md5 for Windows wazuh agent role

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,31 @@
+{
+    "yaml.customTags": [
+        "!And",
+        "!And sequence",
+        "!If",
+        "!If sequence",
+        "!Not",
+        "!Not sequence",
+        "!Equals",
+        "!Equals sequence",
+        "!Or",
+        "!Or sequence",
+        "!FindInMap",
+        "!FindInMap sequence",
+        "!Base64",
+        "!Join",
+        "!Join sequence",
+        "!Cidr",
+        "!Ref",
+        "!Sub",
+        "!Sub sequence",
+        "!GetAtt",
+        "!GetAZs",
+        "!ImportValue",
+        "!ImportValue sequence",
+        "!Select",
+        "!Select sequence",
+        "!Split",
+        "!Split sequence"
+    ]
+}

--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -55,7 +55,7 @@ wazuh_winagent_config:
   # Adding quotes to auth_path_x86 since win_shell outputs error otherwise
   auth_path_x86: C:\'Program Files (x86)'\ossec-agent\agent-auth.exe
   check_md5: True
-  md5: 8ffa75d13280f1aa6ffca54f4273df4d
+  md5: 50455229db051712fef18eb7cda1ce65
 wazuh_winagent_config_url: https://packages.wazuh.com/4.x/windows/wazuh-agent-4.1.5-1.msi
 wazuh_winagent_package_name: wazuh-agent-4.1.5-1.msi
 


### PR DESCRIPTION
The md5 hash in the playbook wazuh-ansible\roles\wazuh\ansible-wazuh-agent\defaults\main.yml is updated for the windows agent download