### PR TITLE
Extend Ansible support for macOS endpoints

### DIFF
--- a/playbooks/wazuh-agent.yml
+++ b/playbooks/wazuh-agent.yml
@@ -10,7 +10,7 @@
         port: 1514
         protocol: tcp
         api_port: 55000
-        api_proto: 'http'
-        api_user: ansible
+        api_proto: 'https'
+        api_user: wazuh
         max_retries: 5
         retry_interval: 5

--- a/roles/wazuh/ansible-wazuh-agent/README.md
+++ b/roles/wazuh/ansible-wazuh-agent/README.md
@@ -12,6 +12,8 @@ This role is compatible with:
  * Fedora
  * Debian
  * Ubuntu
+ * Windows
+ * macOS
 
 
 Role Variables

--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -40,6 +40,7 @@ authd_pass: ''
 wazuh_api_reachable_from_agent: yes
 wazuh_profile_centos: 'centos, centos7, centos7.6'
 wazuh_profile_ubuntu: 'ubuntu, ubuntu18, ubuntu18.04'
+wazuh_profile_macos: 'darwin, darwin21, darwin21.1'
 wazuh_auto_restart: 'yes'
 
 wazuh_notify_time: '10'
@@ -230,6 +231,11 @@ wazuh_agent_syscheck:
       checks: ''
     - dirs: /bin,/sbin,/boot
       checks: ''
+  macos_directories:
+    - dirs: /etc,/usr/bin,/usr/sbin
+      checks: ''
+    - dirs: /bin,/sbin
+      checks: ''
   win_directories:
     - dirs: '%WINDIR%'
       checks: 'recursion_level="0" restrict="regedit.exe$|system.ini$|win.ini$"'
@@ -332,6 +338,17 @@ wazuh_agent_localfiles:
       command: netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d
       alias: 'netstat listening ports'
       frequency: '360'
+  macos:
+    - format: 'full_command'
+      command: netstat -an | awk '{if ((/^(tcp|udp)/) && ($4 != "*.*") && ($5 == "*.*")) {print $1" "$4" "$5}}' | sort -u
+      alias: 'netstat listening ports'
+      frequency: '360'
+    - format: 'macos'
+      location: 'macos'
+      query:
+        type: 'trace,log,activity'
+        level: 'info'
+        value: (process == "sudo") or (process == "sessionlogoutd" and message contains "logout is complete.") or (process == "sshd") or (process == "tccd" and message contains "Update Access Record") or (message contains "SessionAgentNotificationCenter") or (process == "screensharingd" and message contains "Authentication") or (process == "securityd" and eventMessage contains "Session" and subsystem == "com.apple.securityd")
   windows:
     - format: 'eventlog'
       location: 'Application'
@@ -355,6 +372,7 @@ wazuh_agent_active_response:
   ar_disabled: 'no'
   ca_store: "{{ wazuh_dir }}/etc/wpk_root.pem"
   ca_store_win: 'wpk_root.pem'
+  ca_store_macos: 'etc/wpk_root.pem'
   ca_verification: 'yes'
 
 ## Logging

--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -56,7 +56,7 @@ wazuh_winagent_config:
 
 # macOS deployment
 wazuh_macos_config:
-  download_dir: /
+  download_dir: /tmp/
   install_dir: /Library/Ossec/
 
 wazuh_dir: "/var/ossec"

--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -106,6 +106,7 @@ wazuh_agent_enrollment:
   agent_certificate_path: ''
   agent_key_path: ''
   authorization_pass_path: "{{ wazuh_dir }}/etc/authd.pass"
+  authorization_pass_path_macos: "/etc/authd.pass"
   auto_method: 'no'
   delay_after_enrollment: 20
   use_source_ip: 'no'

--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -54,6 +54,11 @@ wazuh_winagent_config:
   auth_path_x86: C:\'Program Files (x86)'\ossec-agent\agent-auth.exe
   check_sha512: True
 
+# macOS deployment
+wazuh_macos_config:
+  download_dir: /
+  install_dir: /Library/Ossec/
+
 wazuh_dir: "/var/ossec"
 
 # This is deprecated, see: wazuh_agent_address

--- a/roles/wazuh/ansible-wazuh-agent/handlers/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/handlers/main.yml
@@ -4,3 +4,6 @@
 
 - name: Windows | Restart Wazuh Agent
   win_service: name=WazuhSvc start_mode=auto state=restarted
+
+- name: macOS | Restart Wazuh Agent
+  command: /Library/Ossec/bin/wazuh-control restart

--- a/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml
@@ -1,0 +1,18 @@
+---
+- name: macOS | Check architecture
+  command: "/usr/bin/uname -m"
+  register: uname_result
+
+- name: macOS | Set architecture variable
+  set_fact:
+    macos_architecture: "{{ 'arm' if uname_result.stdout == 'arm64' else 'intel' }}"
+
+- name: macOS | Set package name and URL based on architecture
+  set_fact:
+    wazuh_macos_package_url: "{{ wazuh_macos_intel_package_url if macos_architecture == 'intel' else wazuh_macos_arm_package_url }}"
+    wazuh_macos_package_name: "{{ wazuh_macos_intel_package_name if macos_architecture == 'intel' else wazuh_macos_arm_package_name }}"
+
+- name: macOS | Check if Wazuh installer is already downloaded
+  stat:
+    path: "{{ wazuh_macos_config.download_dir }}{{ wazuh_macos_package_name }}"
+  register: wazuh_package_downloaded

--- a/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml
@@ -21,12 +21,117 @@
   get_url:
     url: "{{ wazuh_macos_package_url }}"
     dest: "{{ wazuh_macos_config.download_dir }}"
+  register: download_result
   when:
     - not wazuh_package_downloaded.stat.exists
+  
+- name: macOS | Check if Wazuh Agent is already installed
+  stat:
+    path: "{{ wazuh_macos_config.install_dir }}"
+  register: wazuh_installed
+
+- name: macOS | Install Agent if not already installed
+  command: "installer -pkg {{ wazuh_macos_config.download_dir }}{{ wazuh_macos_package_name }} -target /"
+  register: install_result
+
+- name: macOS | Check if client.keys exists
+  stat:
+    path: "{{ wazuh_macos_config.install_dir }}/etc/client.keys"
+  register: client_keys_file
+  tags:
+    - config
+
+- name: macOS | Agent registration via authd
+  block:
+
+    - name: Copy CA root certificate to verify authd
+      copy:
+        src: "{{ wazuh_agent_authd.ssl_agent_ca }}"
+        dest: "{{ wazuh_macos_config.install_dir }}/etc/{{ wazuh_agent_authd.ssl_agent_ca | basename }}"
+        mode: 0644
+      when:
+        - wazuh_agent_authd.ssl_agent_ca is not none
+
+    - name: Copy TLS/SSL certificate for agent verification
+      copy:
+        src: "{{ item }}"
+        dest: "{{ wazuh_macos_config.install_dir }}/etc/{{ item | basename }}"
+        mode: 0644
+      with_items:
+        - "{{ wazuh_agent_authd.ssl_agent_cert }}"
+        - "{{ wazuh_agent_authd.ssl_agent_key }}"
+      when:
+        - wazuh_agent_authd.ssl_agent_cert is not none
+        - wazuh_agent_authd.ssl_agent_key is not none
+    - name: macOS | Register agent (via authd)
+      shell: >
+        {{ wazuh_macos_config.install_dir }}/bin/agent-auth
+        {% if wazuh_agent_authd.agent_name is defined and wazuh_agent_authd.agent_name != None %}
+        -A {{ wazuh_agent_authd.agent_name }}
+        {% endif %}
+        -m {{ wazuh_agent_authd.registration_address }}
+        -p {{ wazuh_agent_authd.port }}
+        {% if wazuh_agent_nat %} -I "any" {% endif %}
+        {% if authd_pass | length > 0 %} -P {{ authd_pass }} {% endif %}
+        {% if wazuh_agent_authd.ssl_agent_ca is defined and wazuh_agent_authd.ssl_agent_ca != None %}
+        -v "{{ wazuh_macos_config.install_dir }}/etc/{{ wazuh_agent_authd.ssl_agent_ca | basename }}"
+        {% endif %}
+        {% if wazuh_agent_authd.ssl_agent_cert is defined and wazuh_agent_authd.ssl_agent_cert != None %}
+        -x "{{ wazuh_macos_config.install_dir }}/etc/{{ wazuh_agent_authd.ssl_agent_cert | basename }}"
+        {% endif %}
+        {% if wazuh_agent_authd.ssl_agent_key is defined and wazuh_agent_authd.ssl_agent_key != None  %}
+        -k "{{ wazuh_macos_config.install_dir }}/etc/{{ wazuh_agent_authd.ssl_agent_key | basename }}"
+        {% endif %}
+        {% if wazuh_agent_authd.ssl_auto_negotiate == 'yes' %} -a {% endif %}
+        {% if wazuh_agent_authd.groups is defined and wazuh_agent_authd.groups | length > 0 %}
+        -G "{{ wazuh_agent_authd.groups | join(',') }}"
+        {% endif %}
+      register: agent_auth_output
+      notify: macOS | Restart Wazuh Agent
+      vars:
+        agent_name: "{% if single_agent_name is defined %}{{ single_agent_name }}{% else %}{{ ansible_hostname }}{% endif %}"
+      when:
+        - not client_keys_file.stat.exists or client_keys_file.stat.size == 0
+        - wazuh_agent_authd.registration_address is not none
+
+    - name: macOS | Verify agent registration
+      shell: >
+        sh -c "echo '{{ agent_auth_output.stdout }} {{ agent_auth_output.stderr }}' | grep 'Valid key received'"
+      when:
+        - not client_keys_file.stat.exists or client_keys_file.stat.size == 0
+        - wazuh_agent_authd.registration_address is not none
+  when:
+    - wazuh_agent_authd.enable | bool
+    - wazuh_agent_config.enrollment.enabled != 'yes'
+  tags:
+    - config
+    - authd
+
+- name: macOS | Installing agent configuration (ossec.conf)
+  template:
+    src: var-ossec-etc-ossec-agent.conf.j2
+    dest: "{{ wazuh_macos_config.install_dir }}/etc/ossec.conf"
+    owner: root
+    group: wazuh
+    mode: 0644
+  notify: macOS | Restart Wazuh Agent
+  tags:
+    - init
+    - config
+
+- name: macOS | Installing local_internal_options.conf
+  template:
+    src: var-ossec-etc-local-internal-options.conf.j2
+    dest: "{{ wazuh_macos_config.install_dir }}/etc/local_internal_options.conf"
+    owner: root
+    group: wazuh
+    mode: 0640
+  notify: macOS | Restart Wazuh Agent
+  tags:
+    - init
+    - config
 
 - name: macOS | Delete downloaded Wazuh agent installer file
-  file:
-    path: "{{ wazuh_macos_config.download_dir }}{{ wazuh_macos_package_name }}"
-    state: absent
-  when:
-    - wazuh_package_downloaded.stat.exists
+   file:
+     path: "{{ wazuh_macos_config.download_dir }}{{ wazuh_macos_package_name }}"
+     state: absent

--- a/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml
@@ -107,6 +107,105 @@
     - config
     - authd
 
+- name: macOS | Agent registration via rest-API
+  block:
+
+    - name: macOS | Establish target Wazuh Manager for registration task
+      set_fact:
+        target_manager: '{{ manager_primary | length | ternary(manager_primary, manager_fallback) | first }}'
+      vars:
+        manager_primary: "{{ wazuh_managers | selectattr('register','true') | list }}"
+        manager_fallback: "{{ wazuh_managers | list }}"
+
+    - name: macOS | Obtain JWT Token
+      uri:
+        url: '{{ target_manager.api_proto }}://{{ target_manager.address }}:{{ target_manager.api_port }}/security/user/authenticate'
+        method: POST
+        url_username: '{{ target_manager.api_user }}'
+        url_password: '{{ api_pass }}'
+        status_code: 200
+        return_content: yes
+        force_basic_auth: yes
+        validate_certs: '{{ target_manager.validate_certs | default(false) }}'
+      no_log: '{{ wazuh_agent_nolog_sensible | bool }}'
+      delegate_to: '{{ inventory_hostname if wazuh_api_reachable_from_agent else "localhost" }}'
+      changed_when: api_jwt_result.json.error == 0
+      register: api_jwt_result
+      become: no
+      tags:
+        - config
+        - api
+
+    - name: macOS | Create the agent key via rest-API
+      uri:
+        url: '{{ target_manager.api_proto }}://{{ target_manager.address }}:{{ target_manager.api_port }}/agents'
+        method: POST
+        body_format: json
+        body:
+          name: '{{ agent_name }}'
+        headers:
+          Authorization: 'Bearer {{ jwt_token }}'
+        status_code: 200
+        return_content: yes
+        validate_certs: '{{ target_manager.validate_certs | default(false) }}'
+      become: no
+      no_log: '{{ wazuh_agent_nolog_sensible | bool }}'
+      delegate_to: '{{ inventory_hostname if wazuh_api_reachable_from_agent else "localhost" }}'
+      changed_when: api_agent_post.json.error == 0
+      register: api_agent_post
+      vars:
+        agent_name: '{{ target_manager.agent_name | default(ansible_hostname) }}'
+        jwt_token: '{{ api_jwt_result.json.data.token }}'
+      tags:
+        - config
+        - api
+
+    - name: macOS | Validate registered agent key matches manager record
+      uri:
+        url: '{{ target_manager.api_proto }}://{{ target_manager.address }}:{{ target_manager.api_port }}/agents/{{ agent_id }}/key'
+        method: GET
+        headers:
+          Authorization: 'Bearer {{ jwt_token }}'
+        status_code: 200
+        return_content: yes
+        validate_certs: '{{ target_manager.validate_certs | default(false) }}'
+      become: no
+      no_log: '{{ wazuh_agent_nolog_sensible | bool }}'
+      delegate_to: '{{ inventory_hostname if wazuh_api_reachable_from_agent else "localhost" }}'
+      register: api_agent_validation
+      vars:
+        agent_id: '{{ api_agent_post.json.data.id }}'
+        agent_key: '{{ api_agent_post.json.data.key }}'
+        jwt_token: '{{ api_jwt_result.json.data.token }}'
+      failed_when: api_agent_validation.json.data.affected_items[0].key != agent_key
+      when:
+      - wazuh_agent_api_validate | bool
+      - api_agent_post.json.error == 0
+      tags:
+        - config
+        - api
+
+    - name: macOS | Import Key (via rest-API)
+      command: "{{ wazuh_macos_config.install_dir }}/bin/manage_agents"
+      environment:
+        OSSEC_ACTION: i
+        OSSEC_AGENT_NAME: '{{ agent_name }}'
+        OSSEC_AGENT_IP: '{{ wazuh_agent_address }}'
+        OSSEC_AGENT_ID: '{{ api_agent_post.json.data.id }}'
+        OSSEC_AGENT_KEY: '{{ api_agent_post.json.data.key }}'
+        OSSEC_ACTION_CONFIRMED: y
+      register: manage_agents_output
+      vars:
+        agent_name: '{{ target_manager.agent_name | default(ansible_hostname) }}'
+      notify: macOS | Restart Wazuh Agent
+  when:
+    - not ( wazuh_agent_authd.enable | bool )
+    - wazuh_agent_config.enrollment.enabled != 'yes'
+    - not client_keys_file.stat.exists or client_keys_file.stat.size == 0
+  tags:
+    - config
+    - api
+
 - name: macOS | Installing agent configuration (ossec.conf)
   template:
     src: var-ossec-etc-ossec-agent.conf.j2
@@ -132,6 +231,6 @@
     - config
 
 - name: macOS | Delete downloaded Wazuh agent installer file
-   file:
+  file:
      path: "{{ wazuh_macos_config.download_dir }}{{ wazuh_macos_package_name }}"
      state: absent

--- a/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml
@@ -16,3 +16,17 @@
   stat:
     path: "{{ wazuh_macos_config.download_dir }}{{ wazuh_macos_package_name }}"
   register: wazuh_package_downloaded
+
+- name: macOS | Download Wazuh Agent package
+  get_url:
+    url: "{{ wazuh_macos_package_url }}"
+    dest: "{{ wazuh_macos_config.download_dir }}"
+  when:
+    - not wazuh_package_downloaded.stat.exists
+
+- name: macOS | Delete downloaded Wazuh agent installer file
+  file:
+    path: "{{ wazuh_macos_config.download_dir }}{{ wazuh_macos_package_name }}"
+    state: absent
+  when:
+    - wazuh_package_downloaded.stat.exists

--- a/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml
@@ -43,26 +43,6 @@
 
 - name: macOS | Agent registration via authd
   block:
-
-    - name: Copy CA root certificate to verify authd
-      copy:
-        src: "{{ wazuh_agent_authd.ssl_agent_ca }}"
-        dest: "{{ wazuh_macos_config.install_dir }}/etc/{{ wazuh_agent_authd.ssl_agent_ca | basename }}"
-        mode: 0644
-      when:
-        - wazuh_agent_authd.ssl_agent_ca is not none
-
-    - name: Copy TLS/SSL certificate for agent verification
-      copy:
-        src: "{{ item }}"
-        dest: "{{ wazuh_macos_config.install_dir }}/etc/{{ item | basename }}"
-        mode: 0644
-      with_items:
-        - "{{ wazuh_agent_authd.ssl_agent_cert }}"
-        - "{{ wazuh_agent_authd.ssl_agent_key }}"
-      when:
-        - wazuh_agent_authd.ssl_agent_cert is not none
-        - wazuh_agent_authd.ssl_agent_key is not none
     - name: macOS | Register agent (via authd)
       shell: >
         {{ wazuh_macos_config.install_dir }}/bin/agent-auth
@@ -73,15 +53,6 @@
         -p {{ wazuh_agent_authd.port }}
         {% if wazuh_agent_nat %} -I "any" {% endif %}
         {% if authd_pass | length > 0 %} -P {{ authd_pass }} {% endif %}
-        {% if wazuh_agent_authd.ssl_agent_ca is defined and wazuh_agent_authd.ssl_agent_ca != None %}
-        -v "{{ wazuh_macos_config.install_dir }}/etc/{{ wazuh_agent_authd.ssl_agent_ca | basename }}"
-        {% endif %}
-        {% if wazuh_agent_authd.ssl_agent_cert is defined and wazuh_agent_authd.ssl_agent_cert != None %}
-        -x "{{ wazuh_macos_config.install_dir }}/etc/{{ wazuh_agent_authd.ssl_agent_cert | basename }}"
-        {% endif %}
-        {% if wazuh_agent_authd.ssl_agent_key is defined and wazuh_agent_authd.ssl_agent_key != None  %}
-        -k "{{ wazuh_macos_config.install_dir }}/etc/{{ wazuh_agent_authd.ssl_agent_key | basename }}"
-        {% endif %}
         {% if wazuh_agent_authd.ssl_auto_negotiate == 'yes' %} -a {% endif %}
         {% if wazuh_agent_authd.groups is defined and wazuh_agent_authd.groups | length > 0 %}
         -G "{{ wazuh_agent_authd.groups | join(',') }}"

--- a/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml
@@ -206,6 +206,16 @@
     - config
     - api
 
+- name: macOS | Agent registration via auto-enrollment
+  debug:
+    msg: Agent registration will be performed through enrollment option in templated ossec.conf
+  when:  wazuh_agent_config.enrollment.enabled == 'yes'
+
+- name: macOS | Ensure group "wazuh" exists
+  ansible.builtin.group:
+    name: wazuh
+    state: present
+
 - name: macOS | Installing agent configuration (ossec.conf)
   template:
     src: var-ossec-etc-ossec-agent.conf.j2
@@ -228,6 +238,20 @@
   notify: macOS | Restart Wazuh Agent
   tags:
     - init
+    - config
+
+- name: Create auto-enrollment password file
+  template:
+    src: authd_pass.j2
+    dest: "{{ wazuh_macos_config.install_dir }}/etc/authd.pass"
+    owner: wazuh
+    group: wazuh
+    mode: 0640
+  when:
+    - wazuh_agent_config.enrollment.enabled == 'yes'
+    - wazuh_agent_config.enrollment.authorization_pass_path_macos | length > 0
+    - authd_pass | length > 0
+  tags:
     - config
 
 - name: macOS | Delete downloaded Wazuh agent installer file

--- a/roles/wazuh/ansible-wazuh-agent/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/main.yml
@@ -23,3 +23,6 @@
 
 - include_tasks: "Linux.yml"
   when: ansible_system == "Linux"
+
+- include_tasks: "macOS.yml"
+  when: ansible_system == "Darwin"

--- a/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
+++ b/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
@@ -67,8 +67,10 @@
       {% if wazuh_agent_config.enrollment.agent_key_path | length > 0 %}
       <agent_key_path>{{ wazuh_agent_config.enrollment.agent_key_path }}</agent_key_path>
       {% endif %}
-      {% if wazuh_agent_config.enrollment.authorization_pass_path | length > 0 %}
+      {% if wazuh_agent_config.enrollment.authorization_pass_path | length > 0 and ansible_system != "Darwin" %}
       <authorization_pass_path>{{ wazuh_agent_config.enrollment.authorization_pass_path }}</authorization_pass_path>
+      {% else %}
+      <authorization_pass_path>{{ wazuh_agent_config.enrollment.authorization_pass_path_macos }}</authorization_pass_path>
       {% endif %}
       {% if wazuh_agent_config.enrollment.auto_method | length > 0 %}
       <auto_method>{{ wazuh_agent_config.enrollment.auto_method }}</auto_method>

--- a/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
+++ b/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
@@ -30,6 +30,9 @@
     <config-profile>{{ wazuh_profile_ubuntu }}</config-profile>
     {% endif %}
     {% endif %}
+    {% if ansible_system == "Darwin" %}
+    <config-profile>{{ wazuh_profile_macos }}</config-profile>
+    {% endif %}
     {% if wazuh_notify_time is not none and wazuh_time_reconnect is not none %}
     <notify_time>{{ wazuh_notify_time }}</notify_time>
     <time-reconnect>{{ wazuh_time_reconnect }}</time-reconnect>
@@ -91,7 +94,7 @@
   {% if wazuh_agent_config.rootcheck is defined %}
   <rootcheck>
     <disabled>no</disabled>
-    {% if ansible_system == "Linux" %}
+    {% if ansible_system == "Linux" or ansible_system == "Darwin" %}
     <check_files>yes</check_files>
     <check_trojans>yes</check_trojans>
     <check_dev>yes</check_dev>
@@ -103,10 +106,14 @@
     <!-- Frequency that rootcheck is executed - every 12 hours -->
     <frequency>{{ wazuh_agent_config.rootcheck.frequency }}</frequency>
 
+    {% if ansible_system == "Darwin" %}
+    <rootkit_files>etc/shared/rootkit_files.txt</rootkit_files>
+    <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
+    {% else %}
     <rootkit_files>{{ wazuh_dir }}/etc/shared/rootkit_files.txt</rootkit_files>
     <rootkit_trojans>{{ wazuh_dir }}/etc/shared/rootkit_trojans.txt</rootkit_trojans>
-    <skip_nfs>yes</skip_nfs>
     {% endif %}
+    <skip_nfs>yes</skip_nfs>
     {% if ansible_os_family == "Windows" %}
     <windows_apps>./shared/win_applications_rcl.txt</windows_apps>
     <windows_malware>./shared/win_malware_rcl.txt</windows_malware>
@@ -179,6 +186,7 @@
   </wodle>
   {% endif %}
 
+  {% if ansible_system != "Darwin" %}
   <wodle name="cis-cat">
     <disabled>{{ wazuh_agent_config.cis_cat.disable }}</disabled>
     <timeout>{{ wazuh_agent_config.cis_cat.timeout }}</timeout>
@@ -193,6 +201,7 @@
     {% endif %}
     <ciscat_path>{% if ansible_os_family == "Windows" %}{{ wazuh_agent_config.cis_cat.ciscat_path_win }}{% else %}{{ wazuh_agent_config.cis_cat.ciscat_path }}{% endif %}</ciscat_path>
   </wodle>
+  {% endif %}
 
   <!-- Osquery integration -->
   <wodle name="osquery">
@@ -249,13 +258,18 @@
   <syscheck>
     <disabled>no</disabled>
     <frequency>{{ wazuh_agent_config.syscheck.frequency }}</frequency>
-    {% if ansible_system == "Linux" %}
+    {% if ansible_system == "Linux" or ansible_system == "Darwin" %}
     <scan_on_start>{{ wazuh_agent_config.syscheck.scan_on_start }}</scan_on_start>
     <!-- Directories to check  (perform all possible verifications) -->
     {% if wazuh_agent_config.syscheck.directories is defined and ansible_system == "Linux" %}
     {% for directory in wazuh_agent_config.syscheck.directories %}
     <directories {{ directory.checks }}>{{ directory.dirs }}</directories>
     {% endfor %}
+    {% elif ansible_system == "Darwin" %}
+    {% for directory in wazuh_agent_config.syscheck.macos_directories %}
+    <directories {{ directory.checks }}>{{ directory.dirs }}</directories>
+    {% endfor %}
+    {% endif %}
     {% endif %}
     {% endif %}
 
@@ -267,7 +281,7 @@
     {% endif %}
 
     <!-- Files/directories to ignore -->
-    {% if wazuh_agent_config.syscheck.ignore is defined and ansible_system == "Linux" %}
+    {% if wazuh_agent_config.syscheck.ignore is defined and (ansible_system == "Linux" or ansible_system == "Darwin") %}    
     {% for ignore in wazuh_agent_config.syscheck.ignore %}
     <ignore>{{ ignore }}</ignore>
     {% endfor %}
@@ -286,7 +300,7 @@
     {% endfor %}
     {% endif %}
 
-    {% if ansible_system == "Linux" %}
+    {% if ansible_system == "Linux" or ansible_system == "Darwin" %}
     <!-- Files no diff -->
     {% for no_diff in wazuh_agent_config.syscheck.no_diff %}
     <nodiff>{{ no_diff }}</nodiff>
@@ -359,6 +373,27 @@
     {% endfor %}
     {% endif %}
     {% endif %}
+  </localfile>
+  {% endfor %}
+  {% endif %}
+
+  {% if ansible_system == "Darwin" %}
+  {% for localfile in wazuh_agent_config.localfiles.macos %}
+
+  <localfile>
+    <log_format>{{ localfile.format }}</log_format>
+    {% if localfile.format == 'command' or localfile.format == 'full_command' %}
+    <command>{{ localfile.command }}</command>
+    <frequency>{{ localfile.frequency }}</frequency>
+    {% if localfile.alias is defined %}
+    <alias>{{ localfile.alias }}</alias>
+    {% endif %}
+  {% else %}
+    <location>{{ localfile.location }}</location>
+    {% if localfile.format == 'macos' %}
+    <query type="{{ localfile.query.type }}" level="{{ localfile.query.level }}">{{ localfile.query.value }}</query>
+    {% endif %}
+  {% endif %}
   </localfile>
   {% endfor %}
   {% endif %}
@@ -439,7 +474,15 @@
 
   <active-response>
     <disabled>{{ wazuh_agent_config.active_response.ar_disabled|default('no') }}</disabled>
-    <ca_store>{% if ansible_os_family == "Windows" %}{{ wazuh_agent_config.active_response.ca_store_win }}{% else %}{{ wazuh_agent_config.active_response.ca_store }}{% endif %}</ca_store>
+    <ca_store>
+    {% if ansible_os_family == "Windows" %}{{ wazuh_agent_config.active_response.ca_store_win }}
+    {% else %}
+    {% if ansible_system == "Darwin" %}{{ wazuh_agent_config.active_response.ca_store_macos }}
+    {% else %}
+    {{ wazuh_agent_config.active_response.ca_store }}
+    {% endif %}
+    {% endif %}
+    </ca_store>
     <ca_verification>{{ wazuh_agent_config.active_response.ca_verification }}</ca_verification>
   </active-response>
 

--- a/roles/wazuh/vars/repo.yml
+++ b/roles/wazuh/vars/repo.yml
@@ -7,6 +7,11 @@ wazuh_winagent_config_url: "https://packages.wazuh.com/4.x/windows/wazuh-agent-{
 wazuh_winagent_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.msi"
 wazuh_winagent_sha512_url: "https://packages.wazuh.com/4.x/checksums/wazuh/{{ wazuh_agent_version }}/wazuh-agent-{{ wazuh_agent_version }}-1.msi.sha512"
 
+wazuh_macos_intel_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.intel64.pkg"
+wazuh_macos_arm_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.arm64.pkg"
+wazuh_macos_intel_package_url: "https://packages.wazuh.com/4.x/macos/{{ wazuh_macos_intel_package_name }}"
+wazuh_macos_arm_package_url: "https://packages.wazuh.com/4.x/macos/{{ wazuh_macos_arm_package_name }}"
+
 certs_gen_tool_version: 4.8
 
 # Url of certificates generator tool

--- a/roles/wazuh/vars/repo_pre-release.yml
+++ b/roles/wazuh/vars/repo_pre-release.yml
@@ -7,6 +7,11 @@ wazuh_winagent_config_url: "https://packages-dev.wazuh.com/pre-release/windows/w
 wazuh_winagent_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.msi"
 wazuh_winagent_sha512_url: "https://packages-dev.wazuh.com/pre-release/checksums/wazuh/{{ wazuh_agent_version }}/wazuh-agent-{{ wazuh_agent_version }}-1.msi.sha512"
 
+wazuh_macos_intel_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.intel64.pkg"
+wazuh_macos_arm_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.arm64.pkg"
+wazuh_macos_intel_package_url: "https://packages-dev.wazuh.com/staging/pre-release/{{ wazuh_macos_intel_package_name }}"
+wazuh_macos_arm_package_url: "https://packages-dev.wazuh.com/pre-release/macos/{{ wazuh_macos_arm_package_name }}"
+
 certs_gen_tool_version: 4.8
 
 # Url of certificates generator tool

--- a/roles/wazuh/vars/repo_staging.yml
+++ b/roles/wazuh/vars/repo_staging.yml
@@ -6,6 +6,11 @@ wazuh_repo:
 wazuh_winagent_config_url: "https://packages-dev.wazuh.com/staging/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi"
 wazuh_winagent_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.msi"
 
+wazuh_macos_intel_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.intel64.pkg"
+wazuh_macos_arm_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.arm64.pkg"
+wazuh_macos_intel_package_url: "https://packages-dev.wazuh.com/staging/macos/{{ wazuh_macos_intel_package_name }}"
+wazuh_macos_arm_package_url: "https://packages-dev.wazuh.com/staging/macos/{{ wazuh_macos_arm_package_name }}"
+
 certs_gen_tool_version: 4.8
 
 # Url of certificates generator tool


### PR DESCRIPTION
## Description

Related issue: https://github.com/wazuh/wazuh-ansible/issues/768

The aim of this PR is to extend the Wazuh Ansible deployment to macOS endpoints. This means that this alternative is now able to install the Wazuh agent in the macOS systems.
A new role `macOS.yml` has been created and the `ossec.conf` template has been updated to support macOS configurations.

This new role supports the three types of enrollment: auto-enrollment (default), via API and via `agentd`.

## Testing

To ensure that this deployment is supported in every macOS-supported versions, is necessary to perform several tests.

### Intel

<details><summary>:green_circle: macOS Sierra</summary>

```console
PLAY [sierra,bigsur] ***********************************************************************************

TASK [Gathering Facts] *********************************************************************************
[WARNING]: Platform darwin on host 10.10.0.251 is using the discovered Python interpreter at
/usr/bin/python2.7, but future installation of another Python interpreter could change the meaning of
that path. See https://docs.ansible.com/ansible-
core/2.15/reference_appendices/interpreter_discovery.html for more information.
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ***********************************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ***********************************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ***********************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ***********************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : Overlay wazuh_agent_config on top of defaults] **************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] **********************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] **********************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] **********************************************
included: /home/davidcr01/Wazuh/ansible/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml for 10.10.0.251

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check architecture] *********************************
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Set architecture variable] **************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Set package name and URL based on architecture] *****
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if Wazuh installer is already downloaded] *****
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Download Wazuh Agent package] ***********************
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if Wazuh Agent is already installed] **********
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Install Agent if not already installed] *************
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if client.keys exists] ************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : Copy CA root certificate to verify authd] *******************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : Copy TLS/SSL certificate for agent verification] ************
skipping: [10.10.0.251] => (item=/home/davidcr01/test/sslagent.cert) 
skipping: [10.10.0.251] => (item=/home/davidcr01/test/sslagent.key) 
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Register agent (via authd)] *************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Verify agent registration] **************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Establish target Wazuh Manager for registration task] ***
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Obtain JWT Token] ***********************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Create the agent key via rest-API] ******************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Validate registered agent key matches manager record] ***
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Import Key (via rest-API)] **************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Agent registration via auto-enrollment] *************
ok: [10.10.0.251] => {
    "msg": "Agent registration will be performed through enrollment option in templated ossec.conf"
}

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Ensure group "wazuh" exists] ************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Installing agent configuration (ossec.conf)] ********
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Installing local_internal_options.conf] *************
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : Create auto-enrollment password file] ***********************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Delete downloaded Wazuh agent installer file] *******
changed: [10.10.0.251]

RUNNING HANDLER [../roles/wazuh/ansible-wazuh-agent : macOS | Restart Wazuh Agent] *********************
changed: [10.10.0.251]

PLAY RECAP *********************************************************************************************
10.10.0.251                : ok=19   changed=7    unreachable=0    failed=0    skipped=14   rescued=0    ignored=0   

```
![sierra-intel](https://github.com/wazuh/wazuh-ansible/assets/72193239/361d72a5-43b2-44ca-8874-cf0652c3b431)


</details>

<details><summary>:green_circle: macOS High Sierra </summary>

```console
PLAY [highsierra] *******************************************************************************************************************************

TASK [Gathering Facts] **************************************************************************************************************************
[WARNING]: Platform darwin on host 10.10.0.251 is using the discovered Python interpreter at /usr/bin/python2.7, but future installation of
another Python interpreter could change the meaning of that path. See https://docs.ansible.com/ansible-
core/2.15/reference_appendices/interpreter_discovery.html for more information.
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ****************************************************************************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ****************************************************************************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ****************************************************************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ****************************************************************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : Overlay wazuh_agent_config on top of defaults] *******************************************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] ***************************************************************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] ***************************************************************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] ***************************************************************************************
included: /home/davidcr01/Wazuh/ansible/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml for 10.10.0.251

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check architecture] **************************************************************************
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Set architecture variable] *******************************************************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Set package name and URL based on architecture] **********************************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if Wazuh installer is already downloaded] **********************************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Download Wazuh Agent package] ****************************************************************
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if Wazuh Agent is already installed] ***************************************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Install Agent if not already installed] ******************************************************
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if client.keys exists] *****************************************************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : Copy CA root certificate to verify authd] ************************************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : Copy TLS/SSL certificate for agent verification] *****************************************************
skipping: [10.10.0.251] => (item=/home/davidcr01/test/sslagent.cert) 
skipping: [10.10.0.251] => (item=/home/davidcr01/test/sslagent.key) 
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Register agent (via authd)] ******************************************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Verify agent registration] *******************************************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Establish target Wazuh Manager for registration task] ****************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Obtain JWT Token] ****************************************************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Create the agent key via rest-API] ***********************************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Validate registered agent key matches manager record] ****************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Import Key (via rest-API)] *******************************************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Agent registration via auto-enrollment] ******************************************************
ok: [10.10.0.251] => {
    "msg": "Agent registration will be performed through enrollment option in templated ossec.conf"
}

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Ensure group "wazuh" exists] *****************************************************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Installing agent configuration (ossec.conf)] *************************************************
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Installing local_internal_options.conf] ******************************************************
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : Create auto-enrollment password file] ****************************************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Delete downloaded Wazuh agent installer file] ************************************************
changed: [10.10.0.251]

RUNNING HANDLER [../roles/wazuh/ansible-wazuh-agent : macOS | Restart Wazuh Agent] **************************************************************
changed: [10.10.0.251]

PLAY RECAP **************************************************************************************************************************************
10.10.0.251                : ok=19   changed=7    unreachable=0    failed=0    skipped=14   rescued=0    ignored=0   
```
![highsierra-intel](https://github.com/wazuh/wazuh-ansible/assets/72193239/7a4fba86-6598-483c-882e-a41ddcfd07b4)


</details>

<details><summary>:green_circle: macOS Mojave </summary>

```console
> ansible-playbook wazuh-agent.yml

PLAY [mojave] ******************************************************************

TASK [Gathering Facts] *********************************************************
[WARNING]: Platform darwin on host 10.10.0.251 is using the discovered Python
interpreter at /usr/bin/python2.7, but future installation of another Python
interpreter could change the meaning of that path. See
https://docs.ansible.com/ansible-
core/2.15/reference_appendices/interpreter_discovery.html for more information.
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ***********************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ***********************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ***********************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ***********************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : Overlay wazuh_agent_config on top of defaults] ***
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] **********************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] **********************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] **********************
included: /home/davidcr01/Wazuh/ansible/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml for 10.10.0.251

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check architecture] *********
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Set architecture variable] ***
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Set package name and URL based on architecture] ***
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if Wazuh installer is already downloaded] ***
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Download Wazuh Agent package] ***
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if Wazuh Agent is already installed] ***
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Install Agent if not already installed] ***
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if client.keys exists] ***
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : Copy CA root certificate to verify authd] ***
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : Copy TLS/SSL certificate for agent verification] ***
skipping: [10.10.0.251] => (item=/home/davidcr01/test/sslagent.cert) 
skipping: [10.10.0.251] => (item=/home/davidcr01/test/sslagent.key) 
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Register agent (via authd)] ***
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Verify agent registration] ***
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Establish target Wazuh Manager for registration task] ***
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Obtain JWT Token] ***********
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Create the agent key via rest-API] ***
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Validate registered agent key matches manager record] ***
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Import Key (via rest-API)] ***
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Agent registration via auto-enrollment] ***
ok: [10.10.0.251] => {
    "msg": "Agent registration will be performed through enrollment option in templated ossec.conf"
}

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Ensure group "wazuh" exists] ***
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Installing agent configuration (ossec.conf)] ***
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Installing local_internal_options.conf] ***
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : Create auto-enrollment password file] ***
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Delete downloaded Wazuh agent installer file] ***
changed: [10.10.0.251]

RUNNING HANDLER [../roles/wazuh/ansible-wazuh-agent : macOS | Restart Wazuh Agent] ***
changed: [10.10.0.251]

PLAY RECAP *********************************************************************
10.10.0.251                : ok=19   changed=7    unreachable=0    failed=0    skipped=14   rescued=0    ignored=0 
```

![image](https://github.com/wazuh/wazuh-ansible/assets/72193239/ae84085a-1c4a-48e9-a1e7-9213f1b6b409)

</details>

<details><summary>:green_circle: macOS Catalina</summary>

```console
> ansible-playbook wazuh-agent.yml

PLAY [catalina] ****************************************************************

TASK [Gathering Facts] *********************************************************
[WARNING]: Platform darwin on host 10.10.0.251 is using the discovered Python
interpreter at /usr/bin/python3, but future installation of another Python
interpreter could change the meaning of that path. See
https://docs.ansible.com/ansible-
core/2.15/reference_appendices/interpreter_discovery.html for more information.
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ***********************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ***********************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ***********************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ***********************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : Overlay wazuh_agent_config on top of defaults] ***
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] **********************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] **********************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] **********************
included: /home/davidcr01/Wazuh/ansible/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml for 10.10.0.251

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check architecture] *********
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Set architecture variable] ***
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Set package name and URL based on architecture] ***
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if Wazuh installer is already downloaded] ***
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Download Wazuh Agent package] ***
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if Wazuh Agent is already installed] ***
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Install Agent if not already installed] ***
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if client.keys exists] ***
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : Copy CA root certificate to verify authd] ***
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : Copy TLS/SSL certificate for agent verification] ***
skipping: [10.10.0.251] => (item=) 
skipping: [10.10.0.251] => (item=) 
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Register agent (via authd)] ***
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Verify agent registration] ***
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Establish target Wazuh Manager for registration task] ***
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Obtain JWT Token] ***********
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Create the agent key via rest-API] ***
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Validate registered agent key matches manager record] ***
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Import Key (via rest-API)] ***
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Agent registration via auto-enrollment] ***
ok: [10.10.0.251] => {
    "msg": "Agent registration will be performed through enrollment option in templated ossec.conf"
}

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Ensure group "wazuh" exists] ***
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Installing agent configuration (ossec.conf)] ***
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Installing local_internal_options.conf] ***
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : Create auto-enrollment password file] ***
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Delete downloaded Wazuh agent installer file] ***
changed: [10.10.0.251]

RUNNING HANDLER [../roles/wazuh/ansible-wazuh-agent : macOS | Restart Wazuh Agent] ***
changed: [10.10.0.251]

PLAY RECAP *********************************************************************
10.10.0.251                : ok=19   changed=7    unreachable=0    failed=0    skipped=14   rescued=0    ignored=0   

```

![image](https://github.com/wazuh/wazuh-ansible/assets/72193239/484fdbe6-fc5b-4cdc-a7c7-6d598594cbcf)

</details>

<details><summary>:green_circle: macOS Big Sur </summary>

```console

>  ansible-playbook wazuh-agent.yml
[DEPRECATION WARNING]: DEFAULT_HASH_BEHAVIOUR option, this feature is fragile and not portable, leading to continual confusion and misuse, use the ``combine`` filter explicitly instead. This feature will be 
removed from ansible-base in version 2.13. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAY [bigsur] *****************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ********************************************************************************************************************************************************************************************
[WARNING]: Platform darwin on host 10.10.0.251 is using the discovered Python interpreter at /usr/bin/python, but future installation of another Python interpreter could change the meaning of that path. See
https://docs.ansible.com/ansible/2.10/reference_appendices/interpreter_discovery.html for more information.
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] **********************************************************************************************************************************************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] **********************************************************************************************************************************************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] **********************************************************************************************************************************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] **********************************************************************************************************************************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : Overlay wazuh_agent_config on top of defaults] *************************************************************************************************************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] *********************************************************************************************************************************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] *********************************************************************************************************************************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] *********************************************************************************************************************************************************
included: /home/nonsatus/Documents/Wazuh/Repositories/wazuh-ansible/merge/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml for 10.10.0.251

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check architecture] ********************************************************************************************************************************************
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Set architecture variable] *************************************************************************************************************************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Set package name and URL based on architecture] ****************************************************************************************************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if Wazuh installer is already downloaded] ****************************************************************************************************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Download Wazuh Agent package] **********************************************************************************************************************************
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if Wazuh Agent is already installed] *********************************************************************************************************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Install Agent if not already installed] ************************************************************************************************************************
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if client.keys exists] ***********************************************************************************************************************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : Copy CA root certificate to verify authd] ******************************************************************************************************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : Copy TLS/SSL certificate for agent verification] ***********************************************************************************************************************
skipping: [10.10.0.251] => (item=) 
skipping: [10.10.0.251] => (item=) 

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Register agent (via authd)] ************************************************************************************************************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Verify agent registration] *************************************************************************************************************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Establish target Wazuh Manager for registration task] **********************************************************************************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Obtain JWT Token] **********************************************************************************************************************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Create the agent key via rest-API] *****************************************************************************************************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Validate registered agent key matches manager record] **********************************************************************************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Import Key (via rest-API)] *************************************************************************************************************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Agent registration via auto-enrollment] ************************************************************************************************************************
ok: [10.10.0.251] => {
    "msg": "Agent registration will be performed through enrollment option in templated ossec.conf"
}

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Ensure group "wazuh" exists] ***********************************************************************************************************************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Installing agent configuration (ossec.conf)] *******************************************************************************************************************
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Installing local_internal_options.conf] ************************************************************************************************************************
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : Create auto-enrollment password file] **********************************************************************************************************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Delete downloaded Wazuh agent installer file] ******************************************************************************************************************
changed: [10.10.0.251]

RUNNING HANDLER [../roles/wazuh/ansible-wazuh-agent : macOS | Restart Wazuh Agent] ********************************************************************************************************************************
changed: [10.10.0.251]

PLAY RECAP ********************************************************************************************************************************************************************************************************
10.10.0.251                : ok=19   changed=7    unreachable=0    failed=0    skipped=14   rescued=0    ignored=0   
```

![image](https://github.com/wazuh/wazuh-ansible/assets/72193239/03886a93-0509-4f11-9101-986520bf0a7d)

</details>

<details><summary>:green_circle: macOS Monterey </summary>

```console
PLAY [macos] *******************************************************************************************

TASK [Gathering Facts] *********************************************************************************
[WARNING]: Platform darwin on host 10.10.0.251 is using the discovered Python interpreter at
/usr/bin/python3, but future installation of another Python interpreter could change the meaning of
that path. See https://docs.ansible.com/ansible-
core/2.15/reference_appendices/interpreter_discovery.html for more information.
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ***********************************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ***********************************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ***********************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ***********************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : Overlay wazuh_agent_config on top of defaults] **************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] **********************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] **********************************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] **********************************************
included: /home/davidcr01/Wazuh/ansible/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml for 10.10.0.251

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check architecture] *********************************
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Set architecture variable] **************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Set package name and URL based on architecture] *****
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if Wazuh installer is already downloaded] *****
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Download Wazuh Agent package] ***********************
changed: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if Wazuh Agent is already installed] **********
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if client.keys exists] ************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : Copy CA root certificate to verify authd] *******************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : Copy TLS/SSL certificate for agent verification] ************
skipping: [10.10.0.251] => (item=/home/davidcr01/test/sslagent.cert) 
skipping: [10.10.0.251] => (item=/home/davidcr01/test/sslagent.key) 
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Register agent (via authd)] *************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Verify agent registration] **************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Establish target Wazuh Manager for registration task] ***
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Obtain JWT Token] ***********************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Create the agent key via rest-API] ******************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Validate registered agent key matches manager record] ***
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Import Key (via rest-API)] **************************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Agent registration via auto-enrollment] *************
ok: [10.10.0.251] => {
    "msg": "Agent registration will be performed through enrollment option in templated ossec.conf"
}

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Ensure group "wazuh" exists] ************************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Installing agent configuration (ossec.conf)] ********
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Installing local_internal_options.conf] *************
ok: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : Create auto-enrollment password file] ***********************
skipping: [10.10.0.251]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Delete downloaded Wazuh agent installer file] *******
changed: [10.10.0.251]

PLAY RECAP *********************************************************************************************
10.10.0.251                : ok=17   changed=3    unreachable=0    failed=0    skipped=14   rescued=0    ignored=0 
```
![monterrey-intel](https://github.com/wazuh/wazuh-ansible/assets/72193239/c7b8c192-fec6-41e5-be01-dbaaf8ae0b2a)


</details>

<details><summary>:green_circle: macOS Ventura </summary>

```console
ansible-playbook wazuh-agent.yml

PLAY [ventura] ********************************************************************

TASK [Gathering Facts] ************************************************************
[WARNING]: Platform darwin on host 3.85.49.188 is using the discovered Python
interpreter at /usr/bin/python3, but future installation of another Python
interpreter could change the meaning of that path. See
https://docs.ansible.com/ansible-
core/2.15/reference_appendices/interpreter_discovery.html for more information.
ok: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] **************************
ok: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] **************************
ok: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] **************************
skipping: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] **************************
skipping: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : Overlay wazuh_agent_config on top of defaults] ***
ok: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] *************************
skipping: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] *************************
skipping: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] *************************
included: /home/davidcr01/Wazuh/ansible/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml for 3.85.49.188

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check architecture] ************
changed: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Set architecture variable] *****
ok: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Set package name and URL based on architecture] ***
ok: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if Wazuh installer is already downloaded] ***
ok: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Download Wazuh Agent package] ***
changed: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if Wazuh Agent is already installed] ***
ok: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Install Agent if not already installed] ***
changed: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if client.keys exists] ***
ok: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : Copy CA root certificate to verify authd] ***
skipping: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : Copy TLS/SSL certificate for agent verification] ***
skipping: [3.85.49.188] => (item=) 
skipping: [3.85.49.188] => (item=) 
skipping: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Register agent (via authd)] ****
skipping: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Verify agent registration] *****
skipping: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Establish target Wazuh Manager for registration task] ***
skipping: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Obtain JWT Token] **************
skipping: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Create the agent key via rest-API] ***
skipping: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Validate registered agent key matches manager record] ***
skipping: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Import Key (via rest-API)] *****
skipping: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Agent registration via auto-enrollment] ***
ok: [3.85.49.188] => {
    "msg": "Agent registration will be performed through enrollment option in templated ossec.conf"
}

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Ensure group "wazuh" exists] ***
ok: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Installing agent configuration (ossec.conf)] ***
changed: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Installing local_internal_options.conf] ***
changed: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : Create auto-enrollment password file] ***
skipping: [3.85.49.188]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Delete downloaded Wazuh agent installer file] ***
changed: [3.85.49.188]

RUNNING HANDLER [../roles/wazuh/ansible-wazuh-agent : macOS | Restart Wazuh Agent] ***
changed: [3.85.49.188]

PLAY RECAP ************************************************************************
3.85.49.188                : ok=19   changed=7    unreachable=0    failed=0    skipped=14   rescued=0    ignored=0   
```

![image](https://github.com/wazuh/wazuh-ansible/assets/72193239/aed4bd29-a1c7-48e8-b458-12b3ca729077)

</details>

### ARM

<details><summary>:green_circle: macOS Big Sur </summary>

```console
> ansible-playbook wazuh-agent.yml

PLAY [bigsurARM] ************************************************************************************************************************************

TASK [Gathering Facts] ******************************************************************************************************************************
[WARNING]: Platform darwin on host 3.92.185.158 is using the discovered Python interpreter at /usr/bin/python3, but future installation of another
Python interpreter could change the meaning of that path. See https://docs.ansible.com/ansible-
core/2.15/reference_appendices/interpreter_discovery.html for more information.
ok: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ********************************************************************************************
ok: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ********************************************************************************************
ok: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ********************************************************************************************
skipping: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ********************************************************************************************
skipping: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : Overlay wazuh_agent_config on top of defaults] ***********************************************************
ok: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] *******************************************************************************************
skipping: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] *******************************************************************************************
skipping: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] *******************************************************************************************
included: /home/davidcr01/Wazuh/ansible/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml for 3.92.185.158

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check architecture] ******************************************************************************
changed: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Set architecture variable] ***********************************************************************
ok: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Set package name and URL based on architecture] **************************************************
ok: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if Wazuh installer is already downloaded] **************************************************
ok: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Download Wazuh Agent package] ********************************************************************
changed: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if Wazuh Agent is already installed] *******************************************************
ok: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Install Agent if not already installed] **********************************************************
changed: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if client.keys exists] *********************************************************************
ok: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : Copy CA root certificate to verify authd] ****************************************************************
skipping: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : Copy TLS/SSL certificate for agent verification] *********************************************************
skipping: [3.92.185.158] => (item=) 
skipping: [3.92.185.158] => (item=) 
skipping: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Register agent (via authd)] **********************************************************************
skipping: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Verify agent registration] ***********************************************************************
skipping: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Establish target Wazuh Manager for registration task] ********************************************
skipping: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Obtain JWT Token] ********************************************************************************
skipping: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Create the agent key via rest-API] ***************************************************************
skipping: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Validate registered agent key matches manager record] ********************************************
skipping: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Import Key (via rest-API)] ***********************************************************************
skipping: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Agent registration via auto-enrollment] **********************************************************
ok: [3.92.185.158] => {
    "msg": "Agent registration will be performed through enrollment option in templated ossec.conf"
}

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Ensure group "wazuh" exists] *********************************************************************
ok: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Installing agent configuration (ossec.conf)] *****************************************************
changed: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Installing local_internal_options.conf] **********************************************************
changed: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : Create auto-enrollment password file] ********************************************************************
skipping: [3.92.185.158]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Delete downloaded Wazuh agent installer file] ****************************************************
changed: [3.92.185.158]

RUNNING HANDLER [../roles/wazuh/ansible-wazuh-agent : macOS | Restart Wazuh Agent] ******************************************************************
changed: [3.92.185.158]

PLAY RECAP ******************************************************************************************************************************************
3.92.185.158               : ok=19   changed=7    unreachable=0    failed=0    skipped=14   rescued=0    ignored=0  
```

![image](https://github.com/wazuh/wazuh-ansible/assets/72193239/4400f0e8-37ab-42be-ba11-eb6275eaf81a)

</details>

<details><summary>:green_circle: macOS Monterey </summary>

```console
PLAY [montereyARM] ***********************************************************************************************************************************************

TASK [Gathering Facts] *******************************************************************************************************************************************
[WARNING]: Platform darwin on host 10.10.0.250 is using the discovered Python interpreter at /usr/bin/python3, but future installation of another Python
interpreter could change the meaning of that path. See https://docs.ansible.com/ansible-core/2.15/reference_appendices/interpreter_discovery.html for more
information.
ok: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] *********************************************************************************************************
ok: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] *********************************************************************************************************
ok: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] *********************************************************************************************************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] *********************************************************************************************************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : Overlay wazuh_agent_config on top of defaults] ************************************************************************
ok: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] ********************************************************************************************************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] ********************************************************************************************************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] ********************************************************************************************************
included: /home/davidcr01/Wazuh/ansible/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml for 10.10.0.250

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check architecture] *******************************************************************************************
changed: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Set architecture variable] ************************************************************************************
ok: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Set package name and URL based on architecture] ***************************************************************
ok: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if Wazuh installer is already downloaded] ***************************************************************
ok: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Download Wazuh Agent package] *********************************************************************************
changed: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if Wazuh Agent is already installed] ********************************************************************
ok: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Install Agent if not already installed] ***********************************************************************
changed: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if client.keys exists] **********************************************************************************
ok: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : Copy CA root certificate to verify authd] *****************************************************************************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : Copy TLS/SSL certificate for agent verification] **********************************************************************
skipping: [10.10.0.250] => (item=/home/davidcr01/test/sslagent.cert) 
skipping: [10.10.0.250] => (item=/home/davidcr01/test/sslagent.key) 
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Register agent (via authd)] ***********************************************************************************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Verify agent registration] ************************************************************************************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Establish target Wazuh Manager for registration task] *********************************************************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Obtain JWT Token] *********************************************************************************************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Create the agent key via rest-API] ****************************************************************************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Validate registered agent key matches manager record] *********************************************************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Import Key (via rest-API)] ************************************************************************************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Agent registration via auto-enrollment] ***********************************************************************
ok: [10.10.0.250] => {
    "msg": "Agent registration will be performed through enrollment option in templated ossec.conf"
}

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Ensure group "wazuh" exists] **********************************************************************************
ok: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Installing agent configuration (ossec.conf)] ******************************************************************
changed: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Installing local_internal_options.conf] ***********************************************************************
changed: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : Create auto-enrollment password file] *********************************************************************************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Delete downloaded Wazuh agent installer file] *****************************************************************
changed: [10.10.0.250]

RUNNING HANDLER [../roles/wazuh/ansible-wazuh-agent : macOS | Restart Wazuh Agent] *******************************************************************************
changed: [10.10.0.250]

PLAY RECAP *******************************************************************************************************************************************************
10.10.0.250                : ok=19   changed=7    unreachable=0    failed=0    skipped=14   rescued=0    ignored=0  
```

![monterey-arm](https://github.com/wazuh/wazuh-ansible/assets/72193239/d212d8d0-0d41-40c8-a8d4-7591b6bc6434)

</details>

<details><summary>:green_circle: macOS Ventura </summary>

```console
PLAY [venturaARM] ******************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************
[WARNING]: Platform darwin on host 10.10.0.250 is using the discovered Python interpreter at /usr/bin/python3, but
future installation of another Python interpreter could change the meaning of that path. See
https://docs.ansible.com/ansible-core/2.15/reference_appendices/interpreter_discovery.html for more information.
ok: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ***************************************************************
ok: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ***************************************************************
ok: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ***************************************************************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ***************************************************************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : Overlay wazuh_agent_config on top of defaults] ******************************
ok: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] **************************************************************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] **************************************************************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] **************************************************************
included: /home/davidcr01/Wazuh/ansible/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml for 10.10.0.250

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check architecture] *************************************************
changed: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Set architecture variable] ******************************************
ok: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Set package name and URL based on architecture] *********************
ok: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if Wazuh installer is already downloaded] *********************
ok: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Download Wazuh Agent package] ***************************************
changed: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if Wazuh Agent is already installed] **************************
ok: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Install Agent if not already installed] *****************************
changed: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Check if client.keys exists] ****************************************
ok: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : Copy CA root certificate to verify authd] ***********************************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : Copy TLS/SSL certificate for agent verification] ****************************
skipping: [10.10.0.250] => (item=/home/davidcr01/test/sslagent.cert) 
skipping: [10.10.0.250] => (item=/home/davidcr01/test/sslagent.key) 
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Register agent (via authd)] *****************************************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Verify agent registration] ******************************************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Establish target Wazuh Manager for registration task] ***************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Obtain JWT Token] ***************************************************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Create the agent key via rest-API] **********************************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Validate registered agent key matches manager record] ***************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Import Key (via rest-API)] ******************************************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Agent registration via auto-enrollment] *****************************
ok: [10.10.0.250] => {
    "msg": "Agent registration will be performed through enrollment option in templated ossec.conf"
}

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Ensure group "wazuh" exists] ****************************************
ok: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Installing agent configuration (ossec.conf)] ************************
changed: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Installing local_internal_options.conf] *****************************
changed: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : Create auto-enrollment password file] ***************************************
skipping: [10.10.0.250]

TASK [../roles/wazuh/ansible-wazuh-agent : macOS | Delete downloaded Wazuh agent installer file] ***********************
changed: [10.10.0.250]

RUNNING HANDLER [../roles/wazuh/ansible-wazuh-agent : macOS | Restart Wazuh Agent] *************************************
changed: [10.10.0.250]

PLAY RECAP *************************************************************************************************************
10.10.0.250                : ok=19   changed=7    unreachable=0    failed=0    skipped=14   rescued=0    ignored=0   
```
![ventura-arm](https://github.com/wazuh/wazuh-ansible/assets/72193239/66dfcffe-7759-42db-b31d-ab7d6db9061a)


</details>
