### PR TITLE
Updated Filebeat module URL

### DIFF
--- a/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
+++ b/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
@@ -8,7 +8,7 @@ filebeat_node_name: node-1
 filebeat_output_indexer_hosts:
   - "localhost:9200"
 
-filebeat_module_package_url: https://packages.wazuh.com/4.x/filebeat
+filebeat_module_package_url: https://packages-dev.wazuh.com/pre-release/filebeat
 filebeat_module_package_name: wazuh-filebeat-0.2.tar.gz
 filebeat_module_package_path: /tmp/
 filebeat_module_destination: /usr/share/filebeat/module

--- a/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
+++ b/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
@@ -8,7 +8,6 @@ filebeat_node_name: node-1
 filebeat_output_indexer_hosts:
   - "localhost:9200"
 
-filebeat_module_package_url: https://packages-dev.wazuh.com/pre-release/filebeat
 filebeat_module_package_name: wazuh-filebeat-0.2.tar.gz
 filebeat_module_package_path: /tmp/
 filebeat_module_destination: /usr/share/filebeat/module

--- a/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
+++ b/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
@@ -8,7 +8,7 @@ filebeat_node_name: node-1
 filebeat_output_indexer_hosts:
   - "localhost:9200"
 
-filebeat_module_package_name: wazuh-filebeat-0.2.tar.gz
+filebeat_module_package_name: wazuh-filebeat-0.3.tar.gz
 filebeat_module_package_path: /tmp/
 filebeat_module_destination: /usr/share/filebeat/module
 filebeat_module_folder: /usr/share/filebeat/module/wazuh

--- a/roles/wazuh/ansible-filebeat-oss/tasks/main.yml
+++ b/roles/wazuh/ansible-filebeat-oss/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- include_vars: ../../vars/repo_vars.yml
+
+- include_vars: ../../vars/repo.yml
+  when: packages_repository == 'production'
+
+- include_vars: ../../vars/repo_pre-release.yml
+  when: packages_repository == 'pre-release'
+
 - include_tasks: RedHat.yml
   when: ansible_os_family == 'RedHat'
 

--- a/roles/wazuh/vars/repo.yml
+++ b/roles/wazuh/vars/repo.yml
@@ -6,6 +6,7 @@ wazuh_repo:
 wazuh_winagent_config_url: "https://packages.wazuh.com/4.x/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi"
 wazuh_winagent_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.msi"
 wazuh_winagent_sha512_url: "https://packages.wazuh.com/4.x/checksums/wazuh/{{ wazuh_agent_version }}/wazuh-agent-{{ wazuh_agent_version }}-1.msi.sha512"
+filebeat_module_package_url: https://packages.wazuh.com/4.x/filebeat
 
 certs_gen_tool_version: 4.7
 

--- a/roles/wazuh/vars/repo_pre-release.yml
+++ b/roles/wazuh/vars/repo_pre-release.yml
@@ -6,6 +6,7 @@ wazuh_repo:
 wazuh_winagent_config_url: "https://packages-dev.wazuh.com/pre-release/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi"
 wazuh_winagent_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.msi"
 wazuh_winagent_sha512_url: "https://packages-dev.wazuh.com/pre-release/checksums/wazuh/{{ wazuh_agent_version }}/wazuh-agent-{{ wazuh_agent_version }}-1.msi.sha512"
+filebeat_module_package_url: https://packages-dev.wazuh.com/pre-release/filebeat
 
 certs_gen_tool_version: 4.7
 


### PR DESCRIPTION
# Description

Closes: https://github.com/wazuh/wazuh-ansible/issues/1130

The aim of this PR is to update the Filebeat module URL. Now, the Filebeat module is downloaded from the `pre-release` directory of the `packages-dev.wazuh.com` repository, instead of the `packages.wazuh.com` repository.

## Testing

The testing has been done in https://github.com/wazuh/wazuh-ansible/issues/1130#issuecomment-1816028033.