### PR TITLE
Delete create_user.py script

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -310,6 +310,11 @@
       with_items:
         - "{{ wazuh_api_users }}"
 
+    - name: Delete create_user script
+      file:
+        path: "{{ wazuh_dir }}/framework/scripts/create_user.py"
+        state: absent
+
   tags:
     - config_api_users
   when:


### PR DESCRIPTION
Related issue https://github.com/wazuh/internal-devel-requests/issues/513

create_user.py script deleted after deployment test:

``` console
root@master:/etc/ansible/roles/wazuh-ansible/playbooks# ls -ltr /var/ossec/framework/scripts/
total 80
-rw-r----- 1 root wazuh 17601 Feb 29 13:05 wazuh_logtest.py
-rw-r----- 1 root wazuh 11155 Feb 29 13:05 wazuh_clusterd.py
-rw-r----- 1 root wazuh  4080 Feb 29 13:05 rbac_control.py
-rw-r----- 1 root wazuh     0 Feb 29 13:05 __init__.py
-rw-r----- 1 root wazuh 13099 Feb 29 13:05 cluster_control.py
-rw-r----- 1 root wazuh  8602 Feb 29 13:05 agent_upgrade.py
-rw-r----- 1 root wazuh 13964 Feb 29 13:05 agent_groups.py
root@master:/etc/ansible/roles/wazuh-ansible/playbooks#
```

![image](https://github.com/wazuh/wazuh-ansible/assets/56500015/d29e4fa3-e836-4ee5-bcd2-ce62ac0984ff)
