### PR TITLE
Dashboard debian version

### DIFF
--- a/roles/wazuh/wazuh-dashboard/tasks/Debian.yml
+++ b/roles/wazuh/wazuh-dashboard/tasks/Debian.yml
@@ -1,7 +1,5 @@
 ---
 - block:
-
-  - include_vars: debian.yml
   - name: Add apt repository signing key
     apt_key:
       url: "{{ wazuh_repo.gpg }}"

--- a/roles/wazuh/wazuh-dashboard/vars/debian.yml
+++ b/roles/wazuh/wazuh-dashboard/vars/debian.yml
@@ -1,2 +1,0 @@
----
-dashboard_version: 4.9.0


### PR DESCRIPTION
Loading Debian vars hides default vars, preventing users from setting a preferred version. From git history, this file changes in step with dashboard_version in default vars so, removing.