### PR TITLE
S3 wodle, support 'type=service' setting block

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -158,11 +158,20 @@ wazuh_manager_monitor_aws:
   interval: '10m'
   run_on_start: 'yes'
   skip_on_error: 'yes'
+  disable_service_block: 'yes' # not present in conf file, only for template condition.
   s3:
     - name: null
       bucket_type: null
       path: null
       only_logs_after: null
+      regions: null
+      access_key: null
+      secret_key: null
+  s3_service:
+    - service_type: null
+      aws_log_groups: null
+      only_logs_after: null
+      remove_log_streams: null
       regions: null
       access_key: null
       secret_key: null

--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -163,6 +163,7 @@ wazuh_manager_monitor_aws:
       bucket_type: null
       path: null
       only_logs_after: null
+      regions: null
       access_key: null
       secret_key: null
 

--- a/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
@@ -586,6 +586,27 @@
       {% endif %}
     </bucket>
     {% endfor %}
+  {% if monitor_aws is defined and monitor_aws.disable_service_block is defined and monitor_aws.disable_service_block == "no" %}
+    {% for service in monitor_aws.s3_service %}
+    <service type="{{ service.service_type }}">
+      {% if service.aws_log_groups is defined %}
+      <aws_log_groups>{{ service.aws_log_groups }}</aws_log_groups>
+      {% endif %}
+      {% if service.only_logs_after is defined %}
+      <only_logs_after>{{ service.only_logs_after }}</only_logs_after>
+      {% endif %}
+      {% if service.remove_log_streams is defined %}
+      <remove_log_streams>{{ service.remove_log_streams }}</remove_log_streams>
+      {% endif %}
+      {% if service.access_key is defined %}
+      <access_key>{{ service.access_key }}</access_key>
+      {% endif %}
+      {% if service.secret_key is defined %}
+      <secret_key>{{ service.secret_key }}</secret_key>
+      {% endif %}
+    </service>
+    {% endfor %}
+  {% endif %}
   </wodle>
 {% endif %}
 

--- a/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
@@ -572,11 +572,18 @@
       {% if bucket.path is defined %}
       <path>{{ bucket.path }}</path>
       {% endif %}
+      {% if bucket.regions is defined %}
+      <regions>{{ bucket.regions }}</regions>
+      {% endif %}
       {% if bucket.only_logs_after is defined %}
       <only_logs_after>{{ bucket.only_logs_after }}</only_logs_after>
       {% endif %}
+      {% if bucket.access_key is defined %}
       <access_key>{{ bucket.access_key }}</access_key>
+      {% endif %}
+      {% if bucket.secret_key is defined %}
       <secret_key>{{ bucket.secret_key }}</secret_key>
+      {% endif %}
     </bucket>
     {% endfor %}
   </wodle>


### PR DESCRIPTION
The wazuh-manager role only support s3 wodle 'type=bucket' , add 'type=service' support.
https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/wodle-s3.html?highlight=aws#service-type