### PR TITLE
[FIX] Remove force_time from body when register agent in wazuh version 4.3 or above

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
@@ -149,7 +149,6 @@
         body:
           name: '{{ agent_name }}'
           ip: '{{ wazuh_agent_address }}'
-          force_time: 1
         headers:
           Authorization: 'Bearer {{ jwt_token }}'
         status_code: 200


### PR DESCRIPTION
According to [wazuh api 4.3 add agent](https://documentation.wazuh.com/4.3/user-manual/api/reference.html\#operation/api.controllers.agent_controller.add_agent) the `force_time` field has been removed. When executing ansible for register agent, wazuh manager makes an error