### PR TITLE
Use `POST` as method of the API login endpoint

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
@@ -125,7 +125,7 @@
     - name: Linux | Obtain JWT Token
       uri:
         url: '{{ target_manager.api_proto }}://{{ target_manager.address }}:{{ target_manager.api_port }}/security/user/authenticate'
-        method: GET
+        method: POST
         url_username: '{{ target_manager.api_user }}'
         url_password: '{{ api_pass }}'
         status_code: 200


### PR DESCRIPTION
This PR closes https://github.com/wazuh/wazuh-ansible/issues/713.

In this pull request, I have changed the method used when requesting the API login endpoint from `GET` to `POST` because as it was said in the related issue, the actual login endpoint (GET) is going to be deprecated.