### PR TITLE
Add Amazon Linux 2023 VDT default configuration

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -210,6 +210,7 @@ wazuh_manager_vulnerability_detector:
       os:
         - 'amazon-linux'
         - 'amazon-linux-2'
+        - 'amazon-linux-2023'
       update_interval: '1h'
       name: '"alas"'
     - enabled: 'no'


### PR DESCRIPTION
|Related issue|
|---|
|wazuh/wazuh#17617|

## Description

This PR adds the corresponding Amazon Linux 2023 entry in the vulnerability detector default configuration after the changes in [Add support for Amazon Linux 2023 in Vulnerability Detector](https://github.com/wazuh/wazuh/issues/17617)

## DoD

- [x] Search for all the places where the vulnerability detector configuration block is defined and add the new Amazon Linux 2023 provider