### PR TITLE
Updated Filebeat module version to 0.4

### DIFF
--- a/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
+++ b/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
@@ -8,7 +8,7 @@ filebeat_node_name: node-1
 filebeat_output_indexer_hosts:
   - "localhost:9200"
 
-filebeat_module_package_name: wazuh-filebeat-0.3.tar.gz
+filebeat_module_package_name: wazuh-filebeat-0.4.tar.gz
 filebeat_module_package_path: /tmp/
 filebeat_module_destination: /usr/share/filebeat/module
 filebeat_module_folder: /usr/share/filebeat/module/wazuh


### PR DESCRIPTION
## Description

Related: https://github.com/wazuh/internal-devel-requests/issues/599
Related: https://github.com/wazuh/internal-devel-requests/issues/596

The aim of this PR is to update the Filebeat module version to 0.4.

## Testing

To test this change, the Wazuh stack has been deployed using the `wazuh-single.yml` playbook.
<details><summary>:green_circle: Show log</summary>

```console
> ansible-playbook wazuh-single.yml -v
Using /home/davidcr01/Wazuh/ansible/playbooks/ansible.cfg as config file

PLAY [ubuntu] *******************************************************************************************************

TASK [Gathering Facts] **********************************************************************************************
ok: [192.168.57.203]

TASK [../roles/wazuh/wazuh-indexer : include_vars] ******************************************************************
ok: [192.168.57.203] => {"ansible_facts": {"packages_repository": "pre-release"}, "ansible_included_var_files": ["/home/davidcr01/Wazuh/ansible/roles/wazuh/wazuh-indexer/tasks/../../vars/repo_vars.yml"], "changed": false}

TASK [../roles/wazuh/wazuh-indexer : include_vars] ******************************************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "packages_repository == 'production'", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/wazuh-indexer : include_vars] ******************************************************************
ok: [192.168.57.203] => {"ansible_facts": {"certs_gen_tool_url": "https://packages-dev.wazuh.com/{{ certs_gen_tool_version }}/wazuh-certs-tool.sh", "certs_gen_tool_version": 4.8, "filebeat_module_package_url": "https://packages-dev.wazuh.com/pre-release/filebeat", "wazuh_macos_arm_package_name": "wazuh-agent-{{ wazuh_agent_version }}-1.arm64.pkg", "wazuh_macos_arm_package_url": "https://packages-dev.wazuh.com/pre-release/macos/{{ wazuh_macos_arm_package_name }}", "wazuh_macos_intel_package_name": "wazuh-agent-{{ wazuh_agent_version }}-1.intel64.pkg", "wazuh_macos_intel_package_url": "https://packages-dev.wazuh.com/staging/pre-release/{{ wazuh_macos_intel_package_name }}", "wazuh_repo": {"apt": "deb https://packages-dev.wazuh.com/pre-release/apt/ unstable main", "gpg": "https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH", "key_id": "0DCFCA5547B19D2A6099506096B3EE5F29111145", "yum": "https://packages-dev.wazuh.com/pre-release/yum/"}, "wazuh_winagent_config_url": "https://packages-dev.wazuh.com/pre-release/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi", "wazuh_winagent_package_name": "wazuh-agent-{{ wazuh_agent_version }}-1.msi", "wazuh_winagent_sha512_url": "https://packages-dev.wazuh.com/pre-release/checksums/wazuh/{{ wazuh_agent_version }}/wazuh-agent-{{ wazuh_agent_version }}-1.msi.sha512"}, "ansible_included_var_files": ["/home/davidcr01/Wazuh/ansible/roles/wazuh/wazuh-indexer/tasks/../../vars/repo_pre-release.yml"], "changed": false}

TASK [../roles/wazuh/wazuh-indexer : include_vars] ******************************************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "packages_repository == 'staging'", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/wazuh-indexer : Check if certificates already exists] ******************************************
ok: [192.168.57.203 -> localhost] => {"changed": false, "stat": {"atime": 1702909942.7678032, "attr_flags": "e", "attributes": ["extents"], "block_size": 4096, "blocks": 8, "charset": "binary", "ctime": 1702909946.631828, "dev": 2051, "device_type": 0, "executable": true, "exists": true, "gid": 1000, "gr_name": "davidcr01", "inode": 10233092, "isblk": false, "ischr": false, "isdir": true, "isfifo": false, "isgid": false, "islnk": false, "isreg": false, "issock": false, "isuid": false, "mimetype": "inode/directory", "mode": "0755", "mtime": 1702909946.631828, "nlink": 3, "path": "/home/davidcr01/Wazuh/ansible/playbooks/indexer/certificates", "pw_name": "davidcr01", "readable": true, "rgrp": true, "roth": true, "rusr": true, "size": 4096, "uid": 1000, "version": "3877728327", "wgrp": false, "woth": false, "writeable": true, "wusr": true, "xgrp": true, "xoth": true, "xusr": true}}

TASK [../roles/wazuh/wazuh-indexer : Local action | Create local temporary directory for certificates generation] ***
skipping: [192.168.57.203] => {"changed": false, "false_condition": "not certificates_folder.stat.exists", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/wazuh-indexer : Local action | Check that the generation tool exists] **************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "not certificates_folder.stat.exists", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/wazuh-indexer : Reload systemd configuration] **************************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "perform_installation", "skip_reason": "Conditional result was False"}

PLAY [ubuntu] *******************************************************************************************************

TASK [Gathering Facts] **********************************************************************************************
ok: [192.168.57.203]

TASK [../roles/wazuh/wazuh-indexer : include_vars] ******************************************************************
ok: [192.168.57.203] => {"ansible_facts": {"packages_repository": "pre-release"}, "ansible_included_var_files": ["/home/davidcr01/Wazuh/ansible/roles/wazuh/wazuh-indexer/tasks/../../vars/repo_vars.yml"], "changed": false}

TASK [../roles/wazuh/wazuh-indexer : include_vars] ******************************************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "packages_repository == 'production'", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/wazuh-indexer : include_vars] ******************************************************************
ok: [192.168.57.203] => {"ansible_facts": {"certs_gen_tool_url": "https://packages-dev.wazuh.com/{{ certs_gen_tool_version }}/wazuh-certs-tool.sh", "certs_gen_tool_version": 4.8, "filebeat_module_package_url": "https://packages-dev.wazuh.com/pre-release/filebeat", "wazuh_macos_arm_package_name": "wazuh-agent-{{ wazuh_agent_version }}-1.arm64.pkg", "wazuh_macos_arm_package_url": "https://packages-dev.wazuh.com/pre-release/macos/{{ wazuh_macos_arm_package_name }}", "wazuh_macos_intel_package_name": "wazuh-agent-{{ wazuh_agent_version }}-1.intel64.pkg", "wazuh_macos_intel_package_url": "https://packages-dev.wazuh.com/staging/pre-release/{{ wazuh_macos_intel_package_name }}", "wazuh_repo": {"apt": "deb https://packages-dev.wazuh.com/pre-release/apt/ unstable main", "gpg": "https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH", "key_id": "0DCFCA5547B19D2A6099506096B3EE5F29111145", "yum": "https://packages-dev.wazuh.com/pre-release/yum/"}, "wazuh_winagent_config_url": "https://packages-dev.wazuh.com/pre-release/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi", "wazuh_winagent_package_name": "wazuh-agent-{{ wazuh_agent_version }}-1.msi", "wazuh_winagent_sha512_url": "https://packages-dev.wazuh.com/pre-release/checksums/wazuh/{{ wazuh_agent_version }}/wazuh-agent-{{ wazuh_agent_version }}-1.msi.sha512"}, "ansible_included_var_files": ["/home/davidcr01/Wazuh/ansible/roles/wazuh/wazuh-indexer/tasks/../../vars/repo_pre-release.yml"], "changed": false}

TASK [../roles/wazuh/wazuh-indexer : include_vars] ******************************************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "packages_repository == 'staging'", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/wazuh-indexer : Check if certificates already exists] ******************************************
ok: [192.168.57.203 -> localhost] => {"changed": false, "stat": {"atime": 1702909942.7678032, "attr_flags": "e", "attributes": ["extents"], "block_size": 4096, "blocks": 8, "charset": "binary", "ctime": 1702909946.631828, "dev": 2051, "device_type": 0, "executable": true, "exists": true, "gid": 1000, "gr_name": "davidcr01", "inode": 10233092, "isblk": false, "ischr": false, "isdir": true, "isfifo": false, "isgid": false, "islnk": false, "isreg": false, "issock": false, "isuid": false, "mimetype": "inode/directory", "mode": "0755", "mtime": 1702909946.631828, "nlink": 3, "path": "/home/davidcr01/Wazuh/ansible/playbooks/indexer/certificates", "pw_name": "davidcr01", "readable": true, "rgrp": true, "roth": true, "rusr": true, "size": 4096, "uid": 1000, "version": "3877728327", "wgrp": false, "woth": false, "writeable": true, "wusr": true, "xgrp": true, "xoth": true, "xusr": true}}
"Conditional result was False"}

TASK [../roles/wazuh/wazuh-indexer : Install Wazuh indexer] *********************************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "ansible_os_family == 'RedHat'", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/wazuh-indexer : Restart Wazuh indexer with security configuration] *****************************
changed: [192.168.57.203] => {"changed": true, "name": "wazuh-indexer", "state": "started", "status": {"ActiveEnterTimestamp": "Mon 2023-12-18 14:33:12 UTC", "ActiveEnterTimestampMonotonic": "545558153", "ActiveExitTimestamp": "n/a",wazuh-indexer"}}

TASK [../roles/wazuh/wazuh-indexer : Copy the Opensearch security internal users template] **************************
changed: [192.168.57.203] => {"changed": true, "checksum": "6475bb616c085f988c1fe09fe9e96750acadf3af", "dest": "/etc/wazuh-indexer/opensearch-security/internal_users.yml", "gid": 122, "group": "wazuh-indexer", "md5sum": "499247bfbc0488b8ddffe47663ebb7a3", "mode": "0644", "owner": "wazuh-indexer", "size": 396, "src": "/home/vagrant/.ansible/tmp/ansible-tmp-1702910284.5670917-38759-103362054756521/source", "state": "file", "uid": 114}

TASK [../roles/wazuh/wazuh-indexer : Hashing the custom admin password] *********************************************
changed: [192.168.57.203] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": true}

TASK [../roles/wazuh/wazuh-indexer : Set the Admin user password] ***************************************************
changed: [192.168.57.203] => {"changed": true, "msg": "1 replacements made", "rc": 0}

TASK [../roles/wazuh/wazuh-indexer : Hash the kibanaserver role/user pasword] ***************************************
changed: [192.168.57.203] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": true}

TASK [../roles/wazuh/wazuh-indexer : Set the kibanaserver user password] ********************************************
changed: [192.168.57.203] => {"changed": true, "msg": "1 replacements made", "rc": 0}

TASK [../roles/wazuh/wazuh-indexer : Create custom user] ************************************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "indexer_custom_user is defined and indexer_custom_user", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/wazuh-indexer : Configure Wazuh indexer JVM memmory.] ******************************************
ok: [192.168.57.203] => {"changed": false, "checksum": "fad8d325d95b5de5bd25aebfe83d13a782a2f2df", "dest": "/etc/wazuh-indexer/jvm.options", "gid": 122, "group": "wazuh-indexer", "mode": "0644", "owner": "root", "path": "/etc/wazuh-indexer/jvm.options", "size": 2475, "state": "file", "uid": 0}

TASK [../roles/wazuh/wazuh-indexer : Ensure extra time for Wazuh indexer to start on reboots] ***********************
ok: [192.168.57.203] => {"backup": "", "changed": false, "msg": ""}

TASK [../roles/wazuh/wazuh-indexer : Index files to remove] *********************************************************
ok: [192.168.57.203] => {"changed": false, "examined": 1, "files": [], "matched": 0, "msg": "All paths examined", "skipped_paths": {}}

TASK [../roles/wazuh/wazuh-indexer : Remove Index Files] ************************************************************
skipping: [192.168.57.203] => {"changed": false, "skipped_reason": "No items in the list"}

TASK [../roles/wazuh/wazuh-indexer : Ensure Wazuh indexer started and enabled] **************************************
ok: [192.168.57.203] => {"changed": false, "enabled": true, "name": "wazuh-indexer", "state": "started", "status": {"ActiveEnterTimestamp": "Mon 2023-12-18 14:38:02 UTC", "ActiveEnterTimestampMonotonic": "835769595", "ActiveExitTimestamp": "Mon 2023-12-18 14:37:41 UTC", "ActiveExitTimestampMonotonic": "814444563", "ActiveState": "active", "After": "-.mount tmp.mount", "WatchdogSignal": "6", "WatchdogTimestamp": "n/a", "WatchdogTimestampMonotonic": "0", "WatchdogUSec": "0", "WorkingDirectory": "/usr/share/wazuh-indexer"}}

TASK [../roles/wazuh/wazuh-indexer : Wait for Wazuh indexer API] ****************************************************
ok: [192.168.57.203] => {"attempts": 1, "changed": false, "content": "1702910298 14:38:18 wazuh yellow 1 1 true 7 7 0 0 3 0 - 70.0%\n", "content_length": "62", "content_type": "text/plain; charset=UTF-8", "cookies": {}, "cookies_string": "", "elapsed": 0, "msg": "OK (62 bytes)", "redirected": false, "status": 200, "url": "https://127.0.0.1:9200/_cat/health/"}

TASK [../roles/wazuh/wazuh-indexer : Wait for Wazuh indexer API (Private IP)] ***************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "hostvars[inventory_hostname]['private_ip'] is defined and hostvars[inventory_hostname]['private_ip']", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/wazuh-indexer : RedHat/CentOS/Fedora | Remove Wazuh indexer repository (and clean up left-over metadata)] ***
skipping: [192.168.57.203] => {"changed": false, "false_condition": "ansible_os_family == \"RedHat\"", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/wazuh-indexer : Reload systemd configuration] **************************************************
ok: [192.168.57.203] => {"changed": false, "name": null, "status": {}}

TASK [../roles/wazuh/ansible-wazuh-manager : Install dependencies] **************************************************
ok: [192.168.57.203] => {"attempts": 1, "cache_update_time": 1702910249, "cache_updated": false, "changed": false}

TASK [../roles/wazuh/ansible-wazuh-manager : include_vars] **********************************************************
ok: [192.168.57.203] => {"ansible_facts": {"packages_repository": "pre-release"}, "ansible_included_var_files": ["/home/davidcr01/Wazuh/ansible/roles/wazuh/ansible-wazuh-manager/vars/../../vars/repo_vars.yml"], "changed": false}

TASK [../roles/wazuh/ansible-wazuh-manager : include_vars] **********************************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "packages_repository == 'production'", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-manager : include_vars] **********************************************************
ok: [192.168.57.203] => {"ansible_facts": {"certs_gen_tool_url": "https://packages-dev.wazuh.com/{{ certs_gen_tool_version }}/wazuh-certs-tool.sh", "certs_gen_tool_version": 4.8, "filebeat_module_package_url": "https://packages-dev.wazuh.com/pre-release/filebeat", "wazuh_macos_arm_package_name": "wazuh-agent-{{ wazuh_agent_version }}-1.arm64.pkg", "wazuh_macos_arm_package_url": "https://packages-dev.wazuh.com/pre-release/macos/{{ wazuh_macos_arm_package_name }}", "wazuh_macos_intel_package_name": "wazuh-agent-{{ wazuh_agent_version }}-1.intel64.pkg", "wazuh_macos_intel_package_url": "https://packages-dev.wazuh.com/staging/pre-release/{{ wazuh_macos_intel_package_name }}", "wazuh_repo": {"apt": "deb https://packages-dev.wazuh.com/pre-release/apt/ unstable main", "gpg": "https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH", "key_id": "0DCFCA5547B19D2A6099506096B3EE5F29111145", "yum": "https://packages-dev.wazuh.com/pre-release/yum/"}, "wazuh_winagent_config_url": "https://packages-dev.wazuh.com/pre-release/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi", "wazuh_winagent_package_name": "wazuh-agent-{{ wazuh_agent_version }}-1.msi", "wazuh_winagent_sha512_url": "https://packages-dev.wazuh.com/pre-release/checksums/wazuh/{{ wazuh_agent_version }}/wazuh-agent-{{ wazuh_agent_version }}-1.msi.sha512"}, "ansible_included_var_files": ["/home/davidcr01/Wazuh/ansible/roles/wazuh/ansible-wazuh-manager/vars/../../vars/repo_pre-release.yml"], "changed": false}

TASK [../roles/wazuh/ansible-wazuh-manager : include_vars] **********************************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "packages_repository == 'staging'", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-manager : Overlay wazuh_manager_config on top of defaults] ***********************
ok: [192.168.57.203] => {"ansible_facts": {"wazuh_manager_config": {"agents_disconnection_alert_time": "100s", "agents_disconnection_time": "20s", "alerts_log": "yes", "api": {"access_block_time": 300, "access_max_login_attempts": 5, "access_max_request_per_minute": 300, "behind_proxy_server": false, "bind_addr": "0.0.0.0", "cache": true, "cache_time": 0.75, "update_interval": "1h"}, {"enabled": "no", "name": "\"arch\"", "update_interval": "1h"}, {"enabled": "no", "name": "\"msu\"", "update_interval": "1h"}, {"enabled": "no", "name": "\"nvd\"", "update_interval": "1h"}], "run_on_start": "yes"}}}, "changed": false}

TASK [../roles/wazuh/ansible-wazuh-manager : include_tasks] *********************************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "(ansible_os_family == \"RedHat\" and ansible_distribution_major_version|int > 5) or (ansible_os_family  == \"RedHat\" and ansible_distribution == \"Amazon\")", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-manager : include_tasks] *********************************************************
included: /home/davidcr01/Wazuh/ansible/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml for 192.168.57.203

TASK [../roles/wazuh/ansible-wazuh-manager : Debian/Ubuntu | Install apt-transport-https, ca-certificates and acl] ***
ok: [192.168.57.203] => {"attempts": 1, "cache_update_time": 1702910249, "cache_updated": false, "changed": false}

TASK [../roles/wazuh/ansible-wazuh-manager : Debian/Ubuntu | Installing Wazuh repository key (Ubuntu 14)] ***********
skipping: [192.168.57.203] => {"changed": false, "false_condition": "ansible_distribution_major_version | int == 14", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-manager : Debian/Ubuntu | Installing Wazuh repository key] ***********************
ok: [192.168.57.203] => {"before": ["96B3EE5F29111145", "417F3D5A664FAB32", "D94AA3F0EFE21092", "871920D1991BC93C"], "changed": false, "fp": "96B3EE5F29111145", "id": "0DCFCA5547B19D2A6099506096B3EE5F29111145", "key_id": "0DCFCA5547B19D2A6099506096B3EE5F29111145", "short_id": "29111145"}

TASK [../roles/wazuh/ansible-wazuh-manager : Debian/Ubuntu | Add Wazuh repositories] ********************************
ok: [192.168.57.203] => {"changed": false, "repo": "deb https://packages-dev.wazuh.com/pre-release/apt/ unstable main", "sources_added": [], "sources_removed": [], "state": "present"}

TASK [../roles/wazuh/ansible-wazuh-manager : Debian/Ubuntu | Set Distribution CIS filename for Debian/Ubuntu] *******
ok: [192.168.57.203] => {"ansible_facts": {"cis_distribution_filename": "cis_debian_linux_rcl.txt"}, "changed": false}

TASK [../roles/wazuh/ansible-wazuh-manager : Debian/Ubuntu | Install OpenJDK-8 repo] ********************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "(ansible_distribution == \"Ubuntu\" and ansible_distribution_major_version | int == 14)", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-manager : Debian/Ubuntu | Install OpenJDK 1.8] ***********************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "wazuh_manager_config.cis_cat.disable == 'no'", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-manager : Debian/Ubuntu | Install OpenScap] **************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "wazuh_manager_config.openscap.disable == 'no'", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-manager : Debian/Ubuntu | Get OpenScap installed version] ************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "wazuh_manager_config.openscap.disable == 'no'", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-manager : Debian/Ubuntu | Check OpenScap version] ********************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "wazuh_manager_config.openscap.disable == 'no'", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-manager : Debian/Ubuntu | Install wazuh-manager] *********************************
ok: [192.168.57.203] => {"cache_update_time": 1702910249, "cache_updated": false, "changed": false}

TASK [../roles/wazuh/ansible-wazuh-manager : include_tasks] *********************************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "wazuh_custom_packages_installation_manager_enabled", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-manager : Install expect] ********************************************************
ok: [192.168.57.203] => {"cache_update_time": 1702910249, "cache_updated": false, "changed": false}

TASK [../roles/wazuh/ansible-wazuh-manager : Generate SSL files for authd] ******************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "wazuh_manager_config.authd.ssl_agent_ca is not none", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-manager : Copy CA, SSL key and cert for authd] ***********************************
skipping: [192.168.57.203] => (item=)  => {"ansible_loop_var": "item", "changed": false, "false_condition": "wazuh_manager_config.authd.ssl_agent_ca is not none", "item": "", "skip_reason": "Conditional result was False"}
skipping: [192.168.57.203] => (item=sslmanager.cert)  => {"ansible_loop_var": "item", "changed": false, "false_condition": "wazuh_manager_config.authd.ssl_agent_ca is not none", "item": "sslmanager.cert", "skip_reason": "Conditional result was False"}
skipping: [192.168.57.203] => (item=sslmanager.key)  => {"ansible_loop_var": "item", "changed": false, "false_condition": "wazuh_manager_config.authd.ssl_agent_ca is not none", "item": "sslmanager.key", "skip_reason": "Conditional result was False"}
skipping: [192.168.57.203] => {"changed": false, "msg": "All items skipped"}

TASK [../roles/wazuh/ansible-wazuh-manager : Verifying for old init authd service] **********************************
ok: [192.168.57.203] => {"changed": false, "stat": {"exists": false}}

TASK [../roles/wazuh/ansible-wazuh-manager : Verifying for old systemd authd service] *******************************
ok: [192.168.57.203] => {"changed": false, "stat": {"exists": false}}

TASK [../roles/wazuh/ansible-wazuh-manager : Ensure ossec-authd service is disabled] ********************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "old_authd_service.stat.exists", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-manager : Removing old init authd services] **************************************
skipping: [192.168.57.203] => (item=/etc/init.d/ossec-authd)  => {"ansible_loop_var": "item", "changed": false, "false_condition": "old_authd_service.stat.exists", "item": "/etc/init.d/ossec-authd", "skip_reason": "Conditional result was False"}
skipping: [192.168.57.203] => (item=/lib/systemd/system/ossec-authd.service)  => {"ansible_loop_var": "item", "changed": false, "false_condition": "old_authd_service.stat.exists", "item": "/lib/systemd/system/ossec-authd.service", "skip_reason": "Conditional result was False"}
skipping: [192.168.57.203] => {"changed": false, "msg": "All items skipped"}

TASK [../roles/wazuh/ansible-wazuh-manager : Installing the local_rules.xml (default local_rules.xml)] **************
ok: [192.168.57.203] => {"changed": false, "checksum": "e2ed6d5f4bc85b2a6338ffa3b67af9c56a6a2b9b", "dest": "/var/ossec/etc/rules/local_rules.xml", "gid": 123, "group": "wazuh", "mode": "0640", "owner": "wazuh", "path": "/var/ossec/etc/rules/local_rules.xml", "size": 496, "state": "file", "uid": 115}

TASK [../roles/wazuh/ansible-wazuh-manager : Adding local rules files] **********************************************
ok: [192.168.57.203] => {"changed": false, "checksum": "948b7acf2a4e9434837fd8a9ae4282d764159a34", "dest": "/var/ossec/etc/rules/sample_custom_rules.xml", "gid": 123, "group": "wazuh", "mode": "0640", "owner": "wazuh", "path": "/var/ossec/etc/rules/sample_custom_rules.xml", "size": 457, "state": "file", "uid": 115}

TASK [../roles/wazuh/ansible-wazuh-manager : Installing the local_decoder.xml] **************************************
ok: [192.168.57.203] => {"changed": false, "checksum": "22b3dffce338aa3b465f90b0a442f1892ab416dd", "dest": "/var/ossec/etc/decoders/local_decoder.xml", "gid": 123, "group": "wazuh", "mode": "0640", "owner": "wazuh", "path": "/var/ossec/etc/decoders/local_decoder.xml", "size": 775, "state": "file", "uid": 115}

TASK [../roles/wazuh/ansible-wazuh-manager : Adding local decoders files] *******************************************
ok: [192.168.57.203] => {"changed": false, "checksum": "ef2930e35e0d314628a611effb545e0571e49b5d", "dest": "/var/ossec/etc/decoders/sample_custom_decoders.xml", "gid": 123, "group": "wazuh", "mode": "0640", "owner": "wazuh", "path": "/var/ossec/etc/decoders/sample_custom_decoders.xml", "size": 775, "state": "file", "uid": 115}

TASK [../roles/wazuh/ansible-wazuh-manager : Configure the shared-agent.conf] ***************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "shared_agent_config is defined", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-manager : Installing the local_internal_options.conf] ****************************
ok: [192.168.57.203] => {"changed": false, "checksum": "e2c8d0d38358dcd7c92e57b8f2cb0e7dfcf112e3", "dest": "/var/ossec/etc/local_internal_options.conf", "gid": 123, "group": "wazuh", "mode": "0640", "owner": "root", "path": "/var/ossec/etc/local_internal_options.conf", "size": 473, "state": "file", "uid": 0}

TASK [../roles/wazuh/ansible-wazuh-manager : Retrieving Agentless Credentials] **************************************
ok: [192.168.57.203] => {"ansible_facts": {}, "ansible_included_var_files": ["/home/davidcr01/Wazuh/ansible/roles/wazuh/ansible-wazuh-manager/vars/agentless_creds.yml"], "changed": false}

TASK [../roles/wazuh/ansible-wazuh-manager : Retrieving authd Credentials] ******************************************
ok: [192.168.57.203] => {"ansible_facts": {}, "ansible_included_var_files": ["/home/davidcr01/Wazuh/ansible/roles/wazuh/ansible-wazuh-manager/vars/authd_pass.yml"], "changed": false}

TASK [../roles/wazuh/ansible-wazuh-manager : Check if syslog output is enabled] *************************************
skipping: [192.168.57.203] => (item={'server': None, 'port': None, 'format': None})  => {"ansible_loop_var": "item", "changed": false, "false_condition": "item.server is not none", "item": {"format": null, "port": null, "server": null}, "skip_reason": "Conditional result was False"}
skipping: [192.168.57.203] => {"changed": false, "msg": "All items skipped"}

TASK [../roles/wazuh/ansible-wazuh-manager : Check if client-syslog is enabled] *************************************
ok: [192.168.57.203] => {"changed": false, "cmd": "set -o pipefail\n\"grep -c 'ossec-csyslogd' /var/ossec/bin/.process_list | xargs echo\"\n", "delta": null, "end": null, "msg": "Did not run command since '/var/ossec/bin/.process_list' does not exist", "rc": 0, "start": null, "stderr": "", "stderr_lines": [], "stdout": "skipped, since /var/ossec/bin/.process_list does not exist", "stdout_lines": ["skipped, since /var/ossec/bin/.process_list does not exist"]}

TASK [../roles/wazuh/ansible-wazuh-manager : Enable client-syslog] **************************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "syslog_output is defined and syslog_output", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-manager : Check if ossec-agentlessd is enabled] **********************************
ok: [192.168.57.203] => {"changed": false, "cmd": "set -o pipefail\n\"grep -c 'ossec-agentlessd' /var/ossec/bin/.process_list | xargs echo\"\n", "delta": null, "end": null, "msg": "Did not run command since '/var/ossec/bin/.process_list' does not exist", "rc": 0, "start": null, "stderr": "", "stderr_lines": [], "stdout": "skipped, since /var/ossec/bin/.process_list does not exist", "stdout_lines": ["skipped, since /var/ossec/bin/.process_list does not exist"]}

TASK [../roles/wazuh/ansible-wazuh-manager : Enable ossec-agentlessd] ***********************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "agentless_creds is defined", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-manager : Checking alert log output settings] ************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "wazuh_manager_config.json_output == 'no'", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-manager : Configure ossec.conf] **************************************************
ok: [192.168.57.203] => {"changed": false, "checksum": "0f19f528e94fe10363c55307c3820b98b5935b2c", "dest": "/var/ossec/etc/ossec.conf", "gid": 123, "group": "wazuh", "mode": "0644", "owner": "root", "path": "/var/ossec/etc/ossec.conf", "size": 10070, "state": "file", "uid": 0}

TASK [../roles/wazuh/ansible-wazuh-manager : Ossec-authd password] **************************************************
skipping: [192.168.57.203] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}

TASK [../roles/wazuh/ansible-wazuh-manager : Copy create_user script] ***********************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "wazuh_api_users is defined", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-manager : Create admin.json] *****************************************************
skipping: [192.168.57.203] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}

TASK [../roles/wazuh/ansible-wazuh-manager : Execute create_user script] ********************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "wazuh_api_users is defined", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-manager : Agentless Hosts & Passwd] **********************************************
skipping: [192.168.57.203] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}

TASK [../roles/wazuh/ansible-wazuh-manager : Encode the secret] *****************************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "agentless_creds is defined", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-manager : Ensure Wazuh Manager service is started and enabled.] ******************
ok: [192.168.57.203] => {"changed": false, "enabled": true, "name": "wazuh-manager", "state": "started", "status": "TimeoutStopUSec": "1min 30s", "TimerSlackNSec": "50000", "Transient": "no", "Type": "forking", "UID": "[not set]", "UMask": "0022", "UnitFilePreset": "enabled", "UnitFileState": "enabled", "UtmpMode": "init", "WantedBy": "multi-user.target", "Wants": "network-online.target", "WatchdogSignal": "6", "WatchdogTimestamp": "n/a", "WatchdogTimestampMonotonic": "0", "WatchdogUSec": "0"}}

TASK [../roles/wazuh/ansible-wazuh-manager : Create agent groups] ***************************************************
skipping: [192.168.57.203] => {"changed": false, "skipped_reason": "No items in the list"}

TASK [../roles/wazuh/ansible-wazuh-manager : Run uninstall tasks] ***************************************************
included: /home/davidcr01/Wazuh/ansible/roles/wazuh/ansible-wazuh-manager/tasks/uninstall.yml for 192.168.57.203

TASK [../roles/wazuh/ansible-wazuh-manager : Debian/Ubuntu | Remove Wazuh repository.] ******************************
ok: [192.168.57.203] => {"changed": false, "repo": "deb https://packages-dev.wazuh.com/pre-release/apt/ unstable main", "sources_added": [], "sources_removed": ["/etc/apt/sources.list.d/wazuh-indexer.list"], "state": "absent"}

TASK [../roles/wazuh/ansible-wazuh-manager : RedHat/CentOS/Fedora | Remove Wazuh repository (and clean up left-over metadata)] ***
skipping: [192.168.57.203] => {"changed": false, "false_condition": "ansible_os_family == \"RedHat\" or ansible_os_family == \"Amazon\"", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-filebeat-oss : include_vars] ***********************************************************
ok: [192.168.57.203] => {"ansible_facts": {"packages_repository": "pre-release"}, "ansible_included_var_files": ["/home/davidcr01/Wazuh/ansible/roles/wazuh/ansible-filebeat-oss/tasks/../../vars/repo_vars.yml"], "changed": false}

TASK [../roles/wazuh/ansible-filebeat-oss : include_vars] ***********************************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "packages_repository == 'production'", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-filebeat-oss : include_vars] ***********************************************************
ok: [192.168.57.203] => {"ansible_facts": {"certs_gen_tool_url": "https://packages-dev.wazuh.com/{{ certs_gen_tool_version }}/wazuh-certs-tool.sh", "certs_gen_tool_version": 4.8, "filebeat_module_package_url": "https://packages-dev.wazuh.com/pre-release/filebeat", "wazuh_macos_arm_package_name": "wazuh-agent-{{ wazuh_agent_version }}-1.arm64.pkg", "wazuh_macos_arm_package_url": "https://packages-dev.wazuh.com/pre-release/macos/{{ wazuh_macos_arm_package_name }}", "wazuh_macos_intel_package_name": "wazuh-agent-{{ wazuh_agent_version }}-1.intel64.pkg", "wazuh_macos_intel_package_url": "https://packages-dev.wazuh.com/staging/pre-release/{{ wazuh_macos_intel_package_name }}", "wazuh_repo": {"apt": "deb https://packages-dev.wazuh.com/pre-release/apt/ unstable main", "gpg": "https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH", "key_id": "0DCFCA5547B19D2A6099506096B3EE5F29111145", "yum": "https://packages-dev.wazuh.com/pre-release/yum/"}, "wazuh_winagent_config_url": "https://packages-dev.wazuh.com/pre-release/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi", "wazuh_winagent_package_name": "wazuh-agent-{{ wazuh_agent_version }}-1.msi", "wazuh_winagent_sha512_url": "https://packages-dev.wazuh.com/pre-release/checksums/wazuh/{{ wazuh_agent_version }}/wazuh-agent-{{ wazuh_agent_version }}-1.msi.sha512"}, "ansible_included_var_files": ["/home/davidcr01/Wazuh/ansible/roles/wazuh/ansible-filebeat-oss/tasks/../../vars/repo_pre-release.yml"], "changed": false}

TASK [../roles/wazuh/ansible-filebeat-oss : include_tasks] **********************************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "ansible_os_family == 'RedHat'", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-filebeat-oss : include_tasks] **********************************************************
included: /home/davidcr01/Wazuh/ansible/roles/wazuh/ansible-filebeat-oss/tasks/Debian.yml for 192.168.57.203

TASK [../roles/wazuh/ansible-filebeat-oss : Debian/Ubuntu | Install apt-transport-https, ca-certificates and acl] ***
ok: [192.168.57.203] => {"attempts": 1, "cache_update_time": 1702910316, "cache_updated": false, "changed": false}

TASK [../roles/wazuh/ansible-filebeat-oss : Debian/Ubuntu | Add Elasticsearch apt key.] *****************************
ok: [192.168.57.203] => {"before": ["96B3EE5F29111145", "417F3D5A664FAB32", "D94AA3F0EFE21092", "871920D1991BC93C"], "changed": false, "fp": "96B3EE5F29111145", "id": "0DCFCA5547B19D2A6099506096B3EE5F29111145", "key_id": "0DCFCA5547B19D2A6099506096B3EE5F29111145", "short_id": "29111145"}

TASK [../roles/wazuh/ansible-filebeat-oss : Debian/Ubuntu | Add Filebeat-oss repository.] ***************************
ok: [192.168.57.203] => {"changed": false, "repo": "deb https://packages.wazuh.com/4.x/apt/ stable main", "sources_added": [], "sources_removed": [], "state": "present"}

TASK [../roles/wazuh/ansible-filebeat-oss : Install Filebeat | Redhat] **********************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "ansible_os_family == 'RedHat'", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-filebeat-oss : Install Filebeat | Debian] **********************************************
ok: [192.168.57.203] => {"attempts": 1, "cache_update_time": 1702910316, "cache_updated": false, "changed": false}

TASK [../roles/wazuh/ansible-filebeat-oss : Checking if Filebeat Module folder file exists] *************************
ok: [192.168.57.203] => {"changed": false, "stat": {"atime": 1702910175.3234773, "attr_flags": "e", "attributes": ["extents"], "block_size": 4096, "blocks": 8, "charset": "binary", "ctime": 1702910175.3234773, "dev": 64768, "device_type": 0, "executable": true, "exists": true, "gid": 0, "gr_name": "root", "inode": 3437576, "isblk": false, "ischr": false, "isdir": true, "isfifo": false, "isgid": false, "islnk": false, "isreg": false, "issock": false, "isuid": false, "mimetype": "inode/directory", "mode": "0755", "mtime": 1702906578.0, "nlink": 5, "path": "/usr/share/filebeat/module/wazuh", "pw_name": "root", "readable": true, "rgrp": true, "roth": true, "rusr": true, "size": 4096, "uid": 0, "version": "3659869669", "wgrp": false, "woth": false, "writeable": true, "wusr": true, "xgrp": true, "xoth": true, "xusr": true}}

TASK [../roles/wazuh/ansible-filebeat-oss : Download Filebeat module package] ***************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "not filebeat_module_folder.stat.exists", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-filebeat-oss : Unpack Filebeat module package] *****************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "not filebeat_module_folder.stat.exists", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-filebeat-oss : Setting 0755 permission for Filebeat module folder] *********************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "not filebeat_module_folder.stat.exists", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-filebeat-oss : Checking if Filebeat Module package file exists] ************************
ok: [192.168.57.203] => {"changed": false, "stat": {"exists": false}}

TASK [../roles/wazuh/ansible-filebeat-oss : Delete Filebeat module package file] ************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "filebeat_module_package.stat.exists", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-filebeat-oss : Copy Filebeat configuration.] *******************************************
ok: [192.168.57.203] => {"changed": false, "checksum": "ef8cb2ac046ce130aa685af76e197474ef9d65b3", "dest": "/etc/filebeat/filebeat.yml", "gid": 0, "group": "root", "mode": "0400", "owner": "root", "path": "/etc/filebeat/filebeat.yml", "size": 874, "state": "file", "uid": 0}

TASK [../roles/wazuh/ansible-filebeat-oss : Fetch latest Wazuh alerts template] *************************************
changed: [192.168.57.203] => {"changed": true, "checksum_dest": null, "checksum_src": "b0e78eb5887dfcb9175b646ade0a333c647f591e", "dest": "/etc/filebeat/wazuh-template.json", "elapsed": 0, "gid": 0, "group": "root", "md5sum": "f2f88b09e17eb01aa39947fbaf4d9fb3", "mode": "0400", "msg": "OK (62776 bytes)", "owner": "root", "size": 62776, "src": "/home/vagrant/.ansible/tmp/ansible-tmp-1702910323.340215-39545-99827451417549/tmpgjhyn7g0", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/wazuh/wazuh/4.8.0/extensions/elasticsearch/7.x/wazuh-template.json"}

TASK [../roles/wazuh/ansible-filebeat-oss : include_tasks] **********************************************************
included: /home/davidcr01/Wazuh/ansible/roles/wazuh/ansible-filebeat-oss/tasks/security_actions.yml for 192.168.57.203

TASK [../roles/wazuh/ansible-filebeat-oss : Ensure Filebeat SSL key pair directory exists.] *************************
changed: [192.168.57.203] => {"changed": true, "gid": 0, "group": "root", "mode": "0764", "owner": "root", "path": "/etc/pki/filebeat", "size": 4096, "state": "directory", "uid": 0}

TASK [../roles/wazuh/ansible-filebeat-oss : Copy the certificates from local to the Manager instance] ***************
changed: [192.168.57.203] => (item=node-1-key.pem) => {"ansible_loop_var": "item", "changed": true, "checksum": "bc0094b486a365394aec8f2e0b25f6e0a0a598a6", "dest": "/etc/pki/filebeat/node-1-key.pem", "gid": 0, "group": "root", "item": "node-1-key.pem", "md5sum": "2e9a3c5097eaa2effd518068203c61a9", "mode": "0620", "owner": "root", "size": 1704, "src": "/home/vagrant/.ansible/tmp/ansible-tmp-1702910324.8628175-39579-147758585095543/source", "state": "file", "uid": 0}
changed: [192.168.57.203] => (item=node-1.pem) => {"ansible_loop_var": "item", "changed": true, "checksum": "5b2ad1b88091b7304b48487e4c9f67925c041312", "dest": "/etc/pki/filebeat/node-1.pem", "gid": 0, "group": "root", "item": "node-1.pem", "md5sum": "7211ab85d9afec4c5ce7f7d3bea4cf65", "mode": "0620", "owner": "root", "size": 1277, "src": "/home/vagrant/.ansible/tmp/ansible-tmp-1702910325.7243564-39579-19925107295958/source", "state": "file", "uid": 0}
changed: [192.168.57.203] => (item=root-ca.pem) => {"ansible_loop_var": "item", "changed": true, "checksum": "0f063f5c7e9fa7c5e18d2e59d73a4ca105d6033e", "dest": "/etc/pki/filebeat/root-ca.pem", "gid": 0, "group": "root", "item": "root-ca.pem", "md5sum": "79b1097c278bb3c54576773e85673472", "mode": "0620", "owner": "root", "size": 1204, "src": "/home/vagrant/.ansible/tmp/ansible-tmp-1702910326.5996919-39579-119475216965161/source", "state": "file", "uid": 0}

TASK [../roles/wazuh/ansible-filebeat-oss : Ensure Filebeat is started and enabled at boot.] ************************
c"TimerSlackNSec": "50000", "Transient": "no", "Type": "simple", "UID": "[not set]", "UMask": "0022", "UnitFilePreset": "enabled", "UnitFileState": "disabled", "UtmpMode": "init", "Wants": "network-online.target", "WatchdogSignal": "6", "WatchdogTimestamp": "n/a", "WatchdogTimestampMonotonic": "0", "WatchdogUSec": "infinity"}}

TASK [../roles/wazuh/ansible-filebeat-oss : include_tasks] **********************************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "ansible_os_family == \"RedHat\"", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-filebeat-oss : include_tasks] **********************************************************
included: /home/davidcr01/Wazuh/ansible/roles/wazuh/ansible-filebeat-oss/tasks/RMDebian.yml for 192.168.57.203

TASK [../roles/wazuh/ansible-filebeat-oss : Debian/Ubuntu | Remove Filebeat repository (and clean up left-over metadata)] ***
ok: [192.168.57.203] => {"changed": false, "repo": "deb https://packages.wazuh.com/4.x/apt/ stable main", "sources_added": [], "sources_removed": ["/etc/apt/sources.list.d/packages_wazuh_com_4_x_apt.list"], "state": "absent"}

TASK [../roles/wazuh/wazuh-dashboard : include_vars] ****************************************************************
ok: [192.168.57.203] => {"ansible_facts": {"packages_repository": "pre-release"}, "ansible_included_var_files": ["/home/davidcr01/Wazuh/ansible/roles/wazuh/wazuh-dashboard/vars/../../vars/repo_vars.yml"], "changed": false}

TASK [../roles/wazuh/wazuh-dashboard : include_vars] ****************************************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "packages_repository == 'production'", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/wazuh-dashboard : include_vars] ****************************************************************
ok: [192.168.57.203] => {"ansible_facts": {"certs_gen_tool_url": "https://packages-dev.wazuh.com/{{ certs_gen_tool_version }}/wazuh-certs-tool.sh", "certs_gen_tool_version": 4.8, "filebeat_module_package_url": "https://packages-dev.wazuh.com/pre-release/filebeat", "wazuh_macos_arm_package_name": "wazuh-agent-{{ wazuh_agent_version }}-1.arm64.pkg", "wazuh_macos_arm_package_url": "https://packages-dev.wazuh.com/pre-release/macos/{{ wazuh_macos_arm_package_name }}", "wazuh_macos_intel_package_name": "wazuh-agent-{{ wazuh_agent_version }}-1.intel64.pkg", "wazuh_macos_intel_package_url": "https://packages-dev.wazuh.com/staging/pre-release/{{ wazuh_macos_intel_package_name }}", "wazuh_repo": {"apt": "deb https://packages-dev.wazuh.com/pre-release/apt/ unstable main", "gpg": "https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH", "key_id": "0DCFCA5547B19D2A6099506096B3EE5F29111145", "yum": "https://packages-dev.wazuh.com/pre-release/yum/"}, "wazuh_winagent_config_url": "https://packages-dev.wazuh.com/pre-release/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi", "wazuh_winagent_package_name": "wazuh-agent-{{ wazuh_agent_version }}-1.msi", "wazuh_winagent_sha512_url": "https://packages-dev.wazuh.com/pre-release/checksums/wazuh/{{ wazuh_agent_version }}/wazuh-agent-{{ wazuh_agent_version }}-1.msi.sha512"}, "ansible_included_var_files": ["/home/davidcr01/Wazuh/ansible/roles/wazuh/wazuh-dashboard/vars/../../vars/repo_pre-release.yml"], "changed": false}

TASK [../roles/wazuh/wazuh-dashboard : include_vars] ****************************************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "packages_repository == 'staging'", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/wazuh-dashboard : RedHat/CentOS/Fedora | Add Wazuh dashboard repo] *****************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "ansible_os_family == 'RedHat'", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/wazuh-dashboard : Install Wazuh dashboard] *****************************************************
skipping: [192.168.57.203] => {"changed": false, "false_condition": "ansible_os_family == 'RedHat'", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/wazuh-dashboard : include_vars] ****************************************************************
ok: [192.168.57.203] => {"ansible_facts": {"dashboard_version": "4.8.0"}, "ansible_included_var_files": ["/home/davidcr01/Wazuh/ansible/roles/wazuh/wazuh-dashboard/vars/debian.yml"], "changed": false}

TASK [../roles/wazuh/wazuh-dashboard : Add apt repository signing key] **********************************************
ok: [192.168.57.203] => {"before": ["96B3EE5F29111145", "417F3D5A664FAB32", "D94AA3F0EFE21092", "871920D1991BC93C"], "changed": false, "fp": "96B3EE5F29111145", "id": "96B3EE5F29111145", "key_id": "96B3EE5F29111145", "short_id": "29111145"}

TASK [../roles/wazuh/wazuh-dashboard : Debian systems | Add Wazuh dashboard repo] ***********************************
changed: [192.168.57.203] => {"changed": true, "repo": "deb https://packages-dev.wazuh.com/pre-release/apt/ unstable main", "sources_added": ["/etc/apt/sources.list.d/packages_dev_wazuh_com_pre_release_apt.list"], "sources_removed": [], "state": "present"}

TASK [../roles/wazuh/wazuh-dashboard : Install Wazuh dashboard] *****************************************************
changed: [192.168.57.203] => {"cache_update_time": 1702910342, "cache_updated": true, "changed": true, "stderr": "", "stderr_lines": [], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following NEW packages will be installed:\n  wazuh-dashboard\n0 upgraded, 1 newly installed, 0 to remove and 167 not upgraded.\nNeed to get 186 MB of archives.\nAfter this operation, 987 MB of additional disk space will be used.\nGet:1 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 wazuh-dashboard amd64 4.8.0-1 [186 MB]\nFetched 186 MB in 57s (3239 kB/s)\nSelecting previously unselected package wazuh-dashboard.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 99448 files and directories currently installed.)\r\nPreparing to unpack .../wazuh-dashboard_4.8.0-1_amd64.deb ...\r\nCreating wazuh-dashboard group... OK\r\nCreating wazuh-dashboard user... OK\r\nUnpacking wazuh-dashboard (4.8.0-1) ...\r\nSetting up wazuh-dashboard (4.8.0-1) ...\r\nNEEDRESTART-VER: 3.5\nNEEDRESTART-KCUR: 5.15.0-69-generic\nNEEDRESTART-KEXP: 5.15.0-69-generic\nNEEDRESTART-KSTA: 1\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "The following NEW packages will be installed:", "  wazuh-dashboard", "0 upgraded, 1 newly installed, 0 to remove and 167 not upgraded.", "Need to get 186 MB of archives.", "After this operation, 987 MB of additional disk space will be used.", "Get:1 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 wazuh-dashboard amd64 4.8.0-1 [186 MB]", "Fetched 186 MB in 57s (3239 kB/s)", "Selecting previously unselected package wazuh-dashboard.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 99448 files and directories currently installed.)", "Preparing to unpack .../wazuh-dashboard_4.8.0-1_amd64.deb ...", "Creating wazuh-dashboard group... OK", "Creating wazuh-dashboard user... OK", "Unpacking wazuh-dashboard (4.8.0-1) ...", "Setting up wazuh-dashboard (4.8.0-1) ...", "NEEDRESTART-VER: 3.5", "NEEDRESTART-KCUR: 5.15.0-69-generic", "NEEDRESTART-KEXP: 5.15.0-69-generic", "NEEDRESTART-KSTA: 1"]}

TASK [../roles/wazuh/wazuh-dashboard : Remove Dashboard configuration file] *****************************************
changed: [192.168.57.203] => {"changed": true, "path": "/etc/wazuh-dashboard//opensearch_dashboards.yml", "state": "absent"}

TASK [../roles/wazuh/wazuh-dashboard : Ensure Dashboard certificates directory permissions.] ************************
changed: [192.168.57.203] => {"changed": true, "gid": 124, "group": "wazuh-dashboard", "mode": "0764", "owner": "wazuh-dashboard", "path": "/etc/wazuh-dashboard/certs/", "size": 4096, "state": "directory", "uid": 116}

TASK [../roles/wazuh/wazuh-dashboard : Copy the certificates from local to the Wazuh dashboard instance] ************
changed: [192.168.57.203] => (item=root-ca.pem) => {"ansible_loop_var": "item", "changed": true, "checksum": "0f063f5c7e9fa7c5e18d2e59d73a4ca105d6033e", "dest": "/etc/wazuh-dashboard/certs/root-ca.pem", "gid": 124, "group": "wazuh-dashboard", "item": "root-ca.pem", "md5sum": "79b1097c278bb3c54576773e85673472", "mode": "0400", "owner": "wazuh-dashboard", "size": 1204, "src": "/home/vagrant/.ansible/tmp/ansible-tmp-1702910458.230819-39837-273471650925522/source", "state": "file", "uid": 116}
changed: [192.168.57.203] => (item=node-1-key.pem) => {"ansible_loop_var": "item", "changed": true, "checksum": "bc0094b486a365394aec8f2e0b25f6e0a0a598a6", "dest": "/etc/wazuh-dashboard/certs/node-1-key.pem", "gid": 124, "group": "wazuh-dashboard", "item": "node-1-key.pem", "md5sum": "2e9a3c5097eaa2effd518068203c61a9", "mode": "0400", "owner": "wazuh-dashboard", "size": 1704, "src": "/home/vagrant/.ansible/tmp/ansible-tmp-1702910458.8716366-39837-47975697166188/source", "state": "file", "uid": 116}
changed: [192.168.57.203] => (item=node-1.pem) => {"ansible_loop_var": "item", "changed": true, "checksum": "5b2ad1b88091b7304b48487e4c9f67925c041312", "dest": "/etc/wazuh-dashboard/certs/node-1.pem", "gid": 124, "group": "wazuh-dashboard", "item": "node-1.pem", "md5sum": "7211ab85d9afec4c5ce7f7d3bea4cf65", "mode": "0400", "owner": "wazuh-dashboard", "size": 1277, "src": "/home/vagrant/.ansible/tmp/ansible-tmp-1702910459.4787457-39837-118120255444626/source", "state": "file", "uid": 116}

TASK [../roles/wazuh/wazuh-dashboard : Copy Configuration File] *****************************************************
changed: [192.168.57.203] => {"changed": true, "checksum": "73329f90bb75106a7a5fc7ce7b3c4b83f3392d8e", "dest": "/etc/wazuh-dashboard//opensearch_dashboards.yml", "gid": 124, "group": "wazuh-dashboard", "md5sum": "896d22db5e2a4e1c09a9fc8b4f3d5205", "mode": "0640", "owner": "wazuh-dashboard", "size": 588, "src": "/home/vagrant/.ansible/tmp/ansible-tmp-1702910460.1458035-39915-79146937929707/source", "state": "file", "uid": 116}

RUNNING HANDLER [../roles/wazuh/ansible-filebeat-oss : restart filebeat] ********************************************
changed: [192.168.57.203] => {"changed": true, "name": "filebeat", "state": "started", "status": {"ActiveEnterTimestamp": "Mon 2023-12-18 14:38:47 UTC", "ActiveEnterTimestampMonotonic": "880666961", "ActiveExitTimestamp": "n/a", "ActiveExitTimestampMonotonic": "0", "ActiveState": "active", "After": "systemd-journald.socket sysinit.target basic.target system.slice network-online.target", "AllowIsolate": "no", "AssertResult": "yes", "AssertTimestamp": "Mon 2023-12-18 14:38:47 "0"}}

RUNNING HANDLER [../roles/wazuh/wazuh-dashboard : restart wazuh-dashboard] ******************************************
changed: [192.168.57.203] => {"changed": true, "name": "wazuh-dashboard", "state": "started", "status": "multi-user.target", "WatchdogSignal": "6", "WatchdogTimestamp": "n/a", "WatchdogTimestampMonotonic": "0", "WatchdogUSec": "0", "WorkingDirectory": "/usr/share/wazuh-dashboard"}}

PLAY RECAP **********************************************************************************************************
192.168.57.203             : ok=96   changed=26   unreachable=0    failed=0    skipped=90   rescued=0    ignored=0   
```
</details>

Notice that the content of the module files has changed corresponding to the related PR changes https://github.com/wazuh/wazuh/pull/19819:
```console
root@ubuntu22:/home/vagrant# cat /usr/share/filebeat/module/wazuh/alerts/ingest/pipeline.json 
{
  "description": "Wazuh alerts pipeline",
  "processors": [
    { "json" : { "field" : "message", "add_to_root": true } },
    {
      "set": {
        "field": "data.aws.region",
        "value": "{{data.aws.awsRegion}}",
        "override": false,
        "ignore_failure": true
      }
    },
    {
      "set": {
        "field": "data.aws.accountId",
        "value": "{{data.aws.aws_account_id}}",
        "override": false,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.srcip",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.win.eventdata.ipAddress",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.aws.sourceIPAddress",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.aws.client_ip",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.aws.service.action.networkConnectionAction.remoteIpDetails.ipAddressV4",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.gcp.jsonPayload.sourceIP",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.office365.ClientIP",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "date": {
        "field": "timestamp",
        "target_field": "@timestamp",
        "formats": ["ISO8601"],
        "ignore_failure": false
      }
    },
    {
      "set": {
        "field": "_index",
        "value": "wazuh-alerts"
      }
    },
    { "remove": { "field": "message", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "ecs", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "beat", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "input_type", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "tags", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "count", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "@version", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "log", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "offset", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "type", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "host", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "fields", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "event", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "fileset", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "service", "ignore_missing": true, "ignore_failure": true } }
  ],
  "on_failure" : [{
    "drop" : { }
  }]
}

root@ubuntu22:/home/vagrant# cat /usr/share/filebeat/module/wazuh/archives/ingest/pipeline.json 
{
  "description": "Wazuh events pipeline",
  "processors": [
    { "json" : { "field" : "message", "add_to_root": true } },
    {
      "set": {
        "field": "data.aws.region",
        "value": "{{data.aws.awsRegion}}",
        "override": false,
        "ignore_failure": true
      }
    },
    {
      "set": {
        "field": "data.aws.accountId",
        "value": "{{data.aws.aws_account_id}}",
        "override": false,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.srcip",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.win.eventdata.ipAddress",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.aws.sourceIPAddress",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.aws.client_ip",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.aws.service.action.networkConnectionAction.remoteIpDetails.ipAddressV4",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.gcp.jsonPayload.sourceIP",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.office365.ClientIP",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "date": {
        "field": "timestamp",
        "target_field": "@timestamp",
        "formats": ["ISO8601"],
        "ignore_failure": false
      }
    },
    {
      "set": {
        "field": "_index",
        "value": "wazuh-archives"
      }
    },
    { "remove": { "field": "message", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "ecs", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "beat", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "input_type", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "tags", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "count", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "@version", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "log", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "offset", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "type", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "host", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "fields", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "event", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "fileset", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "service", "ignore_missing": true, "ignore_failure": true } }
  ],
  "on_failure" : [{
    "drop" : { }
  }]
}
```