### PR TITLE
Fix issue when there is more than one API user

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: "Install dependencies"
   package:
     name:
@@ -9,7 +8,7 @@
       - curl
     state: present
   register: package_status
-  until: "package_status is not failed"  
+  until: "package_status is not failed"
   retries: 10
   delay: 10
 
@@ -26,9 +25,9 @@
 
 - name: Overlay wazuh_manager_config on top of defaults
   set_fact:
-    wazuh_manager_config: '{{ wazuh_manager_config_defaults | combine(config_layer, recursive=True) }}'
+    wazuh_manager_config: "{{ wazuh_manager_config_defaults | combine(config_layer, recursive=True) }}"
   vars:
-    config_layer: '{{ wazuh_manager_config | default({}) }}'
+    config_layer: "{{ wazuh_manager_config | default({}) }}"
   when: wazuh_manager_config_overlay | bool
 
 - include_tasks: "RedHat.yml"
@@ -289,10 +288,8 @@
     - name: Execute create_user script
       script:
         chdir: "{{ wazuh_dir }}/framework/scripts/"
-        cmd: create_user.py --username "{{ item.username }}" --password "{{ item.password }}"
+        cmd: create_user.py
         executable: "{{ wazuh_dir }}/framework/python/bin/python3"
-      with_items:
-        - "{{ wazuh_api_users }}"
 
   tags:
     - config_api_users

--- a/roles/wazuh/ansible-wazuh-manager/templates/admin.json.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/admin.json.j2
@@ -1,4 +1,6 @@
-
+[
 {% for api in wazuh_api_users %}
-{"username":"{{ api['username'] }}", "password": "{{ api['password'] }}"}
+  {"username":"{{ api['username'] }}", "password": "{{ api['password'] }}"}{% if not loop.last %},{% endif %}
+
 {% endfor %}
+]


### PR DESCRIPTION
## What

* Fixed the `admin.json.j2` template to create valid JSON files.
* Modified the `create_user.py` script to read and process all user/password pairs from the `admin.json` file.
* Removed unnecessary parameters (`--username` and `--password`) from the Ansible task command that runs `create_user.py`.

## Why

1. When setting multiple API users or using default users like `wazuh` and `wazuh-gui` in the `wazuh_api_users` variable, the `admin.json.j2` template was generating an invalid JSON file, like:

```json
{"username":"wazuh", "password": "XXXXXX?o?uqu4eiria7j"}
{"username":"wazuh-gui", "password": "XXXXXXX?eirae.Woo9pushie"}
{"username":"custom-vhs", "password": "XXXXXXX??lSsJFEVXOBi7475k.u?MDX"}
```

which generate this error when the **create_user.py ** script try to read the file:

```bash
# /var/ossec/framework/python/bin/python3 create_user.py
Traceback (most recent call last):
  File "/var/ossec/framework/scripts/create_user.py", line 71, in <module>
    users = read_user_file()
  File "/var/ossec/framework/scripts/create_user.py", line 31, in read_user_file
    data = json.load(user_file)
  File "/var/ossec/framework/python/lib/python3.9/json/__init__.py", line 293, in load
    return loads(fp.read(),
  File "/var/ossec/framework/python/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/var/ossec/framework/python/lib/python3.9/json/decoder.py", line 340, in decode
    raise JSONDecodeError("Extra data", s, end)
json.decoder.JSONDecodeError: Extra data: line 3 column 1 (char 62)
``` 

With this fix, the template ensures that each user/password pair is correctly enclosed within its JSON object, resulting in valid JSON.


```json
[
{"username":"wazuh", "password": "XXXXXX?o?uqu4eiria7j"},
{"username":"wazuh-gui", "password": "XXXXXXX?eirae.Woo9pushie"},
{"username":"custom-vhs", "password": "XXXXXXX??lSsJFEVXOBi7475k.u?MDX"}
]
```


2. The `create_user.py` script now processes all user/password pairs from the `admin.json` file without requiring extra parameters (`--username` and `--password`).


