### PR TITLE
Add `wazuh-dashboard` custom packages support

### DIFF
--- a/roles/wazuh/wazuh-dashboard/defaults/main.yml
+++ b/roles/wazuh/wazuh-dashboard/defaults/main.yml
@@ -1,5 +1,10 @@
 ---
 
+# Custom package installation
+wazuh_custom_packages_installation_indexer_enabled: false
+wazuh_custom_packages_installation_indexer_deb_url: ""
+wazuh_custom_packages_installation_indexer_rpm_url: ""
+
 # Dashboard configuration
 indexer_http_port: 9200
 indexer_api_protocol: https

--- a/roles/wazuh/wazuh-dashboard/tasks/Debian.yml
+++ b/roles/wazuh/wazuh-dashboard/tasks/Debian.yml
@@ -22,3 +22,8 @@
 
   tags:
     - install
+  when: not wazuh_custom_packages_installation_dashboard_enabled
+
+- include_tasks: "install_from_custom_package.yml"
+  when:
+    - wazuh_custom_packages_installation_dashboard_enabled

--- a/roles/wazuh/wazuh-dashboard/tasks/RedHat.yml
+++ b/roles/wazuh/wazuh-dashboard/tasks/RedHat.yml
@@ -19,3 +19,8 @@
 
   tags:
     - install
+  when: not wazuh_custom_packages_installation_dashboard_enabled
+
+- include_tasks: "install_from_custom_package.yml"
+  when:
+    - wazuh_custom_packages_installation_dashboard_enabled

--- a/roles/wazuh/wazuh-dashboard/tasks/install_from_custom_package.yml
+++ b/roles/wazuh/wazuh-dashboard/tasks/install_from_custom_package.yml
@@ -1,0 +1,32 @@
+---
+  - block:
+      - name: Install Wazuh Dashboard from .deb packages
+        apt:
+          deb: "{{ wazuh_custom_packages_installation_dashboard_deb_url }}"
+          state: present
+        when:
+          - wazuh_custom_packages_installation_dashboard_enabled
+    when:
+      - ansible_os_family|lower == "debian"
+
+  - block:
+    - name: Install Wazuh Dashboard from .rpm packages | yum
+      yum:
+        name: "{{ wazuh_custom_packages_installation_dashboard_rpm_url }}"
+        state: present
+      when:
+        - wazuh_custom_packages_installation_dashboard_enabled
+        - not (ansible_distribution|lower == "centos" and ansible_distribution_major_version >= "8")
+        - not (ansible_distribution|lower == "redhat" and ansible_distribution_major_version >= "8")
+
+    - name: Install Wazuh Dashboard from .rpm packages | dnf
+      dnf:
+        name: "{{ wazuh_custom_packages_installation_dashboard_rpm_url }}"
+        state: present
+        disable_gpg_check: True
+      when:
+        - wazuh_custom_packages_installation_dashboard_enabled
+        - (ansible_distribution|lower == "centos" and ansible_distribution_major_version >= "8") or
+          (ansible_distribution|lower == "redhat" and ansible_distribution_major_version >= "8")
+    when:
+      - ansible_os_family|lower == "redhat"


### PR DESCRIPTION
| Related issue |
|          ---          |
|   close  #824  |

## Description

As part of E2E testing integration, we need to allow the use of custom packages for the indexer and dashboard.

## Changes

- Added task for dashboard custom packages 


## New flags

Adding the following vars within a host in your inventory, you can install a custom indexer package:
- `wazuh_custom_packages_installation_dashboard_enabled`: Boolean that allows us to use custom packages
- `wazuh_custom_packages_installation_dashboard_deb_url`: Dashboard deb url
- `wazuh_custom_packages_installation_dashboard_rpm_url`: Dashboard rpm url

## Checks

<details><summary>environment used with the Deployer</summary>
</br>

- manager
- 2 indexer nodes
- dashboard
- agent

```yaml
- service: EC2
  instances:
    - ubuntu
  resources:
    - cpu: 2
      memory: 2048

- service: EC2
  instances:
    - ubuntu
    - centos
    - amazonlinux
  resources:
    - cpu: 4
      memory: 4096
    - cpu: 4
      memory: 4096
    - cpu: 4
      memory: 4096

- service: EC2
  instances:
    - ubuntu
```

</details>

<details><summary>inventory</summary>

```yaml
wi_cluster:
  hosts:
    wi1:
      ansible_host: 172.31.11.66
      ansible_user: qa
      ansible_connection: ssh
      private_ip: 172.31.11.66
    wi2:
      ansible_host: 172.31.5.32
      ansible_user: qa
      ansible_connection: ssh
      private_ip: 172.31.5.32
    dashboard:
      ansible_host: 172.31.4.224
      ansible_user: qa
      ansible_connection: ssh
      private_ip: 172.31.4.224
      dashboard_node_name: "node-3"
  vars:
      wazuh_custom_packages_installation_indexer_enabled: yes
      wazuh_custom_packages_installation_indexer_deb_url: https://packages.wazuh.com/4.x/apt/pool/main/w/wazuh-indexer/wazuh-indexer_4.3.5-1_amd64.deb
      wazuh_custom_packages_installation_indexer_rpm_url: https://packages.wazuh.com/4.x/yum/wazuh-indexer-4.3.5-1.x86_64.rpm
      wazuh_custom_packages_installation_dashboard_enabled: yes
      wazuh_custom_packages_installation_dashboard_rpm_url: https://packages.wazuh.com/4.x/yum/wazuh-dashboard-4.3.5-1.x86_64.rpm
      indexer_network_host: 172.31.11.66
      indexer_discovery_nodes:
          - 172.31.11.66
          - 172.31.5.32
      indexer_cluster_nodes:
          - 172.31.11.66
          - 172.31.5.32
      instances:
          node1:
            name: node-1      
            ip: 172.31.11.66
            role: indexer
          node2:
            name: node-2
            ip: 172.31.5.32
            role: indexer
          node3:
            name: node-3
            ip: 172.31.4.224
            role: dashboard
          node4:
            name: node-4
            ip: 172.31.13.86
            role: wazuh
            node_type: master
          node5:
            name: node-5
            ip: 172.31.0.112
            role: wazuh
            node_type: worker
manager:
  hosts:
    master:
      ansible_host: 172.31.13.86
      ansible_user: qa
      ansible_connection: ssh
      private_ip: 172.31.13.86
      wazuh_manager_config:
        cluster:
          disable: 'no'
          node_name: 'master'
          node_type: 'master'
          key: 'c98b62a9b6169ac5f67dae55ae4a9088'
          nodes:
              - 172.31.13.86
          hidden: 'no'
    worker1:
      ansible_host: 172.31.0.112
      ansible_user: qa
      ansible_connection: ssh
      private_ip:  172.31.0.112
      wazuh_manager_config:
        cluster:
          disable: 'no'
          node_name:  "worker1"
          node_type: 'worker'
          key: 'c98b62a9b6169ac5f67dae55ae4a9088'
          nodes:
              - 172.31.13.86
          hidden: 'no'
  vars:
    wazuh_custom_packages_installation_manager_enabled: yes
    wazuh_custom_packages_installation_manager_deb_url: https://packages.wazuh.com/4.x/apt/pool/main/w/wazuh-manager/wazuh-manager_4.3.5-1_amd64.deb
filebeat:
  hosts:
    filebeat1:
          ansible_host: 172.31.11.66
          ansible_user: qa
          ansible_connection: ssh
          filebeat_node_name: node-4
    filebeat2:
          ansible_host: 172.31.0.112
          ansible_user: qa
          ansible_connection: ssh
          filebeat_node_name: node-5
  vars:
    filebeat_output_indexer_hosts:
        - 172.31.11.66
        - 172.31.5.32
all:
  vars:
    ansible_ssh_common_args: -o StrictHostKeyChecking=no
```

</details>

[Build](https://devel.ci.wazuh.info/job/PoC_Provision_Tool_LG/45/console) - :green_circle: 