### PR TITLE
Delete port configuration

### DIFF
--- a/roles/wazuh/ansible-filebeat-oss/templates/filebeat.yml.j2
+++ b/roles/wazuh/ansible-filebeat-oss/templates/filebeat.yml.j2
@@ -16,7 +16,7 @@ setup.ilm.enabled: false
 output.elasticsearch:
   hosts:
 {% for item in filebeat_output_indexer_hosts %}
-  - {{ item }}:9200
+  - {{ item }}
 {% endfor %}
 
 {% if filebeat_security %}


### PR DESCRIPTION
This PR deletes port configuration into filebeat.yml.j2 because generate duplicate port configuration when filebeat-oss is deployed