### PR TITLE
Fix 4.x and 4.9 references in master branch

### DIFF
--- a/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
+++ b/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
@@ -22,7 +22,7 @@ filebeat_ssl_dir: /etc/pki/filebeat
 local_certs_path: "{{ playbook_dir }}/indexer/certificates"
 
 filebeatrepo:
-  apt: 'deb https://packages.wazuh.com/4.x/apt/ stable main'
-  yum: 'https://packages.wazuh.com/4.x/yum/'
+  apt: 'deb https://packages.wazuh.com/5.x/apt/ stable main'
+  yum: 'https://packages.wazuh.com/5.x/yum/'
   gpg: 'https://packages.wazuh.com/key/GPG-KEY-WAZUH'
   key_id: '0DCFCA5547B19D2A6099506096B3EE5F29111145'

--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -65,7 +65,7 @@ wazuh_managers:
     retry_interval: 5
     register: yes
 
-## Authentication Method: Enrollment section (4.x)
+## Authentication Method: Enrollment section (5.x)
 
 # For more information see:
 # * https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/client.html#enrollment

--- a/roles/wazuh/check-packages/scripts/check_packages.sh
+++ b/roles/wazuh/check-packages/scripts/check_packages.sh
@@ -9,7 +9,7 @@ checkPackages(){
     ## Set S3 Bucket URL
     if [ $1 == "production" ]; then
         echo "production"
-        PACKAGES_URL=https://packages.wazuh.com/4.x/
+        PACKAGES_URL=https://packages.wazuh.com/5.x/
     elif [ $1 == "pre-release" ]; then
         echo "pre-release"
         PACKAGES_URL=https://packages-dev.wazuh.com/pre-release/

--- a/roles/wazuh/vars/repo.yml
+++ b/roles/wazuh/vars/repo.yml
@@ -1,19 +1,19 @@
 wazuh_repo:
-  apt: 'deb https://packages.wazuh.com/4.x/apt/ stable main'
-  yum: 'https://packages.wazuh.com/4.x/yum/'
+  apt: 'deb https://packages.wazuh.com/5.x/apt/ stable main'
+  yum: 'https://packages.wazuh.com/5.x/yum/'
   gpg: 'https://packages.wazuh.com/key/GPG-KEY-WAZUH'
   key_id: '0DCFCA5547B19D2A6099506096B3EE5F29111145'
-wazuh_winagent_config_url: "https://packages.wazuh.com/4.x/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi"
+wazuh_winagent_config_url: "https://packages.wazuh.com/5.x/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi"
 wazuh_winagent_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.msi"
-wazuh_winagent_sha512_url: "https://packages.wazuh.com/4.x/checksums/wazuh/{{ wazuh_agent_version }}/wazuh-agent-{{ wazuh_agent_version }}-1.msi.sha512"
-filebeat_module_package_url: https://packages.wazuh.com/4.x/filebeat
+wazuh_winagent_sha512_url: "https://packages.wazuh.com/5.x/checksums/wazuh/{{ wazuh_agent_version }}/wazuh-agent-{{ wazuh_agent_version }}-1.msi.sha512"
+filebeat_module_package_url: https://packages.wazuh.com/5.x/filebeat
 
 wazuh_macos_intel_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.intel64.pkg"
 wazuh_macos_arm_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.arm64.pkg"
-wazuh_macos_intel_package_url: "https://packages.wazuh.com/4.x/macos/{{ wazuh_macos_intel_package_name }}"
-wazuh_macos_arm_package_url: "https://packages.wazuh.com/4.x/macos/{{ wazuh_macos_arm_package_name }}"
+wazuh_macos_intel_package_url: "https://packages.wazuh.com/5.x/macos/{{ wazuh_macos_intel_package_name }}"
+wazuh_macos_arm_package_url: "https://packages.wazuh.com/5.x/macos/{{ wazuh_macos_arm_package_name }}"
 
-certs_gen_tool_version: 4.9
+certs_gen_tool_version: 5.0
 
 # Url of certificates generator tool
 certs_gen_tool_url: "https://packages.wazuh.com/{{ certs_gen_tool_version }}/wazuh-certs-tool.sh"

--- a/roles/wazuh/vars/repo_pre-release.yml
+++ b/roles/wazuh/vars/repo_pre-release.yml
@@ -13,7 +13,7 @@ wazuh_macos_arm_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.arm64.pkg
 wazuh_macos_intel_package_url: "https://packages-dev.wazuh.com/staging/pre-release/{{ wazuh_macos_intel_package_name }}"
 wazuh_macos_arm_package_url: "https://packages-dev.wazuh.com/pre-release/macos/{{ wazuh_macos_arm_package_name }}"
 
-certs_gen_tool_version: 4.9
+certs_gen_tool_version: 5.0
 
 # Url of certificates generator tool
 certs_gen_tool_url: "https://packages-dev.wazuh.com/{{ certs_gen_tool_version }}/wazuh-certs-tool.sh"

--- a/roles/wazuh/vars/repo_staging.yml
+++ b/roles/wazuh/vars/repo_staging.yml
@@ -14,7 +14,7 @@ wazuh_macos_arm_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.arm64.pkg
 wazuh_macos_intel_package_url: "https://packages-dev.wazuh.com/staging/macos/{{ wazuh_macos_intel_package_name }}"
 wazuh_macos_arm_package_url: "https://packages-dev.wazuh.com/staging/macos/{{ wazuh_macos_arm_package_name }}"
 
-certs_gen_tool_version: 4.9
+certs_gen_tool_version: 5.0
 
 # Url of certificates generator tool
 certs_gen_tool_url: "https://packages-dev.wazuh.com/{{ certs_gen_tool_version }}/wazuh-certs-tool.sh"

--- a/roles/wazuh/wazuh-dashboard/templates/wazuh.yml.j2
+++ b/roles/wazuh/wazuh-dashboard/templates/wazuh.yml.j2
@@ -21,7 +21,7 @@
 # ------------------------------- Index patterns -------------------------------
 #
 # Default index pattern to use.
-#pattern: wazuh-alerts-4.x-*
+#pattern: wazuh-alerts-5.x-*
 #
 # ----------------------------------- Checks -----------------------------------
 #
@@ -92,17 +92,17 @@
 # Default: 900 (s)
 #wazuh.monitoring.frequency: 900
 #
-# Configure wazuh-monitoring-4.x-* indices shards and replicas.
+# Configure wazuh-monitoring-5.x-* indices shards and replicas.
 #wazuh.monitoring.shards: 2
 #wazuh.monitoring.replicas: 0
 #
-# Configure wazuh-monitoring-4.x-* indices custom creation interval.
+# Configure wazuh-monitoring-5.x-* indices custom creation interval.
 # Values: h (hourly), d (daily), w (weekly), m (monthly)
 # Default: d
 #wazuh.monitoring.creation: d
 #
 # Default index pattern to use for Wazuh monitoring
-#wazuh.monitoring.pattern: wazuh-monitoring-4.x-*
+#wazuh.monitoring.pattern: wazuh-monitoring-5.x-*
 #
 #
 # ------------------------------- App privileges --------------------------------


### PR DESCRIPTION
Related issue: #1254 
Changed 4.x occurrences to 5.x and 4.9 to 5.0 in the following files as reported on the issue:
```
roles/wazuh/vars/repo_pre-release.yml
roles/wazuh/vars/repo.yml
roles/wazuh/vars/repo_staging.yml
roles/wazuh/ansible-filebeat-oss/defaults.main.yml
roles/wazuh/ansible-wazuh-agent/defaults.main.yml
roles/wazuh/check-packages/scripts/check_packages.sh
```
Then, I haven't found more references to the 4.9 version except on the `CHANGELOG.md` and the `README.md` files but I left them as they are because these are documentation files.