### PR TITLE
Merge 4.6.0 into 4.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ All notable changes to this project will be documented in this file.
 
 - Update to [Wazuh v4.6.0](https://github.com/wazuh/wazuh/blob/v4.6.0/CHANGELOG.md#v460)
 
+## [v4.5.4]
+
+### Added
+
+- Update to [Wazuh v4.5.4](https://github.com/wazuh/wazuh/blob/v4.5.4/CHANGELOG.md#v454)
+
 ## [v4.5.3]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ These playbooks install and configure Wazuh agent, manager and indexer and dashb
 |---------------|---------|--------|
 | v4.7.0        |         |        |
 | v4.6.0        |         |        |
+| v4.5.4        |         |        |
 | v4.5.3        |         |        |
 | v4.5.2        |         |        |
 | v4.5.1        |         |        |


### PR DESCRIPTION
Related: https://github.com/wazuh/wazuh-ansible/issues/1087
The aim of this PR is to bump the 4.6.0 branch into the 4.7.0 branch.