### PR TITLE
Fixed conditional that skip installation of dependencies

### DIFF
--- a/roles/wazuh/wazuh-indexer/tasks/Debian.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/Debian.yml
@@ -1,19 +1,19 @@
-
 ---
-
 - name: Update cache
   apt:
     update_cache: yes
 
-- name: Debian 9 (Stretch)
-  when: (ansible_facts['distribution'] == "Debian" and ansible_facts['distribution_major_version'] == "9")
+- name: Install Debian/Ubuntu pacakges dependencies
   block:
-
     - name: Install Wazuh indexer dependencies
       apt:
-        name: [
-          'unzip', 'wget', 'curl', 'apt-transport-https', software-properties-common
-        ]
+        name:
+          - unzip
+          - wget
+          - curl
+          - apt-transport-https
+          - software-properties-common
+          - gnupg
         state: present
 
 - name: Add Wazuh indexer repository
@@ -27,7 +27,7 @@
       apt_repository:
         repo: "{{ wazuh_repo.apt }}"
         state: present
-        filename: 'wazuh-indexer'
+        filename: "wazuh-indexer"
         update_cache: yes
 
 - name: Install Wazuh indexer


### PR DESCRIPTION
## What

* Removed block conditional that only allow install packages on Debian 9
* Add gnupg package as dependency

## Why

The actual playbook works well if the pacakages (unzip, apt-transport-https, gpg)  are already installed on the systems (Debian 11 in my case), but generate a error about missing packages if we try to install it on other system than Debain 9.

```bash
TASK [../roles/wazuh-ansible/roles/wazuh/wazuh-indexer : Add apt repository signing key] ***************************************************************************************************************************
fatal: [centreon-local]: FAILED! => {"changed": false, "msg": "Failed to find required executable \"gpg\" in paths: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
```

