### PR TITLE
Add Double Quote on password

### DIFF
--- a/roles/wazuh/wazuh-dashboard/templates/wazuh.yml.j2
+++ b/roles/wazuh/wazuh-dashboard/templates/wazuh.yml.j2
@@ -130,5 +130,5 @@ hosts:
       url: {{ api['url'] }}
       port: {{ api['port'] }}
       username: {{ api['username'] }}
-      password: {{ api['password'] }}
+      password: "{{ api['password'] }}"
 {% endfor %}


### PR DESCRIPTION
This PR adds a double quote on Wazuh API password.
Related to https://github.com/wazuh/wazuh-ansible/issues/834