### PR TITLE
Ansible variables changed for Windows agent

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
+++ b/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
@@ -260,7 +260,7 @@
     {% endif %}
 
     <!-- Directories to check  (perform all possible verifications) -->
-    {% if wazuh_agent_config.syscheck.win_directories is defined and ansible_system == "Windows" %}
+    {% if wazuh_agent_config.syscheck.win_directories is defined and ansible_os_family == "Windows" %}
     {% for directory in wazuh_agent_config.syscheck.win_directories %}
     <directories {{ directory.checks }}>{{ directory.dirs }}</directories>
     {% endfor %}
@@ -280,7 +280,7 @@
     {% endfor %}
     {% endif %}
 
-    {% if wazuh_agent_config.syscheck.ignore is defined and ansible_system == "Windows" %}
+    {% if wazuh_agent_config.syscheck.ignore is defined and ansible_os_family == "Windows" %}
     {% for ignore in wazuh_agent_config.syscheck.ignore_win %}
     <ignore type="sregex">{{ ignore }}</ignore>
     {% endfor %}


### PR DESCRIPTION
This PR closes #845. It changes the `ansible_system` variable for `ansible_os_family`.
It was locally tested and the `ansible_system` var does not contain `Windows` and `ansible_os_family` does.