### PR TITLE
Fixed version in cert tool variable

### DIFF
--- a/roles/wazuh/vars/repo.yml
+++ b/roles/wazuh/vars/repo.yml
@@ -13,7 +13,7 @@ wazuh_macos_arm_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.arm64.pkg
 wazuh_macos_intel_package_url: "https://packages.wazuh.com/4.x/macos/{{ wazuh_macos_intel_package_name }}"
 wazuh_macos_arm_package_url: "https://packages.wazuh.com/4.x/macos/{{ wazuh_macos_arm_package_name }}"
 
-certs_gen_tool_version: 4.8
+certs_gen_tool_version: 4.9
 
 # Url of certificates generator tool
 certs_gen_tool_url: "https://packages.wazuh.com/{{ certs_gen_tool_version }}/wazuh-certs-tool.sh"

--- a/roles/wazuh/vars/repo_pre-release.yml
+++ b/roles/wazuh/vars/repo_pre-release.yml
@@ -13,7 +13,7 @@ wazuh_macos_arm_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.arm64.pkg
 wazuh_macos_intel_package_url: "https://packages-dev.wazuh.com/staging/pre-release/{{ wazuh_macos_intel_package_name }}"
 wazuh_macos_arm_package_url: "https://packages-dev.wazuh.com/pre-release/macos/{{ wazuh_macos_arm_package_name }}"
 
-certs_gen_tool_version: 4.8
+certs_gen_tool_version: 4.9
 
 # Url of certificates generator tool
 certs_gen_tool_url: "https://packages-dev.wazuh.com/{{ certs_gen_tool_version }}/wazuh-certs-tool.sh"

--- a/roles/wazuh/vars/repo_staging.yml
+++ b/roles/wazuh/vars/repo_staging.yml
@@ -14,7 +14,7 @@ wazuh_macos_arm_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.arm64.pkg
 wazuh_macos_intel_package_url: "https://packages-dev.wazuh.com/staging/macos/{{ wazuh_macos_intel_package_name }}"
 wazuh_macos_arm_package_url: "https://packages-dev.wazuh.com/staging/macos/{{ wazuh_macos_arm_package_name }}"
 
-certs_gen_tool_version: 4.8
+certs_gen_tool_version: 4.9
 
 # Url of certificates generator tool
 certs_gen_tool_url: "https://packages-dev.wazuh.com/{{ certs_gen_tool_version }}/wazuh-certs-tool.sh"


### PR DESCRIPTION
## Description

The aim of this PR is to bump the `certs_gen_tool_version` variable to the correct value. In the master branch, it must have the `4.9` value, and they were set to `4.8`.