### PR TITLE
Allow overriding the repo_vars_path

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 wazuh_agent_version: 4.9.0
 
+repo_vars_path: "../../vars/repo_vars.yml"
+
 # Custom packages installation
 
 wazuh_custom_packages_installation_agent_enabled: false

--- a/roles/wazuh/ansible-wazuh-agent/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- include_vars: ../../vars/repo_vars.yml
+- include_vars: "{{repo_vars_path}}"
 
 - include_vars: ../../vars/repo.yml
   when: packages_repository == 'production'

--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 wazuh_manager_version: 4.9.0
 
+repo_vars_path: "../../vars/repo_vars.yml"
+
 wazuh_manager_fqdn: "wazuh-server"
 wazuh_manager_package_state: present
 

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -13,7 +13,7 @@
   retries: 10
   delay: 10
 
-- include_vars: ../../vars/repo_vars.yml
+- include_vars: "{{repo_vars_path}}"
 
 - include_vars: ../../vars/repo.yml
   when: packages_repository == 'production'

--- a/roles/wazuh/wazuh-dashboard/defaults/main.yml
+++ b/roles/wazuh/wazuh-dashboard/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+repo_vars_path: "../../vars/repo_vars.yml"
 
 # Dashboard configuration
 indexer_http_port: 9200

--- a/roles/wazuh/wazuh-dashboard/tasks/main.yml
+++ b/roles/wazuh/wazuh-dashboard/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include_vars: ../../vars/repo_vars.yml
+- include_vars: "{{repo_vars_path}}"
 
 - include_vars: ../../vars/repo.yml
   when: packages_repository == 'production'

--- a/roles/wazuh/wazuh-indexer/defaults/main.yml
+++ b/roles/wazuh/wazuh-indexer/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+repo_vars_path: "../../vars/repo_vars.yml"
+
 # Cluster Settings
 indexer_version: 4.9.0
 

--- a/roles/wazuh/wazuh-indexer/tasks/main.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include_vars: ../../vars/repo_vars.yml
+- include_vars: "{{repo_vars_path}}"
 
 - include_vars: ../../vars/repo.yml
   when: packages_repository == 'production'


### PR DESCRIPTION
When a user installs Wazuh roles via Galaxy, the vars folder does not exist. This leads to odd folder structures in the consumers' code base when they attempt to create a replacement. 

With this change, the consumer can override the repo_vars_path and create a file containing all the vars. The production, pre-release, and staging vars will not load so long as they do not set packages_repository