### PR TITLE
Changed `check_packages` role order in playbooks

### DIFF
--- a/.github/playbooks/aio-wazuh.yml
+++ b/.github/playbooks/aio-wazuh.yml
@@ -3,6 +3,12 @@
   become: true
   become_user: root
   roles:
+    # 1. Check packages
+    - role: ../../roles/wazuh/check-packages
+      become: no
+      delegate_to: localhost
+      run_once: true
+    # 2. Generate certificates
     - role: ../../roles/wazuh/wazuh-indexer
       vars:
         generate_certs: true
@@ -30,24 +36,19 @@
   become: true
   become_user: root
   roles:
-    # 1. Check packages
-    - role: ../../roles/wazuh/check-packages
-      become: no
-      delegate_to: localhost
-      run_once: true
-    # 2. Wazuh indexer
+    # 1. Wazuh indexer
     - role: ../../roles/wazuh/wazuh-indexer
       vars:
         indexer_node_name: "wazuh-es01"
         single_node: true
-    # 3. Managers
+    # 2. Managers
     - role: ../../roles/wazuh/ansible-wazuh-manager
     - role: ../../roles/wazuh/ansible-filebeat-oss
       vars:
         filebeat_node_name: "wazuh-mgr01"
         filebeat_output_indexer_hosts:
         - "localhost:9200"
-    # 4. Wazuh dashboard
+    # 3. Wazuh dashboard
     - role: ../../roles/wazuh/wazuh-dashboard
       vars:
         dashboard_node_name: "wazuh-dash01"

--- a/.github/playbooks/single-wazuh.yml
+++ b/.github/playbooks/single-wazuh.yml
@@ -2,6 +2,10 @@
 - name: ConvergeCerts
   hosts: localhost
   roles:
+    - role: ../../roles/wazuh/check-packages
+      become: no
+      delegate_to: localhost
+      run_once: true
     - role: ../../roles/wazuh/wazuh-indexer
       perform_installation: false
   vars:
@@ -15,12 +19,7 @@
 - name: ConvergeInstall
   hosts: localhost
   roles:
-    # 1. Check packages
-    - role: ../../roles/wazuh/check-packages
-      become: no
-      delegate_to: localhost
-      run_once: true
-    # 2. Managers
+    # Managers
     - role: ../../roles/wazuh/ansible-wazuh-manager
       vars:
     - role: ../../roles/wazuh/ansible-filebeat-oss


### PR DESCRIPTION
# Description
Closes: #977 

The aim of this PR is to edit the playbooks in order to fetch the correct Wazuh packages. By making this change, the correct repository will be set before fetching the necessary resources (scripts and packages).