### PR TITLE
Updated manager permissions files from `640` to `660`

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -116,7 +116,7 @@
             dest="{{ wazuh_dir }}/etc/rules/local_rules.xml"
             owner=wazuh
             group=wazuh
-            mode=0640
+            mode=0660
   notify: restart wazuh-manager
   tags:
     - init
@@ -128,7 +128,7 @@
         dest="{{ wazuh_dir }}/etc/rules/"
         owner=wazuh
         group=wazuh
-        mode=0640
+        mode=0660
   notify: restart wazuh-manager
   tags:
     - init
@@ -140,7 +140,7 @@
             dest="{{ wazuh_dir }}/etc/decoders/local_decoder.xml"
             owner=wazuh
             group=wazuh
-            mode=0640
+            mode=0660
   notify: restart wazuh-manager
   tags:
     - init
@@ -152,7 +152,7 @@
         dest="{{ wazuh_dir }}/etc/decoders/"
         owner=wazuh
         group=wazuh
-        mode=0640
+        mode=0660
   notify: restart wazuh-manager
   tags:
     - init
@@ -165,7 +165,7 @@
     dest: "{{ wazuh_dir }}/etc/shared/default/agent.conf"
     owner: wazuh
     group: wazuh
-    mode: 0640
+    mode: 0660
     validate: "{{ wazuh_dir }}/bin/verify-agent-conf -f %s"
   notify: restart wazuh-manager
   tags:


### PR DESCRIPTION
## Description

Closes: https://github.com/wazuh/wazuh-ansible/issues/1201

The aim of this PR is to update some of the manager's files permissions which were not up-to-date. 
These changes involve the permissions of the `rules` files, `decoders` files, and the `agent.conf` file. These changes have been applied following the same permissions as the specs of the Wazuh manager package.

## Testing

The testing is in: https://github.com/wazuh/wazuh-ansible/issues/1201#issuecomment-1980663392

```console
root@ubuntu22:/home/vagrant# ls -ltr /var/ossec/etc/rules/
total 8
-rw-rw---- 1 wazuh wazuh 496 Mar  6 11:35 local_rules.xml
-rw-rw---- 1 wazuh wazuh 457 Mar  6 11:35 sample_custom_rules.xml

root@ubuntu22:/home/vagrant# ls -ltr /var/ossec/etc/decoders/
total 8
-rw-rw---- 1 wazuh wazuh 775 Mar  6 11:35 local_decoder.xml
-rw-rw---- 1 wazuh wazuh 775 Mar  6 11:35 sample_custom_decoders.xml

root@ubuntu22:/home/vagrant# ls -ltr /var/ossec/etc/
total 64
-rw-r----- 1 root  wazuh   114 Jan  2 19:37 localtime
-rw-r----- 1 root  wazuh 14293 Feb 22 09:10 internal_options.conf
drwxrwx--- 2 root  wazuh  4096 Mar  6 11:35 rootcheck
-rw-r----- 1 root  root   1704 Mar  6 11:35 sslmanager.key
-rw-r----- 1 root  root   1164 Mar  6 11:35 sslmanager.cert
-rw-r----- 1 wazuh wazuh     0 Mar  6 11:35 client.keys
drwxrwx--- 2 root  wazuh  4096 Mar  6 11:35 rules
drwxrwx--- 2 root  wazuh  4096 Mar  6 11:35 decoders
-rw-r----- 1 root  wazuh   473 Mar  6 11:35 local_internal_options.conf
-rw-r--r-- 1 root  wazuh  8824 Mar  6 11:35 ossec.conf
drwxrwx--- 3 root  wazuh  4096 Mar  6 11:35 shared
drwxrwx--- 3 root  wazuh  4096 Mar  6 11:35 lists

root@ubuntu22:/home/vagrant# ls -ltr /var/ossec/etc/ | grep local_internal_options
-rw-r----- 1 root  wazuh   473 Mar  6 11:35 local_internal_options.conf
root@ubuntu22:/home/vagrant# 
```
