### PR TITLE
Add missing dependancy (package) (user group)

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
@@ -1,10 +1,11 @@
 ---
-- name: Debian/Ubuntu | Install apt-transport-https, ca-certificates and acl
+- name: Debian/Ubuntu | Install apt-transport-https, ca-certificates, gnupg and acl
   apt:
     name:
       - apt-transport-https
       - ca-certificates
       - acl
+      - gnupg
     state: present
   register: wazuh_agent_ca_package_install
   until: wazuh_agent_ca_package_install is succeeded

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
@@ -218,6 +218,11 @@
     msg: Agent registration will be performed through enrollment option in templated ossec.conf
   when:  wazuh_agent_config.enrollment.enabled == 'yes'
 
+- name: Linux | Ensure group "wazuh" exists
+  ansible.builtin.group:
+    name: wazuh
+    state: present
+
 - name: Linux | Installing agent configuration (ossec.conf)
   template:
     src: var-ossec-etc-ossec-agent.conf.j2


### PR DESCRIPTION
Added gnupg to the list of installed applications for Debian, as it is used later in the playbook. Missing gnupg makes [the following part of the playbook](https://github.com/wazuh/wazuh-ansible/blob/master/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml#L27-L34) fail.

Added an task to ensure the wazuh group exists, else [the following part of the playbook](https://github.com/wazuh/wazuh-ansible/blob/master/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml#L233-L243) will fail.
