### PR TITLE
Removed NVD `update_from_year` parameter

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -224,7 +224,6 @@ wazuh_manager_vulnerability_detector:
       update_interval: '1h'
       name: '"msu"'
     - enabled: 'no'
-      update_from_year: '2010'
       update_interval: '1h'
       name: '"nvd"'
 


### PR DESCRIPTION
This PR aims to remove the `update_from_year` parameter of the VD config. This change was not incorporated in https://github.com/wazuh/wazuh-ansible/pull/983, so it is necessary to fix it.