### PR TITLE
Disable become root in delegated task

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: Get latest Wazuh release
+  become: false
   shell: "curl --silent https://api.github.com/repos/wazuh/wazuh/releases/latest | grep '\"tag_name\":' | sed -E 's/.*\"([^\"]+)\".*/\\1/'| cut -c 2-"
   register: wazuh_latest_release
   delegate_to: localhost


### PR DESCRIPTION
Hello team,

We have applied a little fix to the new task that obtain if it is the latest release or not.

Thanks.