### PR TITLE
Some indexer tasks are only executed once

### DIFF
--- a/roles/wazuh/wazuh-indexer/tasks/security_actions.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/security_actions.yml
@@ -122,5 +122,6 @@
     timeout: 4
   when:
     - indexer_custom_user is defined and indexer_custom_user
+    - inventory_hostname == ansible_play_hosts[0]
 
 

--- a/roles/wazuh/wazuh-indexer/tasks/security_actions.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/security_actions.yml
@@ -102,7 +102,7 @@
     become: yes
     become_user: root
 
-  run_once: true
+  when: inventory_hostname == ansible_play_hosts[0]
 
 - name: Create custom user
   uri:


### PR DESCRIPTION
## Description

Related: https://github.com/wazuh/wazuh-automation/issues/1479

The aim of this PR is to add a condition to some of the Wazuh indexer tasks of the `wazuh-indexer` role. These tasks are included in the `security_actions.yml` file, and they should be executed only once (Wazuh indexer cluster initialization, ISM script execution, etc).
Before, these tasks were executed in every node, and this may cause some unexpected errors:

```console
18:44:31  TASK [/tmp/wazuh-ansible/roles/wazuh/wazuh-indexer : Initialize the Opensearch security index in Wazuh indexer] ***
18:44:31  changed: [54.151.68.99]
18:44:33  
18:44:33  TASK [/tmp/wazuh-ansible/roles/wazuh/wazuh-indexer : Initialize the Opensearch security index in Wazuh indexer] ***
18:44:33  changed: [54.177.124.185]
18:44:34  
18:44:34  TASK [/tmp/wazuh-ansible/roles/wazuh/wazuh-indexer : Initialize ISM script] ****
18:44:34  fatal: [54.151.68.99]: FAILED! => {
18:44:34      "changed": true,
18:44:34      "cmd": [
18:44:34          "/usr/share/wazuh-indexer/bin/indexer-ism-init.sh",
18:44:34          "-p",
18:44:34          "****",
18:44:34          "-i",
18:44:34          "10.0.2.81"
18:44:34      ],
18:44:34      "delta": "0:00:01.378543",
18:44:34      "end": "2023-12-19 17:44:34.038040",
18:44:34      "rc": 1,
18:44:34      "start": "2023-12-19 17:44:32.659497"
18:44:34  }
18:44:34  
18:44:34  STDOUT:
18:44:34  
18:44:34  Will create index templates to configure the alias
18:44:34   SUCC: 'wazuh-alerts' template created or updated
18:44:34   SUCC: 'wazuh-archives' template created or updated
18:44:34  Will create the 'rollover_policy' policy
18:44:34    ERROR: 'rollover_policy' policy not created => 409
18:44:34  ERROR: Indexer ISM initialization failed. Check /tmp/wazuh-indexer/ism-init.log for more information.
```

Now, with this change, this tasks are only executed in the first node of the Wazuh indexer cluster.

## Testing

- [Testing single-node and multi-node deployments](https://github.com/wazuh/wazuh-automation/issues/1479#issuecomment-1885194098)
- [Testing demo environment](https://github.com/wazuh/wazuh-automation/issues/1479#issuecomment-1920963537)
- [Testing single-node again with the last commit](https://github.com/wazuh/wazuh-automation/issues/1479#issuecomment-1918697422)

This PR should be merged also with this PR: https://github.com/wazuh/wazuh-automation/pull/1542