### PR TITLE
Feature package locking

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
@@ -5,9 +5,22 @@
 - include_tasks: "Debian.yml"
   when: ansible_os_family == "Debian"
 
+- name: Linux | Get installed wazuh-agent version
+  ansible.builtin.package_facts:
+    manager: auto
+
 - include_tasks: "installation_from_custom_packages.yml"
   when:
     - wazuh_custom_packages_installation_agent_enabled
+
+- name: Linux CentOS/RedHat | Version unlock wazuh-agent
+  community.general.yum_versionlock:
+    name: "wazuh-agent"
+    state: absent
+  when:
+    - ansible_os_family|lower == "redhat"
+    - "'wazuh-agent' in ansible_facts.packages"
+    - not ansible_facts.packages['wazuh-agent'][0]['version'].startswith(wazuh_agent_version)
 
 - name: Linux CentOS/RedHat | Install wazuh-agent
   yum:
@@ -20,6 +33,22 @@
   tags:
     - init
 
+- name: Linux CentOS/RedHat | Version lock wazuh-agent
+  community.general.yum_versionlock:
+    name: "wazuh-agent"
+    state: present
+  when:
+    - ansible_os_family|lower == "redhat"
+
+- name: Linux Debian | Version unlock wazuh-agent
+  dpkg_selections:
+    name: "wazuh-agent"
+    selection: install
+  when:
+    - ansible_os_family|lower != "redhat"
+    - "'wazuh-agent' in ansible_facts.packages"
+    - not ansible_facts.packages['wazuh-agent'][0]['version'].startswith(wazuh_agent_version)
+
 - name: Linux Debian | Install wazuh-agent
   apt:
     name: "wazuh-agent={{ wazuh_agent_version }}-*"
@@ -31,6 +60,13 @@
     - not ansible_check_mode
   tags:
     - init
+
+- name: Linux Debian | Version lock wazuh-agent
+  dpkg_selections:
+    name: "wazuh-agent"
+    selection: hold
+  when:
+    - ansible_os_family|lower != "redhat"
 
 - name: Linux | Check if client.keys exists
   stat:

--- a/roles/wazuh/ansible-wazuh-agent/tasks/RMDebian.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/RMDebian.yml
@@ -1,6 +1,1 @@
 ---
-- name: Remove Wazuh repository (and clean up left-over metadata)
-  apt_repository:
-    repo: "{{ wazuh_agent_config.repo.apt }}"
-    state: absent
-  changed_when: false

--- a/roles/wazuh/ansible-wazuh-agent/tasks/RMRedHat.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/RMRedHat.yml
@@ -1,6 +1,1 @@
 ---
-- name: Remove Wazuh repository (and clean up left-over metadata)
-  yum_repository:
-    name: wazuh_repo
-    state: absent
-  changed_when: false

--- a/roles/wazuh/ansible-wazuh-agent/tasks/RedHat.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/RedHat.yml
@@ -33,6 +33,11 @@
   tags:
     - init
 
+- name: RedHat/CentOS/Fedora | Install yum-plugin-versionlock
+  yum: name=yum-plugin-versionlock state=present
+  tags:
+    - init
+
 - name: Set Distribution CIS filename for RHEL5
   set_fact:
     cis_distribution_filename: cis_rhel5_linux_rcl.txt


### PR DESCRIPTION
This is an attempt at fixing the idempotency issue discussed in https://github.com/wazuh/wazuh-ansible/issues/1240.

Packages get version locked and unlocked when installing/updating them, rather than adding and removing the package repositories on each run.

Unfortunately, it requires a module from the community.general collection. I am not sure if you want to introduce this.