### PR TITLE
Fix sca template issue for day, wday and time parameters to 4.3

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
@@ -248,13 +248,13 @@
     <skip_nfs>yes</skip_nfs>
   {% endif %}
   {% if wazuh_manager_config.sca.day | length > 0 %}
-    <day>yes</day>
+    <day>{{ wazuh_manager_config.sca.day }}</day>
   {% endif %}
   {% if wazuh_manager_config.sca.wday | length > 0 %}
-    <wday>yes</wday>
+    <wday>{{ wazuh_manager_config.sca.wday }}</wday>
   {% endif %}
   {% if wazuh_manager_config.sca.time | length > 0 %}
-    <time>yes</time>
+    <time>{{ wazuh_manager_config.sca.time }}</time>
   {% endif %}
   </sca>
 


### PR DESCRIPTION
Issue: https://github.com/wazuh/wazuh-ansible/issues/692

I was able to replicate the error reported by the community user and apply the proposed fix with satisfactory results.

Before the fix:
```
root@Debian-Buster:~# /var/ossec/bin/wazuh-control start
2021/12/30 18:51:27 wazuh-modulesd: ERROR: (1241): Invalid day format: 'yes'.
2021/12/30 18:51:27 wazuh-modulesd: ERROR: (1235): Invalid value for element 'wday': yes.
2021/12/30 18:51:27 wazuh-modulesd: ERROR: (1202): Configuration error at 'etc/ossec.conf'.
wazuh-modulesd: Configuration error. Exiting
```

After the fix:
```
root@Debian-Buster:~# /var/ossec/bin/wazuh-control status
wazuh-clusterd not running...
wazuh-modulesd is running...
wazuh-monitord is running...
wazuh-logcollector is running...
wazuh-remoted is running...
wazuh-syscheckd is running...
wazuh-analysisd is running...
wazuh-maild not running...
wazuh-execd is running...
wazuh-db is running...
wazuh-authd is running...
wazuh-agentlessd not running...
wazuh-integratord not running...
wazuh-dbd not running...
wazuh-csyslogd not running...
wazuh-apid is running...

```

```
  <sca>
    <enabled>yes</enabled>
    <scan_on_start>yes</scan_on_start>
    <interval>12h</interval>
    <skip_nfs>yes</skip_nfs>
    <wday>saturday</wday>
    <time>00:00</time>
  </sca>

```