### PR TITLE
Changed Windows agent installation with SHA512 verification 

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -53,8 +53,7 @@ wazuh_winagent_config:
   auth_path: C:\Program Files\ossec-agent\agent-auth.exe
   # Adding quotes to auth_path_x86 since win_shell outputs error otherwise
   auth_path_x86: C:\'Program Files (x86)'\ossec-agent\agent-auth.exe
-  check_md5: True
-  md5: 3823a34bb108b9ad4e9fb43cb8f0b4e3
+  check_sha512: True
 
 wazuh_dir: "/var/ossec"
 

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Windows.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Windows.yml
@@ -30,16 +30,29 @@
   when:
     - not wazuh_package_downloaded.stat.exists
 
+- name: Windows | Download SHA512 checksum file
+  win_get_url:
+    url: "{{ wazuh_winagent_sha512_url }}"
+    dest: "{{ wazuh_winagent_config.download_dir }}"
+  when:
+    - not wazuh_package_downloaded.stat.exists
+  
+- name: Extract checksum from SHA512 file
+  win_shell: Get-Content "{{ wazuh_winagent_config.download_dir }}{{ wazuh_winagent_package_name }}.sha512" | ForEach-Object { $_.Split(' ')[0] }
+  register: extracted_checksum
+  when:
+    - not wazuh_package_downloaded.stat.exists
+
 - name: Windows | Verify the Wazuh Agent installer
   win_stat:
     path: "{{ wazuh_winagent_config.download_dir }}{{ wazuh_winagent_package_name }}"
     get_checksum: true
-    checksum_algorithm: md5
+    checksum_algorithm: sha512
   register: wazuh_agent_status
   failed_when:
-    - wazuh_agent_status.stat.checksum != wazuh_winagent_config.md5
+    - wazuh_agent_status.stat.checksum != extracted_checksum.stdout
   when:
-    - wazuh_winagent_config.check_md5
+    - wazuh_winagent_config.check_sha512
 
 
 - name: Windows | Install Agent if not already installed

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Windows.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Windows.yml
@@ -107,3 +107,8 @@
   win_file:
     path: "{{ wazuh_winagent_config.download_dir }}{{ wazuh_winagent_package_name }}"
     state: absent
+
+- name: Windows | Delete downloaded checksum file
+  win_file:
+    path: "{{ wazuh_winagent_config.download_dir }}{{ wazuh_winagent_package_name }}.sha512"
+    state: absent

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Windows.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Windows.yml
@@ -35,13 +35,13 @@
     url: "{{ wazuh_winagent_sha512_url }}"
     dest: "{{ wazuh_winagent_config.download_dir }}"
   when:
-    - not wazuh_package_downloaded.stat.exists
+    - wazuh_winagent_config.check_sha512
   
 - name: Extract checksum from SHA512 file
   win_shell: Get-Content "{{ wazuh_winagent_config.download_dir }}{{ wazuh_winagent_package_name }}.sha512" | ForEach-Object { $_.Split(' ')[0] }
   register: extracted_checksum
   when:
-    - not wazuh_package_downloaded.stat.exists
+    - wazuh_winagent_config.check_sha512
 
 - name: Windows | Verify the Wazuh Agent installer
   win_stat:
@@ -50,10 +50,9 @@
     checksum_algorithm: sha512
   register: wazuh_agent_status
   failed_when:
-    - wazuh_agent_status.stat.checksum != extracted_checksum.stdout
+    - wazuh_agent_status.stat.checksum != extracted_checksum.stdout_lines[0]
   when:
     - wazuh_winagent_config.check_sha512
-
 
 - name: Windows | Install Agent if not already installed
   win_package:

--- a/roles/wazuh/vars/repo.yml
+++ b/roles/wazuh/vars/repo.yml
@@ -5,7 +5,7 @@ wazuh_repo:
   key_id: '0DCFCA5547B19D2A6099506096B3EE5F29111145'
 wazuh_winagent_config_url: "https://packages.wazuh.com/4.x/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi"
 wazuh_winagent_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.msi"
-
+wazuh_winagent_sha512_url: "https://packages.wazuh.com/4.x/checksums/wazuh/{{ wazuh_agent_version }}/wazuh-agent-{{ wazuh_agent_version }}-1.msi.sha512"
 certs_gen_tool_version: 4.5
 
 # Url of certificates generator tool

--- a/roles/wazuh/vars/repo_pre-release.yml
+++ b/roles/wazuh/vars/repo_pre-release.yml
@@ -5,7 +5,7 @@ wazuh_repo:
   key_id: '0DCFCA5547B19D2A6099506096B3EE5F29111145'
 wazuh_winagent_config_url: "https://packages-dev.wazuh.com/pre-release/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi"
 wazuh_winagent_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.msi"
-
+wazuh_winagent_sha512_url: "https://packages-dev.wazuh.com/pre-release/checksums/wazuh/{{ wazuh_agent_version }}/wazuh-agent-{{ wazuh_agent_version }}-1.msi.sha512"
 certs_gen_tool_version: 4.5
 
 # Url of certificates generator tool


### PR DESCRIPTION
## Description

Closes: https://github.com/wazuh/wazuh-ansible/issues/1001

The aim of this PR is to change the MD5 checksum verification of the Windows agent by the SHA512 verification.
This change now uses the `.sha512` file located in our repositories and published in the releases, so the checksum is no longer hardcoded.

## Testing

Some testing has been performed in the `Testing` part of [this comment](https://github.com/wazuh/wazuh-ansible/issues/1001#issuecomment-1700979713).