### PR TITLE
Fixed MD5 checksum for 4.5.0

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -54,7 +54,7 @@ wazuh_winagent_config:
   # Adding quotes to auth_path_x86 since win_shell outputs error otherwise
   auth_path_x86: C:\'Program Files (x86)'\ossec-agent\agent-auth.exe
   check_md5: True
-  md5: a03806b7302767d0470d65d3f103fabb
+  md5: fd53c0afc26394ef5ce6a0922186de29
 
 wazuh_dir: "/var/ossec"
 


### PR DESCRIPTION
Partially closes: https://github.com/wazuh/wazuh-ansible/issues/990 
The aim of this PR is to fix the MD5 checksum for the `wazuh-agent-4.5.0.msi` file. 