### PR TITLE
Clarification on the composition of the Dashboard node

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ These playbooks install and configure Wazuh agent, manager and indexer and dashb
 ## Example: production-ready distributed environment
 
 ### Playbook
-The hereunder example playbook uses the `wazuh-ansible` role to provision a production-ready Wazuh environment. The architecture includes 2 Wazuh nodes, 3 Wazuh indexer nodes and a mixed Wazuh dashboard node.
+The hereunder example playbook uses the `wazuh-ansible` role to provision a production-ready Wazuh environment. The architecture includes 2 Wazuh nodes, 3 Wazuh indexer nodes and a mixed Wazuh dashboard node (Wazuh indexer data node + Wazuh dashboard).
 
 ```yaml
 ---


### PR DESCRIPTION
A clarification is made on how the Wazuh Dashboard node is composed, since it contains, in addition to the dashboard, a Wazuh indexer data node

Closes: https://github.com/wazuh/wazuh-ansible/issues/754