### PR TITLE
Adding missing filters for integrations

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
@@ -551,6 +551,12 @@
     {% if integration.rule_id is defined %}
     <rule_id>{{ integration.rule_id }}</rule_id>
     {% endif %}
+    {% if integration.group is defined %}
+    <group>{{ integration.group }}</group>
+    {% endif %}
+    {% if integration.event_location is defined %}
+    <event_location>{{ integration.event_location }}</event_location>
+    {% endif %}
   </integration>
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
Add `group` and `event_location`: https://documentation.wazuh.com/current/user-manual/manager/manual-integration.html