### PR TITLE
Correct re-register of filebeat_module_folder

### DIFF
--- a/roles/wazuh/ansible-filebeat-oss/tasks/main.yml
+++ b/roles/wazuh/ansible-filebeat-oss/tasks/main.yml
@@ -28,24 +28,24 @@
 - name: Checking if Filebeat Module folder file exists
   stat:
     path: "{{ filebeat_module_folder }}"
-  register: filebeat_module_folder
+  register: filebeat_module_folder_info
 
 - name: Download Filebeat module package
   get_url:
     url: "{{ filebeat_module_package_url }}/{{ filebeat_module_package_name }}"
     dest: "{{ filebeat_module_package_path }}"
-  when: not filebeat_module_folder.stat.exists
+  when: not filebeat_module_folder_info.stat.exists
 
 - name: Unpack Filebeat module package
   unarchive:
     src: "{{ filebeat_module_package_path }}/{{ filebeat_module_package_name }}"
     dest: "{{ filebeat_module_destination }}"
     remote_src: yes
-  when: not filebeat_module_folder.stat.exists
+  when: not filebeat_module_folder_info.stat.exists
 
 - name: Setting 0755 permission for Filebeat module folder
   file: dest={{ filebeat_module_folder }} mode=u=rwX,g=rwX,o=rwX recurse=yes
-  when: not filebeat_module_folder.stat.exists
+  when: not filebeat_module_folder_info.stat.exists
 
 - name: Checking if Filebeat Module package file exists
   stat:


### PR DESCRIPTION
The variable ``filebeat_module_folder`` was re-registered as its stat output, leading to an incorrect filepath being used later on.

```
[wazuh-host ~]$ ls
'{'\''changed'\'': False, '\''stat'\'': {'\''exists'\'': False}, '\''failed'\'': False}'
```

To illustrate, I added some debug outputs:
```
- name: Debug 1
  debug:
    msg: "{{ filebeat_module_folder }}"
- name: Checking if Filebeat Module folder file exists
  stat:
    path: "{{ filebeat_module_folder }}"
  register: filebeat_module_folder
- name: Debug 2
  debug:
    msg: "{{ filebeat_module_folder }}"
```

```
TASK [<ommitted>/ansible/roles/wazuh-ansible/wazuh-ansible/roles/wazuh/ansible-filebeat-oss : Debug 1] *****************************************************************************************
Thursday 12 October 2023  10:48:46 +0000 (0:00:00.067)       0:01:28.481 ******                                                                                                                                                                
ok: [ommitted] =>                                                                                                
  msg: /usr/share/filebeat/module/wazuh

TASK [<ommitted>/ansible/roles/wazuh-ansible/wazuh-ansible/roles/wazuh/ansible-filebeat-oss : Checking if Filebeat Module folder file exists] **************************************************
Thursday 12 October 2023  10:48:46 +0000 (0:00:00.073)       0:01:28.554 ****** 
ok: [ommitted]

TASK [<ommitted>/ansible/roles/wazuh-ansible/wazuh-ansible/roles/wazuh/ansible-filebeat-oss : Debug 2] *****************************************************************************************
Thursday 12 October 2023  10:48:47 +0000 (0:00:00.343)       0:01:28.898 ****** 
ok: [ommitted] => 
  msg:
    changed: false                                                                                                                                                                                                                             
    failed: false                                                                                                      
    stat:                 
      exists: false
```