### PR TITLE
Updating vulnerability detector default configuration with AlmaLinux support

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -191,6 +191,12 @@ wazuh_manager_vulnerability_detector:
       update_interval: '1h'
       name: '"debian"'
     - enabled: 'no'
+      os:
+        - '8'
+        - '9'
+      update_interval: '1h'
+      name: '"almalinux"'
+    - enabled: 'no'
       update_from_year: '2010'
       update_interval: '1h'
       name: '"redhat"'


### PR DESCRIPTION
## Description

This PR adds the corresponding AlmaLinux entry in the vulnerability detector default configuration after the changes in [Add support for AlmaLinux in Vulnerability Detector](https://github.com/wazuh/wazuh/pull/16343#top)
#16343.

## DoD

- [x] Search for all the places where the vulnerability detector configuration block is defined and add the new AlmaLinux provider