### PR TITLE
Fix to be able to set complex passwords with symbols too

### DIFF
--- a/roles/wazuh/ansible-filebeat-oss/templates/filebeat.yml.j2
+++ b/roles/wazuh/ansible-filebeat-oss/templates/filebeat.yml.j2
@@ -21,7 +21,7 @@ output.elasticsearch:
 
 {% if filebeat_security %}
   username: {{ indexer_security_user }}
-  password: {{ indexer_security_password }}
+  password: "{{ indexer_security_password }}"
   protocol: https
   ssl.certificate_authorities:
     - {{ filebeat_ssl_dir }}/root-ca.pem

--- a/roles/wazuh/wazuh-dashboard/tasks/main.yml
+++ b/roles/wazuh/wazuh-dashboard/tasks/main.yml
@@ -83,7 +83,7 @@
 
 - name: Configure opensearch.password in opensearch_dashboards.keystore
   shell: >-
-    echo {{ dashboard_password }} | /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root add -f --stdin opensearch.password
+    echo '{{ dashboard_password }}' | /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root add -f --stdin opensearch.password
   args:
     executable: /bin/bash
   become: yes

--- a/roles/wazuh/wazuh-indexer/tasks/security_actions.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/security_actions.yml
@@ -49,7 +49,7 @@
   - name: Hashing the custom admin password
     shell: |
       export JAVA_HOME=/usr/share/wazuh-indexer/jdk
-      {{ indexer_sec_plugin_tools_path }}/hash.sh -p {{ indexer_admin_password }}
+      {{ indexer_sec_plugin_tools_path }}/hash.sh -p '{{ indexer_admin_password }}'
     register: indexer_admin_password_hashed
     no_log: '{{ indexer_nolog_sensible | bool }}'
   
@@ -65,7 +65,7 @@
   - name: Hash the kibanaserver role/user pasword
     shell: |
       export JAVA_HOME=/usr/share/wazuh-indexer/jdk
-      {{ indexer_sec_plugin_tools_path }}/hash.sh -p {{ dashboard_password }}
+      {{ indexer_sec_plugin_tools_path }}/hash.sh -p '{{ dashboard_password }}'
     register: indexer_kibanaserver_password_hashed
     no_log: '{{ indexer_nolog_sensible | bool }}'
   


### PR DESCRIPTION
This PR fixes the issue that it's currently not possible to set complex passwords for admin / kibanaserver user which include (special) symbols like `.#*,` etc.