### PR TITLE
Rename aio group to wazuh_aio

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ The hereunder example playbook uses the `wazuh-ansible` role to provision a sing
 ```yaml
 ---
 # Certificates generation
-  - hosts: aio
+  - hosts: wazuh_aio
     roles:
       - role: ../roles/wazuh/wazuh-indexer
         perform_installation: false
@@ -359,7 +359,7 @@ The hereunder example playbook uses the `wazuh-ansible` role to provision a sing
     tags:
       - generate-certs
 # Single node
-  - hosts: aio
+  - hosts: wazuh_aio
     become: yes
     become_user: root
     roles:
@@ -386,7 +386,7 @@ The hereunder example playbook uses the `wazuh-ansible` role to provision a sing
 ### Inventory file
 
 ```ini
-[aio]
+[wazuh_aio]
 <your server host>
 
 [all:vars]

--- a/playbooks/wazuh-single.yml
+++ b/playbooks/wazuh-single.yml
@@ -1,6 +1,6 @@
 ---
 # Certificates generation
-  - hosts: aio
+  - hosts: wazuh_aio
     roles:
       - role: ../roles/wazuh/wazuh-indexer
         perform_installation: false
@@ -16,7 +16,7 @@
     tags:
       - generate-certs
 # Single node
-  - hosts: aio
+  - hosts: wazuh_aio
     become: yes
     become_user: root
     roles:


### PR DESCRIPTION
The current group name is only useful as a demonstration but prefixing with wazuh_ allows it to be used directly in an inventory while maintaining clarity about the groups purpose.

This is a breaking change for those using aio as a group name.