### PR TITLE
Allow wazuh-single playbook to run in check mode

### DIFF
--- a/roles/wazuh/wazuh-indexer/tasks/main.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/main.yml
@@ -109,6 +109,7 @@
       tags: debug
       when:
         - hostvars[inventory_hostname]['private_ip'] is not defined or not hostvars[inventory_hostname]['private_ip']
+        - not ansible_check_mode
 
     - name: Wait for Wazuh indexer API (Private IP)
       uri:
@@ -128,6 +129,7 @@
       tags: debug
       when:
         - hostvars[inventory_hostname]['private_ip'] is defined and hostvars[inventory_hostname]['private_ip']
+        - not ansible_check_mode
 
     - import_tasks: "RMRedHat.yml"
       when: ansible_os_family == "RedHat"

--- a/roles/wazuh/wazuh-indexer/tasks/security_actions.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/security_actions.yml
@@ -60,7 +60,9 @@
       replace: "{{ indexer_password_hash | quote }}"
     vars:
       indexer_password_hash: "{{ indexer_admin_password_hashed.stdout_lines | last }}"
-  
+    when:
+      - not ansible_check_mode
+
   # this can also be achieved with password_hash, but it requires dependencies on the controller
   - name: Hash the kibanaserver role/user pasword
     shell: |
@@ -76,7 +78,9 @@
       replace: "{{ indexer_password_hash | quote }}"
     vars:
       indexer_password_hash: "{{ indexer_kibanaserver_password_hashed.stdout_lines | last }}"
-  
+    when:
+      - not ansible_check_mode
+
   - name: Initialize the Opensearch security index in Wazuh indexer
     command: >
       sudo -u wazuh-indexer OPENSEARCH_PATH_CONF={{ indexer_conf_path }}


### PR DESCRIPTION
Several steps in the wazuh install process are not 'check mode safe' by default, this changeset skips them when ansible-playbook is run with --check.