### PR TITLE
Add Debian Bookworm to VDT default configuration

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -189,6 +189,7 @@ wazuh_manager_vulnerability_detector:
       os:
         - 'buster'
         - 'bullseye'
+        - 'bookworm'
       update_interval: '1h'
       name: '"debian"'
     - enabled: 'no'


### PR DESCRIPTION
|Related issue|
|---|
|wazuh/wazuh#18516|

## Description

This PR adds the corresponding Debian Bookworm entry in the vulnerability detector default configuration after the changes in [Add support for Debian Bookworm in Vulnerability Detector](https://github.com/wazuh/wazuh/pull/18516)

## DoD

- [x] Search for all the places where the vulnerability detector configuration block is defined and add the new Debian Bookworm provider