### PR TITLE
Fix sca agent template issue for day, wday and time parameters to 4.3

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
+++ b/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
@@ -233,13 +233,13 @@
     <skip_nfs>yes</skip_nfs>
   {% endif %}
   {% if wazuh_agent_config.sca.day | length > 0 %}
-    <day>yes</day>
+    <day>{{ wazuh_agent_config.sca.day }}</day>
   {% endif %}
   {% if wazuh_agent_config.sca.wday | length > 0 %}
-    <wday>yes</wday>
+    <wday>{{ wazuh_agent_config.sca.wday }}</wday>
   {% endif %}
   {% if wazuh_agent_config.sca.time | length > 0 %}
-    <time>yes</time>
+    <time>{{ wazuh_agent_config.sca.time }}</time>
   {% endif %}
   </sca>
 


### PR DESCRIPTION
Closes: https://github.com/wazuh/wazuh-ansible/issues/692

We have to apply the same correction for SCA applied for the manager in the agents.

Before the change:
![Screenshot_20220117_090422](https://user-images.githubusercontent.com/64099752/149769558-44771202-5855-4fb7-95f8-f2c038d913ed.png)

After  the change: 

![Screenshot_20220117_091841](https://user-images.githubusercontent.com/64099752/149769666-d17aa996-abef-423e-9b1d-7be706c62778.png)


manager PR: https://github.com/wazuh/wazuh-ansible/pull/694