### PR TITLE
Add Solaris support using custom packages

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/tasks/Solaris.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Solaris.yml
@@ -1,0 +1,8 @@
+- name: Download agent package
+  get_url:
+    url: "{{ solaris_agent_pkg }}"
+    dest: /export/home/vagrant
+    validate_certs: no
+
+- include_tasks: "installation_from_custom_packages.yml"
+  when: wazuh_custom_packages_installation_agent_enabled

--- a/roles/wazuh/ansible-wazuh-agent/tasks/installation_from_custom_packages.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/installation_from_custom_packages.yml
@@ -26,3 +26,21 @@
       - wazuh_custom_packages_installation_agent_enabled
       - (ansible_distribution|lower == "centos" and ansible_distribution_major_version >= "8") or
         (ansible_distribution|lower == "redhat" and ansible_distribution_major_version >= "8")
+
+# Solaris
+  - name: Create noask file
+    lineinfile:
+      path: "/export/home/vagrant/noaskfile"
+      line: action=nocheck
+      create: yes
+    when: ansible_os_family == "Solaris"
+
+
+  - name: Install solaris wazuh agent custom package
+    become: true
+    shell: pkgadd -a noaskfile -d wazuh-* -n all
+    environment:
+      PATH: "/opt/python3/bin/:/usr/sbin:/usr/bin:/usr/sbin/:/opt/csw/gnu/:/usr/sfw/bin/:/opt/csw/bin/"
+    args:
+      chdir: "/export/home/vagrant"
+    when: ansible_os_family == 'Solaris'

--- a/roles/wazuh/ansible-wazuh-agent/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/main.yml
@@ -24,3 +24,6 @@
 
 - include_tasks: "Linux.yml"
   when: ansible_system == "Linux"
+
+- include_tasks: "Solaris.yml"
+  when: ansible_os_family == "Solaris"


### PR DESCRIPTION
| Related issue |
|          ---          |
|   close  #799  |

## Description

As part of #797, this PR aims to extend the ansible playbooks so we can install custom Solaris packages.

## Changes

- Added task for Solaris custom packages 


## How to use it

Adding the following vars within a host in your inventory, you can install a custom windows agent package:
- `solaris_agent_pkg` - Agent package url
- `wazuh_custom_packages_installation_agent_enabled` - Boolean that allows us to use custom packages

## Checks

```
PLAY RECAP ***************************************************************************************************************************************************************************************************
Deployer_65_20220621095447_solaris_10_0_0 : ok=9    changed=4    unreachable=0    failed=0    skipped=6    rescued=0    ignored=0   
Deployer_65_20220621095447_solaris_11_0_1 : ok=9    changed=4    unreachable=0    failed=0    skipped=6    rescued=0    ignored=0 
```