### PR TITLE
Use group names in agent playbook

### DIFF
--- a/playbooks/wazuh-agent.yml
+++ b/playbooks/wazuh-agent.yml
@@ -1,12 +1,12 @@
 ---
-- hosts: <your wazuh agents hosts>
+- hosts: wazuh_clients:!wazuh_aio
   become: yes
   become_user: root
   roles:
     - ../roles/wazuh/ansible-wazuh-agent
   vars:
     wazuh_managers:
-      - address: <your manager IP>
+      - address: wazuh_aio
         port: 1514
         protocol: tcp
         api_port: 55000
@@ -14,3 +14,4 @@
         api_user: ansible
         max_retries: 5
         retry_interval: 5
+


### PR DESCRIPTION
In commit e532e214d56c15f676c6ca45f1ba4ba8078849f3 wazuh-agent changed from using hard coded values to placeholder text. While this solved the problem of defaulting to resources not in peoples environment it means everyone has to change the playbook, even in simple deployments.

This change introduces a wazuh_clients group for target hosts and uses wazuh_aio (also proposed in PR #930 ) for the managers address.