### PR TITLE
Added retry in Debian/Ubuntu installs in PR checks

### DIFF
--- a/roles/wazuh/ansible-filebeat-oss/tasks/main.yml
+++ b/roles/wazuh/ansible-filebeat-oss/tasks/main.yml
@@ -23,6 +23,9 @@
   tags:
   - install
   - init
+  until: "install is not failed"  
+  retries: 10
+  delay: 10
   when: ansible_os_family == 'Debian'
 
 - name: Checking if Filebeat Module folder file exists

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -8,6 +8,10 @@
       - tar
       - curl
     state: present
+  register: package_status
+  until: "package_status is not failed"  
+  retries: 10
+  delay: 10
 
 - include_vars: ../../vars/repo_vars.yml
 


### PR DESCRIPTION
Added a validation that the package has been installed and a series of delays and retrys to avoid failure due to dpkg lock stuck by another installation process.

Tests were performed on this PR https://github.com/wazuh/wazuh-ansible/pull/966