### PR TITLE
Fixed `wazuh_template_branch` and `config.yml` template name for `4.6.0`

### DIFF
--- a/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
+++ b/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 filebeat_version: 7.10.2
 
-wazuh_template_branch: 4.6
+wazuh_template_branch: v4.6.0
 
 filebeat_node_name: node-1
 

--- a/roles/wazuh/wazuh-indexer/tasks/local_actions.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/local_actions.yml
@@ -30,8 +30,8 @@
 
   - name: Local action | Prepare the certificates generation template file
     template:
-      src: "templates/wazuh-config.yml.j2"
-      dest: "{{ local_certs_path }}/wazuh-config.yml"
+      src: "templates/config.yml.j2"
+      dest: "{{ local_certs_path }}/config.yml"
       mode: 0644
     register: tlsconfig_template
 


### PR DESCRIPTION
## Description

This PR closes the following issue: https://github.com/wazuh/wazuh-ansible/issues/1030
The aim of this PR is to 
- Update the `wazuh_template_branch` variable which was pointing to the non-existing `4.6` branch. Now, it is pointed to the `v4.6.0` tag.
- Update the `config.yml` template name, changed from `wazuh-config.yml.j2` to `config.yml.j2`

## Logs

The following test was performed in Jenkins and the Demo deployment was successfully working: https://ci.wazuh.info/job/Procedure_deploy_demo/155/consoleFull