### PR TITLE
use ansible_facts to reference facts

### DIFF
--- a/.github/playbooks/single-wazuh.yml
+++ b/.github/playbooks/single-wazuh.yml
@@ -35,4 +35,4 @@
           - gpg-agent
         state: present
         update_cache: yes
-      when: ansible_distribution == "Ubuntu"
+      when: ansible_facts.os_family == "Ubuntu"

--- a/roles/wazuh/ansible-filebeat-oss/tasks/main.yml
+++ b/roles/wazuh/ansible-filebeat-oss/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - include_tasks: RedHat.yml
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts.os_family == 'RedHat'
 
 - include_tasks: Debian.yml
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts.os_family == 'Debian'
 
 - name: Install Filebeat | Redhat
   yum:
@@ -13,7 +13,7 @@
   tags:
   - install
   - init
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts.os_family == 'RedHat'
 
 - name: Install Filebeat | Debian
   apt:
@@ -23,7 +23,7 @@
   tags:
   - install
   - init
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts.os_family == 'Debian'
 
 - name: Checking if Filebeat Module folder file exists
   stat:
@@ -72,7 +72,7 @@
     enabled: true
 
 - include_tasks: "RMRedHat.yml"
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts.os_family == "RedHat"
 
 - include_tasks: "RMDebian.yml"
-  when: ansible_os_family == "Debian"
+  when: ansible_facts.os_family == "Debian"

--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -70,7 +70,7 @@ wazuh_agent_config_overlay: yes
 
 # This is a middle ground between breaking existing uses of wazuh_agent_nat
 # and allow working with agents having several network interfaces
-wazuh_agent_address: '{{ "any" if wazuh_agent_nat else ansible_default_ipv4.address }}'
+wazuh_agent_address: '{{ "any" if wazuh_agent_nat else ansible_facts.default_ipv4.address }}'
 
 # List of managers. The first one with register variable declared *and* set to true
 # is the one used to register the agent. Otherwise, the first one in the list will be used.

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
@@ -16,7 +16,7 @@
     state: present
   register: wazuh_agent_ca_package_install
   until: wazuh_agent_ca_package_install is succeeded
-  when: not (ansible_distribution == "Debian" and ansible_distribution_major_version in ['11'])
+  when: not (ansible_facts.distribution == "Debian" and ansible_facts.distribution_major_version in ['11'])
 
 - name: Debian/Ubuntu | Installing Wazuh repository key (Ubuntu 14)
   become: true
@@ -28,8 +28,8 @@
     executable: /bin/bash
   changed_when: false
   when:
-    - ansible_distribution == "Ubuntu"
-    - ansible_distribution_major_version | int == 14
+    - ansible_facts.distribution == "Ubuntu"
+    - ansible_facts.distribution_major_version | int == 14
     - not wazuh_agent_sources_installation.enabled
     - not wazuh_custom_packages_installation_agent_enabled
 
@@ -38,7 +38,7 @@
     url: "{{ wazuh_agent_config.repo.gpg }}"
     id: "{{ wazuh_agent_config.repo.key_id }}"
   when:
-    - not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int == 14)
+    - not (ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int == 14)
     - not wazuh_agent_sources_installation.enabled
     - not wazuh_custom_packages_installation_agent_enabled
 
@@ -55,7 +55,7 @@
 - name: Debian/Ubuntu | Set Distribution CIS filename for debian
   set_fact:
     cis_distribution_filename: cis_debian_linux_rcl.txt
-  when: ansible_os_family == "Debian"
+  when: ansible_facts.os_family == "Debian"
 
 - name: Debian/Ubuntu | Install OpenJDK-8 repo
   apt_repository:
@@ -63,7 +63,7 @@
     state: present
     update_cache: true
   when:
-    - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int == 14)
+    - (ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int == 14)
 
 - when:
     - wazuh_agent_config.cis_cat.disable == 'no'

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
@@ -1,9 +1,9 @@
 ---
 - include_tasks: "RedHat.yml"
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts.os_family == "RedHat"
 
 - include_tasks: "Debian.yml"
-  when: ansible_os_family == "Debian"
+  when: ansible_facts.os_family == "Debian"
 
 - include_tasks: "installation_from_sources.yml"
   when:
@@ -19,7 +19,7 @@
     state: present
     lock_timeout: '{{ wazuh_agent_yum_lock_timeout }}'
   when:
-    - ansible_os_family|lower == "redhat"
+    - ansible_facts.os_family|lower == "redhat"
     - not wazuh_agent_sources_installation.enabled
     - not wazuh_custom_packages_installation_agent_enabled
   tags:
@@ -31,7 +31,7 @@
     state: present
     cache_valid_time: 3600
   when:
-    - ansible_os_family|lower != "redhat"
+    - ansible_facts.os_family|lower != "redhat"
     - not wazuh_agent_sources_installation.enabled
     - not wazuh_custom_packages_installation_agent_enabled
     - not ansible_check_mode
@@ -94,7 +94,7 @@
       register: agent_auth_output
       notify: restart wazuh-agent
       vars:
-        agent_name: "{% if single_agent_name is defined %}{{ single_agent_name }}{% else %}{{ ansible_hostname }}{% endif %}"
+        agent_name: "{% if single_agent_name is defined %}{{ single_agent_name }}{% else %}{{ ansible_facts.hostname }}{% endif %}"
       when:
         - not client_keys_file.stat.exists or client_keys_file.stat.size == 0
         - wazuh_agent_authd.registration_address is not none
@@ -161,7 +161,7 @@
       changed_when: api_agent_post.json.error == 0
       register: api_agent_post
       vars:
-        agent_name: '{{ target_manager.agent_name | default(ansible_hostname) }}'
+        agent_name: '{{ target_manager.agent_name | default(ansible_facts.hostname) }}'
         jwt_token: '{{ api_jwt_result.json.data.token }}'
       tags:
         - config
@@ -203,7 +203,7 @@
         OSSEC_ACTION_CONFIRMED: y
       register: manage_agents_output
       vars:
-        agent_name: '{{ target_manager.agent_name | default(ansible_hostname) }}'
+        agent_name: '{{ target_manager.agent_name | default(ansible_facts.hostname) }}'
       notify: restart wazuh-agent
   when:
     - not ( wazuh_agent_authd.enable | bool )
@@ -270,10 +270,10 @@
 
 - include_tasks: "RMRedHat.yml"
   when:
-    - ansible_os_family == "RedHat"
+    - ansible_facts.os_family == "RedHat"
     - not wazuh_agent_sources_installation.enabled
 
 - include_tasks: "RMDebian.yml"
   when:
-    - ansible_os_family == "Debian"
+    - ansible_facts.os_family == "Debian"
     - not wazuh_agent_sources_installation.enabled

--- a/roles/wazuh/ansible-wazuh-agent/tasks/RedHat.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/RedHat.yml
@@ -8,8 +8,8 @@
     gpgcheck: true
   changed_when: false
   when:
-    - (ansible_facts['os_family']|lower == 'redhat') and (ansible_distribution|lower != 'amazon')
-    - (ansible_distribution_major_version|int <= 5)
+    - (ansible_facts['os_family']|lower == 'redhat') and (ansible_facts.distribution|lower != 'amazon')
+    - (ansible_facts.distribution_major_version|int <= 5)
     - not wazuh_agent_sources_installation.enabled
     - not wazuh_custom_packages_installation_agent_enabled
   register: repo_v5_installed
@@ -38,26 +38,26 @@
 - name: Set Distribution CIS filename for RHEL5
   set_fact:
     cis_distribution_filename: cis_rhel5_linux_rcl.txt
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "5"
+  when: ansible_facts.os_family == "RedHat" and ansible_facts.distribution_major_version == "5"
 
 - name: Set Distribution CIS filename for RHEL6
   set_fact:
     cis_distribution_filename: cis_rhel6_linux_rcl.txt
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "6"
+  when: ansible_facts.os_family == "RedHat" and ansible_facts.distribution_major_version == "6"
 
 - name: Set Distribution CIS filename for RHEL7
   set_fact:
     cis_distribution_filename: cis_rhel7_linux_rcl.txt
   when:
-    - ansible_os_family == "RedHat"
-    - ansible_distribution_major_version == "7"
+    - ansible_facts.os_family == "RedHat"
+    - ansible_facts.distribution_major_version == "7"
 
 - name: Set Distribution CIS filename for RHEL7 (Amazon)
   set_fact:
     cis_distribution_filename: cis_rhel7_linux_rcl.txt
   when:
-    - ansible_distribution == "Amazon"
-    - ansible_distribution_major_version == "NA"
+    - ansible_facts.distribution == "Amazon"
+    - ansible_facts.distribution_major_version == "NA"
 
 - name: RedHat/CentOS/RedHat | Install openscap
   package: name=openscap-scanner state=present

--- a/roles/wazuh/ansible-wazuh-agent/tasks/installation_from_custom_packages.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/installation_from_custom_packages.yml
@@ -4,7 +4,7 @@
       deb: "{{ wazuh_custom_packages_installation_agent_deb_url }}"
       state: present
     when:
-      - ansible_os_family|lower == "debian"
+      - ansible_facts.os_family|lower == "debian"
       - wazuh_custom_packages_installation_agent_enabled
 
   - name: Install Wazuh Agent from .rpm packages | yum
@@ -12,17 +12,17 @@
       name: "{{ wazuh_custom_packages_installation_agent_rpm_url }}"
       state: present
     when:
-      - ansible_os_family|lower == "redhat"
+      - ansible_facts.os_family|lower == "redhat"
       - wazuh_custom_packages_installation_agent_enabled
-      - not (ansible_distribution|lower == "centos" and ansible_distribution_major_version >= "8")
-      - not (ansible_distribution|lower == "redhat" and ansible_distribution_major_version >= "8")
+      - not (ansible_facts.distribution|lower == "centos" and ansible_facts.distribution_major_version >= "8")
+      - not (ansible_facts.distribution|lower == "redhat" and ansible_facts.distribution_major_version >= "8")
 
   - name: Install Wazuh Agent from .rpm packages | dnf
     dnf:
       name: "{{ wazuh_custom_packages_installation_agent_rpm_url }}"
       state: present
     when:
-      - ansible_os_family|lower == "redhat"
+      - ansible_facts.os_family|lower == "redhat"
       - wazuh_custom_packages_installation_agent_enabled
-      - (ansible_distribution|lower == "centos" and ansible_distribution_major_version >= "8") or
-        (ansible_distribution|lower == "redhat" and ansible_distribution_major_version >= "8")
+      - (ansible_facts.distribution|lower == "centos" and ansible_facts.distribution_major_version >= "8") or
+        (ansible_facts.distribution|lower == "redhat" and ansible_facts.distribution_major_version >= "8")

--- a/roles/wazuh/ansible-wazuh-agent/tasks/installation_from_sources.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/installation_from_sources.yml
@@ -25,7 +25,7 @@
       name:
         - policycoreutils-python
     when:
-      - ansible_os_family|lower == "redhat"
+      - ansible_facts.os_family|lower == "redhat"
 
   - name: Installing policycoreutils-python-utils (Debian families)
     package:
@@ -34,7 +34,7 @@
         - curl
         - policycoreutils
     when:
-      - ansible_os_family|lower == "debian"
+      - ansible_facts.os_family|lower == "debian"
 
   - name: Download required packages from github.com/wazuh/wazuh
     get_url:

--- a/roles/wazuh/ansible-wazuh-agent/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/main.yml
@@ -19,7 +19,7 @@
   when: wazuh_agent_config_overlay | bool
 
 - include_tasks: "Windows.yml"
-  when: ansible_os_family == "Windows"
+  when: ansible_facts.os_family == "Windows"
 
 - include_tasks: "Linux.yml"
-  when: ansible_system == "Linux"
+  when: ansible_facts.system == "Linux"

--- a/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
+++ b/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
@@ -24,9 +24,9 @@
     </server>
     {% endfor %}
     {% if wazuh_profile_centos is not none or wazuh_profile_ubuntu is not none %}
-    {% if ansible_distribution == 'CentOS' %}
+    {% if ansible_facts.distribution == 'CentOS' %}
     <config-profile>{{ wazuh_profile_centos }}</config-profile>
-    {% elif ansible_distribution == "Ubuntu" %}
+    {% elif ansible_facts.distribution == "Ubuntu" %}
     <config-profile>{{ wazuh_profile_ubuntu }}</config-profile>
     {% endif %}
     {% endif %}
@@ -91,7 +91,7 @@
   {% if wazuh_agent_config.rootcheck is defined %}
   <rootcheck>
     <disabled>no</disabled>
-    {% if ansible_system == "Linux" %}
+    {% if ansible_facts.system == "Linux" %}
     <check_files>yes</check_files>
     <check_trojans>yes</check_trojans>
     <check_dev>yes</check_dev>
@@ -107,7 +107,7 @@
     <rootkit_trojans>{{ wazuh_dir }}/etc/shared/rootkit_trojans.txt</rootkit_trojans>
     <skip_nfs>yes</skip_nfs>
     {% endif %}
-    {% if ansible_os_family == "Windows" %}
+    {% if ansible_facts.os_family == "Windows" %}
     <windows_apps>./shared/win_applications_rcl.txt</windows_apps>
     <windows_malware>./shared/win_malware_rcl.txt</windows_malware>
     {% endif %}
@@ -116,61 +116,61 @@
   {% endif %}
 
 
-  {% if ansible_system == "Linux" and wazuh_agent_config.openscap.disable == 'no' %}
+  {% if ansible_facts.system == "Linux" and wazuh_agent_config.openscap.disable == 'no' %}
   <wodle name="open-scap">
     <disabled>{{ wazuh_agent_config.openscap.disable }}</disabled>
     <timeout>{{ wazuh_agent_config.openscap.timeout }}</timeout>
     <interval>{{ wazuh_agent_config.openscap.interval }}</interval>
     <scan-on-start>{{ wazuh_agent_config.openscap.scan_on_start }}</scan-on-start>
-    {% if ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'xenial' %}
+    {% if ansible_facts.distribution == 'Ubuntu' and ansible_facts.distribution_release == 'xenial' %}
     <content type="xccdf" path="ssg-ubuntu-1604-ds.xml">
       <profile>xccdf_org.ssgproject.content_profile_common</profile>
     </content>
-    {% elif ansible_distribution == 'Debian' %}
-    {% if ansible_distribution_release == 'jessie' %}
+    {% elif ansible_facts.distribution == 'Debian' %}
+    {% if ansible_facts.distribution_release == 'jessie' %}
     {% if openscap_version_valid.stdout == "0" %}
     <content type="xccdf" path="ssg-debian-8-ds.xml">
       <profile>xccdf_org.ssgproject.content_profile_common</profile>
     </content>
     <content type="oval" path="cve-debian-8-oval.xml"/>
     {% endif %}
-    {% elif ansible_distribution_release == 'stretch' %}
+    {% elif ansible_facts.distribution_release == 'stretch' %}
     <content type="oval" path="cve-debian-9-oval.xml"/>
     {% endif %}
-    {% elif ansible_distribution == 'CentOS' %}
-      {% if ansible_distribution_major_version == '8' %}
+    {% elif ansible_facts.distribution == 'CentOS' %}
+      {% if ansible_facts.distribution_major_version == '8' %}
         {# Policy not available #}
-      {% elif ansible_distribution_major_version == '7' %}
+      {% elif ansible_facts.distribution_major_version == '7' %}
       <content type="xccdf" path="ssg-centos-7-ds.xml">
         <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
         <profile>xccdf_org.ssgproject.content_profile_common</profile>
       </content>
-      {% elif ansible_distribution_major_version == '6' %}
+      {% elif ansible_facts.distribution_major_version == '6' %}
       <content type="xccdf" path="ssg-centos-6-ds.xml">
         <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
         <profile>xccdf_org.ssgproject.content_profile_common</profile>
       </content>
       {% endif %}
-    {% elif ansible_distribution == 'RedHat' %}
-      {% if ansible_distribution_major_version == '8' %}
+    {% elif ansible_facts.distribution == 'RedHat' %}
+      {% if ansible_facts.distribution_major_version == '8' %}
         {# Policy not available #}
-      {% elif ansible_distribution_major_version == '7' %}
+      {% elif ansible_facts.distribution_major_version == '7' %}
       <content type="xccdf" path="ssg-rhel-7-ds.xml">
         <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
         <profile>xccdf_org.ssgproject.content_profile_common</profile>
       </content>
-      {% elif ansible_distribution_major_version == '6' %}
+      {% elif ansible_facts.distribution_major_version == '6' %}
       <content type="xccdf" path="ssg-rhel-6-ds.xml">
         <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
         <profile>xccdf_org.ssgproject.content_profile_common</profile>
       </content>
       {% endif %}
-      {% if ansible_distribution_major_version == '7' %}
+      {% if ansible_facts.distribution_major_version == '7' %}
       <content type="oval" path="cve-redhat-7-ds.xml"/>
-      {% elif ansible_distribution_major_version == '6' %}
+      {% elif ansible_facts.distribution_major_version == '6' %}
       <content type="oval" path="cve-redhat-6-ds.xml"/>
       {% endif %}
-    {% elif ansible_distribution == 'Fedora' %}
+    {% elif ansible_facts.distribution == 'Fedora' %}
       <content type="xccdf" path="ssg-fedora-ds.xml">
         <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
         <profile>xccdf_org.ssgproject.content_profile_common</profile>
@@ -184,25 +184,25 @@
     <timeout>{{ wazuh_agent_config.cis_cat.timeout }}</timeout>
     <interval>{{ wazuh_agent_config.cis_cat.interval }}</interval>
     <scan-on-start>{{ wazuh_agent_config.cis_cat.scan_on_start }}</scan-on-start>
-    {% if wazuh_agent_config.cis_cat.install_java == 'yes' and ansible_system == "Linux" %}
+    {% if wazuh_agent_config.cis_cat.install_java == 'yes' and ansible_facts.system == "Linux" %}
     <java_path>/usr/bin</java_path>
-    {% elif ansible_os_family == "Windows" %}
+    {% elif ansible_facts.os_family == "Windows" %}
     <java_path>{{ wazuh_agent_config.cis_cat.java_path_win }}</java_path>
     {% else %}
     <java_path>{{ wazuh_agent_config.cis_cat.java_path }}</java_path>
     {% endif %}
-    <ciscat_path>{% if ansible_os_family == "Windows" %}{{ wazuh_agent_config.cis_cat.ciscat_path_win }}{% else %}{{ wazuh_agent_config.cis_cat.ciscat_path }}{% endif %}</ciscat_path>
+    <ciscat_path>{% if ansible_facts.os_family == "Windows" %}{{ wazuh_agent_config.cis_cat.ciscat_path_win }}{% else %}{{ wazuh_agent_config.cis_cat.ciscat_path }}{% endif %}</ciscat_path>
   </wodle>
 
   <!-- Osquery integration -->
   <wodle name="osquery">
     <disabled>{{ wazuh_agent_config.osquery.disable }}</disabled>
     <run_daemon>{{ wazuh_agent_config.osquery.run_daemon }}</run_daemon>
-    {% if ansible_os_family == "Windows" %}
+    {% if ansible_facts.os_family == "Windows" %}
     <bin_path>{{ wazuh_agent_config.osquery.bin_path_win }}</bin_path>
     {% endif %}
-    <log_path>{% if ansible_os_family == "Windows" %}{{ wazuh_agent_config.osquery.log_path_win }}{% else %}{{ wazuh_agent_config.osquery.log_path }}{% endif %}</log_path>
-    <config_path>{% if ansible_os_family == "Windows" %}{{ wazuh_agent_config.osquery.config_path_win }}{% else %}{{ wazuh_agent_config.osquery.config_path }}{% endif %}</config_path>
+    <log_path>{% if ansible_facts.os_family == "Windows" %}{{ wazuh_agent_config.osquery.log_path_win }}{% else %}{{ wazuh_agent_config.osquery.log_path }}{% endif %}</log_path>
+    <config_path>{% if ansible_facts.os_family == "Windows" %}{{ wazuh_agent_config.osquery.config_path_win }}{% else %}{{ wazuh_agent_config.osquery.config_path }}{% endif %}</config_path>
     <add_labels>{{ wazuh_agent_config.osquery.add_labels }}</add_labels>
   </wodle>
 
@@ -249,10 +249,10 @@
   <syscheck>
     <disabled>no</disabled>
     <frequency>{{ wazuh_agent_config.syscheck.frequency }}</frequency>
-    {% if ansible_system == "Linux" %}
+    {% if ansible_facts.system == "Linux" %}
     <scan_on_start>{{ wazuh_agent_config.syscheck.scan_on_start }}</scan_on_start>
     <!-- Directories to check  (perform all possible verifications) -->
-    {% if wazuh_agent_config.syscheck.directories is defined and ansible_system == "Linux" %}
+    {% if wazuh_agent_config.syscheck.directories is defined and ansible_facts.system == "Linux" %}
     {% for directory in wazuh_agent_config.syscheck.directories %}
     <directories {{ directory.checks }}>{{ directory.dirs }}</directories>
     {% endfor %}
@@ -260,14 +260,14 @@
     {% endif %}
 
     <!-- Directories to check  (perform all possible verifications) -->
-    {% if wazuh_agent_config.syscheck.win_directories is defined and ansible_os_family == "Windows" %}
+    {% if wazuh_agent_config.syscheck.win_directories is defined and ansible_facts.os_family == "Windows" %}
     {% for directory in wazuh_agent_config.syscheck.win_directories %}
     <directories {{ directory.checks }}>{{ directory.dirs }}</directories>
     {% endfor %}
     {% endif %}
 
     <!-- Files/directories to ignore -->
-    {% if wazuh_agent_config.syscheck.ignore is defined and ansible_system == "Linux" %}
+    {% if wazuh_agent_config.syscheck.ignore is defined and ansible_facts.system == "Linux" %}
     {% for ignore in wazuh_agent_config.syscheck.ignore %}
     <ignore>{{ ignore }}</ignore>
     {% endfor %}
@@ -280,13 +280,13 @@
     {% endfor %}
     {% endif %}
 
-    {% if wazuh_agent_config.syscheck.ignore is defined and ansible_os_family == "Windows" %}
+    {% if wazuh_agent_config.syscheck.ignore is defined and ansible_facts.os_family == "Windows" %}
     {% for ignore in wazuh_agent_config.syscheck.ignore_win %}
     <ignore type="sregex">{{ ignore }}</ignore>
     {% endfor %}
     {% endif %}
 
-    {% if ansible_system == "Linux" %}
+    {% if ansible_facts.system == "Linux" %}
     <!-- Files no diff -->
     {% for no_diff in wazuh_agent_config.syscheck.no_diff %}
     <nodiff>{{ no_diff }}</nodiff>
@@ -298,7 +298,7 @@
     <skip_sys>{{ wazuh_agent_config.syscheck.skip_sys }}</skip_sys>
     {% endif %}
 
-    {% if ansible_os_family == "Windows" %}
+    {% if ansible_facts.os_family == "Windows" %}
     {% for registry_key in wazuh_agent_config.syscheck.windows_registry %}
     {% if registry_key.arch is defined %}
     <windows_registry arch="{{ registry_key.arch }}">{{ registry_key.key }}</windows_registry>
@@ -308,7 +308,7 @@
     {% endfor %}
     {% endif %}
 
-    {% if ansible_os_family == "Windows" %}
+    {% if ansible_facts.os_family == "Windows" %}
     {% for registry_key in wazuh_agent_config.syscheck.windows_registry_ignore %}
     {% if registry_key.type is defined %}
     <registry_ignore type="{{ registry_key.type }}">{{ registry_key.key }}</registry_ignore>
@@ -318,7 +318,7 @@
     {% endfor %}
     {% endif %}
 
-    {% if ansible_os_family == "Windows" %}
+    {% if ansible_facts.os_family == "Windows" %}
     <!-- Frequency for ACL checking (seconds) -->
     <windows_audit_interval>{{ wazuh_agent_config.syscheck.win_audit_interval }}</windows_audit_interval>
     {% endif %}
@@ -340,7 +340,7 @@
   {% endif %}
 
   <!-- Files to monitor (localfiles) -->
-  {% if ansible_system == "Linux" %}
+  {% if ansible_facts.system == "Linux" %}
   {% for localfile in wazuh_agent_config.localfiles.linux %}
 
   <localfile>
@@ -363,7 +363,7 @@
   {% endfor %}
   {% endif %}
 
-  {% if ansible_os_family == "Debian" %}
+  {% if ansible_facts.os_family == "Debian" %}
   {% for localfile in wazuh_agent_config.localfiles.debian %}
 
   <localfile>
@@ -386,7 +386,7 @@
   {% endfor %}
   {% endif %}
 
-  {% if ansible_os_family == "RedHat" %}
+  {% if ansible_facts.os_family == "RedHat" %}
   {% for localfile in wazuh_agent_config.localfiles.centos %}
 
   <localfile>
@@ -409,7 +409,7 @@
   {% endfor %}
   {% endif %}
 
-  {% if ansible_os_family == "Windows" %}
+  {% if ansible_facts.os_family == "Windows" %}
   {% for localfile in wazuh_agent_config.localfiles.windows %}
 
   <localfile>
@@ -439,7 +439,7 @@
 
   <active-response>
     <disabled>{{ wazuh_agent_config.active_response.ar_disabled|default('no') }}</disabled>
-    <ca_store>{% if ansible_os_family == "Windows" %}{{ wazuh_agent_config.active_response.ca_store_win }}{% else %}{{ wazuh_agent_config.active_response.ca_store }}{% endif %}</ca_store>
+    <ca_store>{% if ansible_facts.os_family == "Windows" %}{{ wazuh_agent_config.active_response.ca_store_win }}{% else %}{{ wazuh_agent_config.active_response.ca_store }}{% endif %}</ca_store>
     <ca_verification>{{ wazuh_agent_config.active_response.ca_verification }}</ca_verification>
   </active-response>
 

--- a/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
@@ -22,8 +22,8 @@
     executable: /bin/bash
   changed_when: false
   when:
-    - ansible_distribution == "Ubuntu"
-    - ansible_distribution_major_version | int == 14
+    - ansible_facts.distribution == "Ubuntu"
+    - ansible_facts.distribution_major_version | int == 14
     - not wazuh_manager_sources_installation.enabled
     - not wazuh_custom_packages_installation_manager_enabled
 
@@ -32,7 +32,7 @@
     url: "{{ wazuh_manager_config.repo.gpg }}"
     id: "{{ wazuh_manager_config.repo.key_id }}"
   when:
-    - not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int == 14)
+    - not (ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int == 14)
     - not wazuh_manager_sources_installation.enabled
     - not wazuh_custom_packages_installation_manager_enabled
 
@@ -57,7 +57,7 @@
     state: present
     update_cache: true
   when:
-    - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int == 14)
+    - (ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int == 14)
 
 - when:
     - wazuh_manager_config.cis_cat.disable == 'no'

--- a/roles/wazuh/ansible-wazuh-manager/tasks/RedHat.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/RedHat.yml
@@ -8,8 +8,8 @@
     gpgcheck: true
   changed_when: false
   when:
-    - (ansible_os_family|lower == 'redhat') and (ansible_distribution|lower != 'amazon')
-    - (ansible_distribution_major_version|int <= 5)
+    - (ansible_facts.os_family|lower == 'redhat') and (ansible_facts.distribution|lower != 'amazon')
+    - (ansible_facts.distribution_major_version|int <= 5)
     - not wazuh_manager_sources_installation.enabled
     - not wazuh_custom_packages_installation_manager_enabled
   register: repo_v5_manager_installed
@@ -35,15 +35,15 @@
   until: wazuh_manager_openscp_packages_installed is succeeded
   tags:
     - init
-  when: not (ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA") and
-        not (ansible_distribution == "CentOS" and ansible_distribution_major_version == "8")
+  when: not (ansible_facts.distribution == "Amazon" and ansible_facts.distribution_major_version == "NA") and
+        not (ansible_facts.distribution == "CentOS" and ansible_facts.distribution_major_version == "8")
 
 - name: CentOS 6 | Install Software Collections (SCL) Repository
   package: name=centos-release-scl state=present
   register: wazuh_manager_scl_packages_installed
   until: wazuh_manager_scl_packages_installed is succeeded
   when:
-    - ansible_distribution == 'CentOS' and ansible_distribution_major_version == '6'
+    - ansible_facts.distribution == 'CentOS' and ansible_facts.distribution_major_version == '6'
     - wazuh_manager_config.cluster.disable != 'yes'
 
 - name: RedHat 6 | Enabling Red Hat Software Collections (RHSCL)
@@ -52,7 +52,7 @@
     - rhui-REGION-rhel-server-rhscl
     - rhel-server-rhscl-6-rpms
   when:
-    - ansible_distribution == 'RedHat' and  ansible_distribution_major_version == '6'
+    - ansible_facts.distribution == 'RedHat' and  ansible_facts.distribution_major_version == '6'
     - wazuh_manager_config.cluster.disable != 'yes'
 
 - name: CentOS/RedHat 6 | Install Python 2.7
@@ -60,7 +60,7 @@
   register: wazuh_manager_python_package_installed
   until: wazuh_manager_python_package_installed is succeeded
   when:
-    - ( ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat' ) and ansible_distribution_major_version == '6'
+    - ( ansible_facts.distribution == 'CentOS' or ansible_facts.distribution == 'RedHat' ) and ansible_facts.distribution_major_version == '6'
     - wazuh_manager_config.cluster.disable != 'yes'
 
 - name: RedHat/CentOS/Fedora | Install OpenJDK 1.8
@@ -74,24 +74,24 @@
 - name: Set Distribution CIS filename for RHEL5/CentOS-5
   set_fact:
     cis_distribution_filename: cis_rhel5_linux_rcl.txt
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '5'
+  when: ansible_facts.os_family == "RedHat" and ansible_facts.distribution_major_version == '5'
 
 - name: Set Distribution CIS filename for RHEL6/CentOS-6
   set_fact:
     cis_distribution_filename: cis_rhel6_linux_rcl.txt
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '6'
+  when: ansible_facts.os_family == "RedHat" and ansible_facts.distribution_major_version == '6'
 
 - name: Set Distribution CIS filename for RHEL7/CentOS-7
   set_fact:
     cis_distribution_filename: cis_rhel7_linux_rcl.txt
   when:
-    - ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'
+    - ansible_facts.os_family == "RedHat" and ansible_facts.distribution_major_version == '7'
 
 - name: Set Distribution CIS filename for RHEL7/CentOS-7 (Amazon)
   set_fact:
     cis_distribution_filename: cis_rhel7_linux_rcl.txt
   when:
-    - ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA"
+    - ansible_facts.distribution == "Amazon" and ansible_facts.distribution_major_version == "NA"
 
 - name: Install dependencies to build from sources
   yum:
@@ -106,7 +106,7 @@
   register: wazuh_manager_main_packages_installed
   until: wazuh_manager_main_packages_installed is succeeded
   when:
-    - ansible_os_family|lower == "redhat"
+    - ansible_facts.os_family|lower == "redhat"
     - not wazuh_manager_sources_installation.enabled
     - not wazuh_custom_packages_installation_manager_enabled
   tags:
@@ -126,7 +126,7 @@
     regexp: 'echo -n "Starting Wazuh-manager: "'
     replace: "echo -n \"Starting Wazuh-manager (EL6): \"; source /opt/rh/python27/enable; export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:{{ wazuh_dir }}/framework/lib"
   when:
-    - ansible_distribution in ['CentOS', 'RedHat', 'Amazon'] and ansible_distribution_major_version|int == 6
+    - ansible_facts.distribution in ['CentOS', 'RedHat', 'Amazon'] and ansible_facts.distribution_major_version|int == 6
     - wazuh_manager_config.cluster.disable != 'yes'
 
 - name: Install expect (EL5)
@@ -138,7 +138,7 @@
   register: wazuh_manager_main_packages_installed
   until: wazuh_manager_main_packages_installed is succeeded
   when:
-    - ansible_os_family|lower == "RedHat"
-    - ansible_distribution_major_version|int < 6
+    - ansible_facts.os_family|lower == "RedHat"
+    - ansible_facts.distribution_major_version|int < 6
   tags:
     - init

--- a/roles/wazuh/ansible-wazuh-manager/tasks/installation_from_custom_packages.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/installation_from_custom_packages.yml
@@ -7,7 +7,7 @@
         when:
           - wazuh_custom_packages_installation_manager_enabled
     when:
-      - ansible_os_family|lower == "debian"
+      - ansible_facts.os_family|lower == "debian"
 
   - block:
     - name: Install Wazuh Manager from .rpm packages | yum
@@ -16,8 +16,8 @@
         state: present
       when:
         - wazuh_custom_packages_installation_manager_enabled
-        - not (ansible_distribution|lower == "centos" and ansible_distribution_major_version >= "8")
-        - not (ansible_distribution|lower == "redhat" and ansible_distribution_major_version >= "8")
+        - not (ansible_facts.distribution|lower == "centos" and ansible_facts.distribution_major_version >= "8")
+        - not (ansible_facts.distribution|lower == "redhat" and ansible_facts.distribution_major_version >= "8")
 
     - name: Install Wazuh Manager from .rpm packages | dnf
       dnf:
@@ -25,7 +25,7 @@
         state: present
       when:
         - wazuh_custom_packages_installation_manager_enabled
-        - (ansible_distribution|lower == "centos" and ansible_distribution_major_version >= "8") or
-          (ansible_distribution|lower == "redhat" and ansible_distribution_major_version >= "8")
+        - (ansible_facts.distribution|lower == "centos" and ansible_facts.distribution_major_version >= "8") or
+          (ansible_facts.distribution|lower == "redhat" and ansible_facts.distribution_major_version >= "8")
     when:
-      - ansible_os_family|lower == "redhat"
+      - ansible_facts.os_family|lower == "redhat"

--- a/roles/wazuh/ansible-wazuh-manager/tasks/installation_from_sources.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/installation_from_sources.yml
@@ -36,7 +36,7 @@
           name:
             - policycoreutils-python
         when:
-          - ansible_os_family|lower == "redhat"
+          - ansible_facts.os_family|lower == "redhat"
 
       - name: Installing policycoreutils-python-utils (Debian families)
         package:
@@ -45,7 +45,7 @@
             - curl
             - policycoreutils
         when:
-          - ansible_os_family|lower == "debian"
+          - ansible_facts.os_family|lower == "debian"
 
       - name: Remove old repository folder
         file:

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -28,18 +28,18 @@
   when: wazuh_manager_config_overlay | bool
 
 - include_tasks: "RedHat.yml"
-  when: (ansible_os_family == "RedHat" and ansible_distribution_major_version|int > 5) or (ansible_os_family  == "RedHat" and ansible_distribution == "Amazon")
+  when: (ansible_facts.os_family == "RedHat" and ansible_facts.distribution_major_version|int > 5) or (ansible_facts.os_family  == "RedHat" and ansible_facts.distribution == "Amazon")
 
 - include_tasks: "Debian.yml"
-  when: ansible_os_family == "Debian"
+  when: ansible_facts.os_family == "Debian"
 
 - name: Install expect
   package:
     name: expect
     state: "{{ wazuh_manager_package_state }}"
   when:
-    - not (ansible_os_family|lower == "redhat" and ansible_distribution_major_version|int < 6) and
-      not (ansible_distribution|lower == "centos" and ansible_distribution_major_version|int == 8)
+    - not (ansible_facts.os_family|lower == "redhat" and ansible_facts.distribution_major_version|int < 6) and
+      not (ansible_facts.distribution|lower == "centos" and ansible_facts.distribution_major_version|int == 8)
   tags: init
 
 - name: Generate SSL files for authd

--- a/roles/wazuh/ansible-wazuh-manager/tasks/uninstall.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/uninstall.yml
@@ -5,11 +5,11 @@
     repo: "{{ wazuh_manager_config.repo.apt }}"
     state: absent
   changed_when: false
-  when: ansible_os_family == "Debian"
+  when: ansible_facts.os_family == "Debian"
 
 - name: RedHat/CentOS/Fedora | Remove Wazuh repository (and clean up left-over metadata)
   yum_repository:
     name: wazuh_repo
     state: absent
   changed_when: false
-  when: ansible_os_family == "RedHat" or ansible_os_family == "Amazon"
+  when: ansible_facts.os_family == "RedHat" or ansible_facts.os_family == "Amazon"

--- a/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
@@ -136,61 +136,61 @@
     <skip_nfs>yes</skip_nfs>
   </rootcheck>
 
-    {% if ansible_system == "Linux" and wazuh_manager_config.openscap.disable == 'no' %}
+    {% if ansible_facts.system == "Linux" and wazuh_manager_config.openscap.disable == 'no' %}
   <wodle name="open-scap">
     <disabled>no</disabled>
     <timeout>{{ wazuh_manager_config.openscap.timeout }}</timeout>
     <interval>{{ wazuh_manager_config.openscap.interval }}</interval>
     <scan-on-start>{{ wazuh_manager_config.openscap.scan_on_start }}</scan-on-start>
-    {% if ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'xenial' %}
+    {% if ansible_facts.distribution == 'Ubuntu' and ansible_facts.distribution_release == 'xenial' %}
     <content type="xccdf" path="ssg-ubuntu-1604-ds.xml">
       <profile>xccdf_org.ssgproject.content_profile_common</profile>
     </content>
-    {% elif ansible_distribution == 'Debian' %}
-    {% if ansible_distribution_release == 'jessie' %}
+    {% elif ansible_facts.distribution == 'Debian' %}
+    {% if ansible_facts.distribution_release == 'jessie' %}
     {% if openscap_version_valid.stdout == "0" %}
     <content type="xccdf" path="ssg-debian-8-ds.xml">
       <profile>xccdf_org.ssgproject.content_profile_common</profile>
     </content>
     <content type="oval" path="cve-debian-8-oval.xml"/>
     {% endif %}
-    {% elif ansible_distribution_release == 'stretch' %}
+    {% elif ansible_facts.distribution_release == 'stretch' %}
     <content type="oval" path="cve-debian-9-oval.xml"/>
     {% endif %}
-    {% elif ansible_distribution == 'CentOS' %}
-      {% if ansible_distribution_major_version == '8' %}
+    {% elif ansible_facts.distribution == 'CentOS' %}
+      {% if ansible_facts.distribution_major_version == '8' %}
         {# Policy not available #}
-      {% elif ansible_distribution_major_version == '7' %}
+      {% elif ansible_facts.distribution_major_version == '7' %}
       <content type="xccdf" path="ssg-centos-7-ds.xml">
         <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
         <profile>xccdf_org.ssgproject.content_profile_common</profile>
       </content>
-      {% elif ansible_distribution_major_version == '6' %}
+      {% elif ansible_facts.distribution_major_version == '6' %}
       <content type="xccdf" path="ssg-centos-6-ds.xml">
         <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
         <profile>xccdf_org.ssgproject.content_profile_common</profile>
       </content>
       {% endif %}
-    {% elif ansible_distribution == 'RedHat' %}
-      {% if ansible_distribution_major_version == '8' %}
+    {% elif ansible_facts.distribution == 'RedHat' %}
+      {% if ansible_facts.distribution_major_version == '8' %}
         {# Policy not available #}
-      {% elif ansible_distribution_major_version == '7' %}
+      {% elif ansible_facts.distribution_major_version == '7' %}
       <content type="xccdf" path="ssg-rhel-7-ds.xml">
         <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
         <profile>xccdf_org.ssgproject.content_profile_common</profile>
       </content>
-      {% elif ansible_distribution_major_version == '6' %}
+      {% elif ansible_facts.distribution_major_version == '6' %}
       <content type="xccdf" path="ssg-rhel-6-ds.xml">
         <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
         <profile>xccdf_org.ssgproject.content_profile_common</profile>
       </content>
       {% endif %}
-      {% if ansible_distribution_major_version == '7' %}
+      {% if ansible_facts.distribution_major_version == '7' %}
       <content type="oval" path="cve-redhat-7-ds.xml"/>
-      {% elif ansible_distribution_major_version == '6' %}
+      {% elif ansible_facts.distribution_major_version == '6' %}
       <content type="oval" path="cve-redhat-6-ds.xml"/>
       {% endif %}
-    {% elif ansible_distribution == 'Fedora' %}
+    {% elif ansible_facts.distribution == 'Fedora' %}
       <content type="xccdf" path="ssg-fedora-ds.xml">
         <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
         <profile>xccdf_org.ssgproject.content_profile_common</profile>
@@ -440,7 +440,7 @@
   </localfile>
 {% endfor %}
 
-{% if ansible_os_family == "Debian" %}
+{% if ansible_facts.os_family == "Debian" %}
 {% for localfile in wazuh_manager_config.localfiles.debian %}
 
   <localfile>
@@ -479,7 +479,7 @@
 {% endfor %}
 {% endif -%}
 
-{% if ansible_os_family == "RedHat" %}
+{% if ansible_facts.os_family == "RedHat" %}
 {% for localfile in wazuh_manager_config.localfiles.centos %}
 
   <localfile>

--- a/roles/wazuh/wazuh-dashboard/tasks/main.yml
+++ b/roles/wazuh/wazuh-dashboard/tasks/main.yml
@@ -11,10 +11,10 @@
   when: packages_repository == 'staging'
 
 - import_tasks: RedHat.yml
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts.os_family == 'RedHat'
 
 - import_tasks: Debian.yml
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts.os_family == 'Debian'
 
 - name: Remove Dashboard configuration file
   file:
@@ -96,4 +96,4 @@
     state: started
 
 - import_tasks: RMRedHat.yml
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts.os_family == 'RedHat'

--- a/roles/wazuh/wazuh-indexer/tasks/RedHat.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/RedHat.yml
@@ -33,7 +33,7 @@
         become: yes
 
     when:
-      - ansible_distribution == 'Amazon'
+      - ansible_facts.distribution == 'Amazon'
 
   - name: RedHat/CentOS/Fedora | Install Indexer dependencies
     yum:

--- a/roles/wazuh/wazuh-indexer/tasks/main.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/main.yml
@@ -16,10 +16,10 @@
 
 - block:
     - import_tasks: RedHat.yml
-      when: ansible_os_family == 'RedHat'
+      when: ansible_facts.os_family == 'RedHat'
 
     - import_tasks: Debian.yml
-      when: ansible_os_family == 'Debian'
+      when: ansible_facts.os_family == 'Debian'
 
     - name: Remove performance analyzer plugin from Wazuh indexer
       become: true
@@ -130,7 +130,7 @@
         - hostvars[inventory_hostname]['private_ip'] is defined and hostvars[inventory_hostname]['private_ip']
 
     - import_tasks: "RMRedHat.yml"
-      when: ansible_os_family == "RedHat"
+      when: ansible_facts.os_family == "RedHat"
 
     - name: Reload systemd configuration
       systemd:

--- a/roles/wazuh/wazuh-indexer/templates/jvm.options.j2
+++ b/roles/wazuh/wazuh-indexer/templates/jvm.options.j2
@@ -28,9 +28,9 @@
 -Xmx32000m
 {% endif %}
 {% else %}
--Xms{% if ansible_memtotal_mb < 64000 %}{{ ((ansible_memtotal_mb|int)/2)|int }}m{% else %}32000m{% endif %}
+-Xms{% if ansible_facts.memtotal_mb < 64000 %}{{ ((ansible_facts.memtotal_mb|int)/2)|int }}m{% else %}32000m{% endif %}
 
--Xmx{% if ansible_memtotal_mb < 64000 %}{{ ((ansible_memtotal_mb|int)/2)|int }}m{% else %}32000m{% endif %}
+-Xmx{% if ansible_facts.memtotal_mb < 64000 %}{{ ((ansible_facts.memtotal_mb|int)/2)|int }}m{% else %}32000m{% endif %}
 {% endif %}
 
 


### PR DESCRIPTION
By default, Ansible injects a variable for every fact, prefixed with
ansible_. This can result in a large number of variables for each host,
which at scale can incur a performance penalty. Ansible provides a
configuration option [0] that can be set to False to prevent this
injection of facts. In this case, facts should be referenced via
ansible_facts.<fact>.

This change updates all references to Ansible facts from using
individual fact variables to using the items in the
ansible_facts dictionary. This allows users to disable fact variable
injection in their Ansible configuration, which may provide some
performance improvement.

[0] https://docs.ansible.com/ansible/latest/reference_appendices/config.html#inject-facts-as-vars