### PR TITLE
Fixed `apt_key` deprecation

### DIFF
--- a/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
+++ b/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
@@ -22,7 +22,8 @@ filebeat_ssl_dir: /etc/pki/filebeat
 local_certs_path: "{{ playbook_dir }}/indexer/certificates"
 
 filebeatrepo:
-  apt: 'deb https://packages.wazuh.com/4.x/apt/ stable main'
+  keyring_path: '/usr/share/keyrings/wazuh.gpg'
+  apt: "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main"
   yum: 'https://packages.wazuh.com/4.x/yum/'
   gpg: 'https://packages.wazuh.com/key/GPG-KEY-WAZUH'
-  key_id: '0DCFCA5547B19D2A6099506096B3EE5F29111145'
+  path: '/tmp/WAZUH-GPG-KEY'

--- a/roles/wazuh/ansible-filebeat-oss/tasks/Debian.yml
+++ b/roles/wazuh/ansible-filebeat-oss/tasks/Debian.yml
@@ -9,11 +9,20 @@
   register: filebeat_ca_packages_install
   until: filebeat_ca_packages_install is succeeded
 
-- name: Debian/Ubuntu | Add Elasticsearch apt key.
-  apt_key:
+- name: Debian/Ubuntu | Download Filebeat apt key.
+  get_url:
     url: "{{ filebeatrepo.gpg }}"
-    id: "{{ filebeatrepo.key_id }}"
-    state: present
+    dest: "{{ filebeatrepo.path }}"
+
+- name: Import Filebeat GPG key
+  command: "gpg --no-default-keyring --keyring gnupg-ring:{{ filebeatrepo.keyring_path }} --import {{ filebeatrepo.path }}"
+  args:
+    creates: "{{ filebeatrepo.keyring_path }}"
+
+- name: Set permissions for Filebeat GPG key
+  file:
+    path: "{{ filebeatrepo.keyring_path }}"
+    mode: '0644'
 
 - name: Debian/Ubuntu | Add Filebeat-oss repository.
   apt_repository:

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
@@ -38,10 +38,26 @@
     - ansible_distribution_major_version | int == 14
     - not wazuh_custom_packages_installation_agent_enabled
 
-- name: Debian/Ubuntu | Installing Wazuh repository key
-  apt_key:
+- name: Debian/Ubuntu | Download Wazuh repository key
+  get_url:
     url: "{{ wazuh_agent_config.repo.gpg }}"
-    id: "{{ wazuh_agent_config.repo.key_id }}"
+    dest: "{{ wazuh_agent_config.repo.path }}"
+  when:
+    - not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int == 14)
+    - not wazuh_custom_packages_installation_agent_enabled
+
+- name: Debian/Ubuntu | Import Wazuh GPG key
+  command: "gpg --no-default-keyring --keyring gnupg-ring:{{ wazuh_agent_config.repo.keyring_path }} --import {{ wazuh_agent_config.repo.path }}"
+  when:
+    - not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int == 14)
+    - not wazuh_custom_packages_installation_agent_enabled
+  args:
+    creates: "{{ wazuh_agent_config.repo.keyring_path }}"
+
+- name: Debian/Ubuntu | Set permissions for Wazuh GPG key
+  file:
+    path: "{{ wazuh_agent_config.repo.keyring_path }}"
+    mode: '0644'
   when:
     - not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int == 14)
     - not wazuh_custom_packages_installation_agent_enabled

--- a/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
@@ -26,10 +26,26 @@
     - ansible_distribution_major_version | int == 14
     - not wazuh_custom_packages_installation_manager_enabled
 
-- name: Debian/Ubuntu | Installing Wazuh repository key
-  apt_key:
+- name: Debian/Ubuntu | Download Wazuh repository key
+  get_url:
     url: "{{ wazuh_manager_config.repo.gpg }}"
-    id: "{{ wazuh_manager_config.repo.key_id }}"
+    dest: "{{ wazuh_manager_config.repo.path }}"
+  when:
+    - not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int == 14)
+    - not wazuh_custom_packages_installation_manager_enabled
+
+- name: Debian/Ubuntu | Import Wazuh GPG key
+  command: "gpg --no-default-keyring --keyring gnupg-ring:{{ wazuh_manager_config.repo.keyring_path }} --import {{ wazuh_manager_config.repo.path }}"
+  when:
+    - not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int == 14)
+    - not wazuh_custom_packages_installation_manager_enabled
+  args:
+    creates: "{{ wazuh_manager_config.repo.keyring_path }}"
+
+- name: Debian/Ubuntu | Set permissions for Wazuh GPG key
+  file:
+    path: "{{ wazuh_manager_config.repo.keyring_path }}"
+    mode: '0644'
   when:
     - not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int == 14)
     - not wazuh_custom_packages_installation_manager_enabled

--- a/roles/wazuh/vars/repo.yml
+++ b/roles/wazuh/vars/repo.yml
@@ -1,8 +1,9 @@
 wazuh_repo:
-  apt: 'deb https://packages.wazuh.com/4.x/apt/ stable main'
+  keyring_path: '/usr/share/keyrings/wazuh.gpg'
+  apt: 'deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main'
   yum: 'https://packages.wazuh.com/4.x/yum/'
   gpg: 'https://packages.wazuh.com/key/GPG-KEY-WAZUH'
-  key_id: '0DCFCA5547B19D2A6099506096B3EE5F29111145'
+  path: '/tmp/WAZUH-GPG-KEY'
 wazuh_winagent_config_url: "https://packages.wazuh.com/4.x/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi"
 wazuh_winagent_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.msi"
 wazuh_winagent_sha512_url: "https://packages.wazuh.com/4.x/checksums/wazuh/{{ wazuh_agent_version }}/wazuh-agent-{{ wazuh_agent_version }}-1.msi.sha512"

--- a/roles/wazuh/vars/repo_pre-release.yml
+++ b/roles/wazuh/vars/repo_pre-release.yml
@@ -1,8 +1,9 @@
 wazuh_repo:
-  apt: 'deb https://packages-dev.wazuh.com/pre-release/apt/ unstable main'
+  keyring_path: '/usr/share/keyrings/wazuh.gpg'
+  apt: 'deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages-dev.wazuh.com/pre-release/apt/ unstable main'
   yum: 'https://packages-dev.wazuh.com/pre-release/yum/'
   gpg: 'https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH'
-  key_id: '0DCFCA5547B19D2A6099506096B3EE5F29111145'
+  path: '/tmp/WAZUH-GPG-KEY'
 wazuh_winagent_config_url: "https://packages-dev.wazuh.com/pre-release/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi"
 wazuh_winagent_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.msi"
 wazuh_winagent_sha512_url: "https://packages-dev.wazuh.com/pre-release/checksums/wazuh/{{ wazuh_agent_version }}/wazuh-agent-{{ wazuh_agent_version }}-1.msi.sha512"
@@ -10,7 +11,7 @@ filebeat_module_package_url: https://packages-dev.wazuh.com/pre-release/filebeat
 
 wazuh_macos_intel_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.intel64.pkg"
 wazuh_macos_arm_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.arm64.pkg"
-wazuh_macos_intel_package_url: "https://packages-dev.wazuh.com/staging/pre-release/{{ wazuh_macos_intel_package_name }}"
+wazuh_macos_intel_package_url: "https://packages-dev.wazuh.com/pre-release/{{ wazuh_macos_intel_package_name }}"
 wazuh_macos_arm_package_url: "https://packages-dev.wazuh.com/pre-release/macos/{{ wazuh_macos_arm_package_name }}"
 
 certs_gen_tool_version: 4.8

--- a/roles/wazuh/vars/repo_staging.yml
+++ b/roles/wazuh/vars/repo_staging.yml
@@ -1,8 +1,9 @@
 wazuh_repo:
-  apt: 'deb https://packages-dev.wazuh.com/staging/apt/ unstable main'
+  keyring_path: '/usr/share/keyrings/wazuh.gpg'
+  apt: 'deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages-dev.wazuh.com/staging/apt/ unstable main'
   yum: 'https://packages-dev.wazuh.com/staging/yum/'
   gpg: 'https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH'
-  key_id: '0DCFCA5547B19D2A6099506096B3EE5F29111145'
+  path: '/tmp/WAZUH-GPG-KEY'
 wazuh_winagent_config_url: "https://packages-dev.wazuh.com/staging/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi"
 wazuh_winagent_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.msi"
 wazuh_winagent_sha512_url: "https://packages-dev.wazuh.com/staging/checksums/wazuh/{{ wazuh_agent_version }}/wazuh-agent-{{ wazuh_agent_version }}-1.msi.sha512"

--- a/roles/wazuh/wazuh-dashboard/tasks/Debian.yml
+++ b/roles/wazuh/wazuh-dashboard/tasks/Debian.yml
@@ -2,10 +2,20 @@
 - block:
 
   - include_vars: debian.yml
-  - name: Add apt repository signing key
-    apt_key:
+  - name: Download apt repository signing key
+    get_url:
       url: "{{ wazuh_repo.gpg }}"
-      state: present
+      dest: "{{ wazuh_repo.path }}"
+  
+  - name: Import Wazuh repository GPG key
+    command: "gpg --no-default-keyring --keyring gnupg-ring:{{ wazuh_repo.keyring_path }} --import {{ wazuh_repo.path }}"
+    args:
+      creates: "{{ wazuh_repo.keyring_path }}"
+
+  - name: Set permissions for Wazuh repository GPG key
+    file:
+      path: "{{ wazuh_repo.keyring_path }}"
+      mode: '0644'
 
   - name: Debian systems | Add Wazuh dashboard repo
     apt_repository:

--- a/roles/wazuh/wazuh-indexer/tasks/Debian.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/Debian.yml
@@ -19,9 +19,19 @@
 - name: Add Wazuh indexer repository
   block:
     - name: Add apt repository signing key
-      apt_key:
+      get_url:
         url: "{{ wazuh_repo.gpg }}"
-        state: present
+        dest: "{{ wazuh_repo.path }}"
+  
+    - name: Import Wazuh repository GPG key
+      command: "gpg --no-default-keyring --keyring gnupg-ring:{{ wazuh_repo.keyring_path }} --import {{ wazuh_repo.path }}"
+      args:
+        creates: "{{ wazuh_repo.keyring_path }}"
+
+    - name: Set permissions for Wazuh repository GPG key
+      file:
+        path: "{{ wazuh_repo.keyring_path }}"
+        mode: '0644'
 
     - name: Add Wazuh indexer repository
       apt_repository:


### PR DESCRIPTION
## Description

Related: https://github.com/wazuh/wazuh-ansible/issues/1289
The aim of this PR is to fix the `apt_key` deprecation of the Wazuh ansible deployment. This function of Ansible has been deprecated and is generating some trouble in the new versions of Ansible.
This change aims to adapt to every Ansible version, changing the way the Wazuh GPG is imported.


## Testing

The following testing has been performed:

:green_circle: Ubuntu 24 - AIO

```console
root@ip-172-31-39-58:/home/ubuntu# ansible --version
ansible [core 2.16.6]
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3/dist-packages/ansible
  ansible collection location = /root/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/bin/ansible
  python version = 3.12.3 (main, Apr 10 2024, 05:33:47) [GCC 13.2.0] (/usr/bin/python3)
  jinja version = 3.1.2
  libyaml = True
root@ip-172-31-39-58:/home/ubuntu# 
```

<details><summary>Log</summary>

[ubuntu24.log](https://github.com/wazuh/wazuh-ansible/files/15402681/ubuntu24.log)


</details>


:green_circle: Ubuntu 18 - AIO
```console
root@ip-172-31-43-38:/home/ubuntu# ansible --version
ansible 2.9.27
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.17 (default, Mar  8 2023, 18:40:28) [GCC 7.5.0]
root@ip-172-31-43-38:/home/ubuntu# 
```



<details><summary>Log</summary>

[ubuntu18.log](https://github.com/wazuh/wazuh-ansible/files/15402685/ubuntu18.log)


</details>


:green_circle: Debian 12 - AIO

```console
root@ip-172-31-34-35:/home/admin# ansible --version
ansible [core 2.14.3]
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3/dist-packages/ansible
  ansible collection location = /root/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/bin/ansible
  python version = 3.11.2 (main, Mar 13 2023, 12:18:29) [GCC 12.2.0] (/usr/bin/python3)
  jinja version = 3.1.2
  libyaml = True
root@ip-172-31-34-35:/home/admin# 
```

<details><summary>Log</summary>

[debian12.log](https://github.com/wazuh/wazuh-ansible/files/15402689/debian12.log)

</details>


<details><summary>:green_circle: Ubuntu 18 - Wazuh agent</summary>

```console
root@ip-172-31-43-38:/home/ubuntu/wazuh-ansible/playbooks# ansible-playbook wazuh-agent.yml -v
Using /home/ubuntu/wazuh-ansible/playbooks/ansible.cfg as config file
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not
match 'all'

PLAY [localhost] ************************************************************************************************

TASK [Gathering Facts] ******************************************************************************************
ok: [localhost]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ********************************************************
ok: [localhost] => {"ansible_facts": {"packages_repository": "pre-release"}, "ansible_included_var_files": ["/home/ubuntu/wazuh-ansible/roles/wazuh/ansible-wazuh-agent/tasks/../../vars/repo_vars.yml"], "changed": false}

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ********************************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ********************************************************
ok: [localhost] => {"ansible_facts": {"certs_gen_tool_url": "https://packages-dev.wazuh.com/{{ certs_gen_tool_version }}/wazuh-certs-tool.sh", "certs_gen_tool_version": 4.8, "filebeat_module_package_url": "https://packages-dev.wazuh.com/pre-release/filebeat", "wazuh_macos_arm_package_name": "wazuh-agent-{{ wazuh_agent_version }}-1.arm64.pkg", "wazuh_macos_arm_package_url": "https://packages-dev.wazuh.com/pre-release/macos/{{ wazuh_macos_arm_package_name }}", "wazuh_macos_intel_package_name": "wazuh-agent-{{ wazuh_agent_version }}-1.intel64.pkg", "wazuh_macos_intel_package_url": "https://packages-dev.wazuh.com/pre-release/{{ wazuh_macos_intel_package_name }}", "wazuh_repo": {"apt": "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages-dev.wazuh.com/pre-release/apt/ unstable main", "gpg": "https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH", "keyring_path": "/usr/share/keyrings/wazuh.gpg", "path": "/tmp/WAZUH-GPG-KEY", "yum": "https://packages-dev.wazuh.com/pre-release/yum/"}, "wazuh_winagent_config_url": "https://packages-dev.wazuh.com/pre-release/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi", "wazuh_winagent_package_name": "wazuh-agent-{{ wazuh_agent_version }}-1.msi", "wazuh_winagent_sha512_url": "https://packages-dev.wazuh.com/pre-release/checksums/wazuh/{{ wazuh_agent_version }}/wazuh-agent-{{ wazuh_agent_version }}-1.msi.sha512"}, "ansible_included_var_files": ["/home/ubuntu/wazuh-ansible/roles/wazuh/ansible-wazuh-agent/tasks/../../vars/repo_pre-release.yml"], "changed": false}

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ********************************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Overlay wazuh_agent_config on top of defaults] ***********************
ok: [localhost] => {"ansible_facts": {"wazuh_agent_config": {"active_response": {"ar_disabled": "no", "ca_store": "/var/ossec/etc/wpk_root.pem", "ca_store_macos": "etc/

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] *******************************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] *******************************************************
included: /home/ubuntu/wazuh-ansible/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml for localhost

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] *******************************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] *******************************************************
included: /home/ubuntu/wazuh-ansible/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml for localhost

TASK [../roles/wazuh/ansible-wazuh-agent : Update apt-get repo and cache] ***************************************
[WARNING]: Updating cache and auto-installing missing dependency: python-apt
ok: [localhost] => {"cache_update_time": 1716364857, "cache_updated": false, "changed": false}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Install ca-certificates and gnupg] *******************
ok: [localhost] => {"attempts": 1, "cache_update_time": 1716364857, "cache_updated": false, "changed": false}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Install apt-transport-https and acl] *****************
changed: [localhost] => {"attempts": 1, "cache_update_time": 1716364857, "cache_updated": false, "changed": true, "stderr": "", "stderr_lines": [], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following packages were automatically installed and are no longer required:\n  ieee-data python-certifi python-chardet python-jmespath python-kerberos\n  python-libcloud python-lockfile python-netaddr python-openssl\n  python-requests python-selinux python-simplejson python-urllib3\n  python-xmltodict\nUse 'sudo apt autoremove' to remove them.\nThe following NEW packages will be installed:\n  apt-transport-https\n0 upgraded, 1 newly installed, 0 to remove and 83 not upgraded.\nNeed to get 1692 B of archives.\nAfter this operation, 155 kB of additional disk space will be used.\nGet:1 http://us-east-1.ec2.archive.ubuntu.com/ubuntu bionic-updates/universe amd64 apt-transport-https all 1.6.17 [1692 B]\nFetched 1692 B in 0s (156 kB/s)\nSelecting previously unselected package apt-transport-https.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 68539 files and directories currently installed.)\r\nPreparing to unpack .../apt-transport-https_1.6.17_all.deb ...\r\nUnpacking apt-transport-https (1.6.17) ...\r\nSetting up apt-transport-https (1.6.17) ...\r\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "The following packages were automatically installed and are no longer required:", "  ieee-data python-certifi python-chardet python-jmespath python-kerberos", "  python-libcloud python-lockfile python-netaddr python-openssl", "  python-requests python-selinux python-simplejson python-urllib3", "  python-xmltodict", "Use 'sudo apt autoremove' to remove them.", "The following NEW packages will be installed:", "  apt-transport-https", "0 upgraded, 1 newly installed, 0 to remove and 83 not upgraded.", "Need to get 1692 B of archives.", "After this operation, 155 kB of additional disk space will be used.", "Get:1 http://us-east-1.ec2.archive.ubuntu.com/ubuntu bionic-updates/universe amd64 apt-transport-https all 1.6.17 [1692 B]", "Fetched 1692 B in 0s (156 kB/s)", "Selecting previously unselected package apt-transport-https.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 68539 files and directories currently installed.)", "Preparing to unpack .../apt-transport-https_1.6.17_all.deb ...", "Unpacking apt-transport-https (1.6.17) ...", "Setting up apt-transport-https (1.6.17) ..."]}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Installing Wazuh repository key (Ubuntu 14)] *********
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Download Wazuh repository key] ***********************
changed: [localhost] => {"changed": true, "checksum_dest": null, "checksum_src": "df6876db873e3508f22f9914ec3d07efc054668b", "dest": "/tmp/WAZUH-GPG-KEY", "elapsed": 0, "gid": 0, "group": "root", "md5sum": "73414e5a5e3edec5104d4a7572a178cf", "mode": "0644", "msg": "OK (3141 bytes)", "owner": "root", "size": 3141, "src": "/root/.ansible/tmp/ansible-tmp-1716364871.67-8308-122703908768286/tmpE9_c5b", "state": "file", "status_code": 200, "uid": 0, "url": "https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH"}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Import Wazuh GPG key] ********************************
changed: [localhost] => {"changed": true, "cmd": ["gpg", "--no-default-keyring", "--keyring", "gnupg-ring:/usr/share/keyrings/wazuh.gpg", "--import", "/tmp/WAZUH-GPG-KEY"], "delta": "0:00:00.011721", "end": "2024-05-22 08:01:12.976815", "rc": 0, "start": "2024-05-22 08:01:12.965094", "stderr": "gpg: keyring '/usr/share/keyrings/wazuh.gpg' created\ngpg: directory '/root/.gnupg' created\ngpg: /root/.gnupg/trustdb.gpg: trustdb created\ngpg: key 96B3EE5F29111145: public key \"Wazuh.com (Wazuh Signing Key) <support@wazuh.com>\" imported\ngpg: Total number processed: 1\ngpg:               imported: 1", "stderr_lines": ["gpg: keyring '/usr/share/keyrings/wazuh.gpg' created", "gpg: directory '/root/.gnupg' created", "gpg: /root/.gnupg/trustdb.gpg: trustdb created", "gpg: key 96B3EE5F29111145: public key \"Wazuh.com (Wazuh Signing Key) <support@wazuh.com>\" imported", "gpg: Total number processed: 1", "gpg:               imported: 1"], "stdout": "", "stdout_lines": []}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Set permissions for Wazuh GPG key] *******************
changed: [localhost] => {"changed": true, "gid": 0, "group": "root", "mode": "0644", "owner": "root", "path": "/usr/share/keyrings/wazuh.gpg", "size": 2279, "state": "file", "uid": 0}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Add Wazuh repositories] ******************************
changed: [localhost] => {"changed": true, "repo": "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages-dev.wazuh.com/pre-release/apt/ unstable main", "state": "present"}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Set Distribution CIS filename for debian] ************
ok: [localhost] => {"ansible_facts": {"cis_distribution_filename": "cis_debian_linux_rcl.txt"}, "changed": false}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Install OpenJDK-8 repo] ******************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Install OpenJDK 1.8] *********************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Install OpenScap] ************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Get OpenScap installed version] **********************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Check OpenScap version] ******************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] *******************************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux CentOS/RedHat | Install wazuh-agent] ***************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux Debian | Install wazuh-agent] **********************************
changed: [localhost] => {"cache_update_time": 1716364880, "cache_updated": false, "changed": true, "stderr": "", "stderr_lines": [], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following packages were automatically installed and are no longer required:\n  ieee-data python-certifi python-chardet python-jmespath python-kerberos\n  python-libcloud python-lockfile python-netaddr python-openssl\n  python-requests python-selinux python-simplejson python-urllib3\n  python-xmltodict\nUse 'sudo apt autoremove' to remove them.\nThe following NEW packages will be installed:\n  wazuh-agent\n0 upgraded, 1 newly installed, 0 to remove and 83 not upgraded.\nNeed to get 10.3 MB of archives.\nAfter this operation, 34.0 MB of additional disk space will be used.\nGet:1 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 wazuh-agent amd64 4.8.0-1 [10.3 MB]\nPreconfiguring packages ...\nFetched 10.3 MB in 1s (14.1 MB/s)\nSelecting previously unselected package wazuh-agent.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 68543 files and directories currently installed.)\r\nPreparing to unpack .../wazuh-agent_4.8.0-1_amd64.deb ...\r\nUnpacking wazuh-agent (4.8.0-1) ...\r\nSetting up wazuh-agent (4.8.0-1) ...\r\nProcessing triggers for systemd (237-3ubuntu10.56) ...\r\nProcessing triggers for ureadahead (0.100.0-21) ...\r\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "The following packages were automatically installed and are no longer required:", "  ieee-data python-certifi python-chardet python-jmespath python-kerberos", "  python-libcloud python-lockfile python-netaddr python-openssl", "  python-requests python-selinux python-simplejson python-urllib3", "  python-xmltodict", "Use 'sudo apt autoremove' to remove them.", "The following NEW packages will be installed:", "  wazuh-agent", "0 upgraded, 1 newly installed, 0 to remove and 83 not upgraded.", "Need to get 10.3 MB of archives.", "After this operation, 34.0 MB of additional disk space will be used.", "Get:1 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 wazuh-agent amd64 4.8.0-1 [10.3 MB]", "Preconfiguring packages ...", "Fetched 10.3 MB in 1s (14.1 MB/s)", "Selecting previously unselected package wazuh-agent.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 68543 files and directories currently installed.)", "Preparing to unpack .../wazuh-agent_4.8.0-1_amd64.deb ...", "Unpacking wazuh-agent (4.8.0-1) ...", "Setting up wazuh-agent (4.8.0-1) ...", "Processing triggers for systemd (237-3ubuntu10.56) ...", "Processing triggers for ureadahead (0.100.0-21) ..."]}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux | Check if client.keys exists] *********************************
ok: [localhost] => {"changed": false, "stat": {"atime": 1716364889.0, "attr_flags": "e", "attributes": ["extents"], "block_size": 4096, "blocks": 0, "charset": "binary", "checksum": "da39a3ee5e6b4b0d3255bfef95601890afd80709", "ctime": 1716364891.657231, "dev": 66305, "device_type": 0, "executable": false, "exists": true, "gid": 115, "gr_name": "wazuh", "inode": 275875, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mimetype": "inode/x-empty", "mode": "0640", "mtime": 1715683196.0, "nlink": 1, "path": "/var/ossec/etc/client.keys", "pw_name": "root", "readable": true, "rgrp": true, "roth": false, "rusr": true, "size": 0, "uid": 0, "version": "2748384826", "wgrp": false, "woth": false, "writeable": true, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}}

TASK [../roles/wazuh/ansible-wazuh-agent : Copy CA root certificate to verify authd] ****************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Copy TLS/SSL certificate for agent verification] *********************
skipping: [localhost] => (item=)  => {"ansible_loop_var": "item", "changed": false, "item": "", "skip_reason": "Conditional result was False"}
skipping: [localhost] => (item=)  => {"ansible_loop_var": "item", "changed": false, "item": "", "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux | Register agent (via authd)] **********************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux | Verify agent registration] ***********************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Establish target Wazuh Manager for registration task] ****************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux | Obtain JWT Token] ********************************************
skipping: [localhost] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux | Create the agent key via rest-API] ***************************
skipping: [localhost] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux | Validate registered agent key matches manager record] ********
skipping: [localhost] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux | Import Key (via rest-API)] ***********************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux | Agent registration via auto-enrollment] **********************
ok: [localhost] => {
    "msg": "Agent registration will be performed through enrollment option in templated ossec.conf"
}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux | Ensure group "wazuh" exists] *********************************
ok: [localhost] => {"changed": false, "gid": 115, "name": "wazuh", "state": "present", "system": false}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux | Installing agent configuration (ossec.conf)] *****************
changed: [localhost] => {"changed": true, "checksum": "75aa1c3729ccb58fd581e2f500c96031a627438e", "dest": "/var/ossec/etc/ossec.conf", "gid": 115, "group": "wazuh", "md5sum": "81ad6132758de364564b20764bddd392", "mode": "0644", "owner": "root", "size": 5817, "src": "/root/.ansible/tmp/ansible-tmp-1716364895.96-10371-183137421922316/source", "state": "file", "uid": 0}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux | Installing local_internal_options.conf] **********************
changed: [localhost] => {"changed": true, "checksum": "0836cd8eb65da2b28a8ce0256089c16a96b539f7", "dest": "/var/ossec/etc/local_internal_options.conf", "gid": 115, "group": "wazuh", "md5sum": "2946474af41ec939dfa232ef36773876", "mode": "0640", "owner": "root", "size": 575, "src": "/root/.ansible/tmp/ansible-tmp-1716364896.86-10411-160188730493627/source", "state": "file", "uid": 0}

TASK [../roles/wazuh/ansible-wazuh-agent : Create auto-enrollment password file] ********************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux | Ensure Wazuh Agent service is started and enabled] ***********
changed: [localhost] => {"changed": true, "enabled": true, "name": "wazuh-agent", "state": "started", "status": {"ActiveEnterTimestampMonotonic": "0", 

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] *******************************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] *******************************************************
included: /home/ubuntu/wazuh-ansible/roles/wazuh/ansible-wazuh-agent/tasks/RMDebian.yml for localhost

TASK [../roles/wazuh/ansible-wazuh-agent : Remove Wazuh repository (and clean up left-over metadata)] ***********
ok: [localhost] => {"changed": false, "repo": "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages-dev.wazuh.com/pre-release/apt/ unstable main", "state": "absent"}

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] *******************************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

RUNNING HANDLER [../roles/wazuh/ansible-wazuh-agent : restart wazuh-agent] **************************************
changed: [localhost] => {"changed": true, "enabled": true, "name": "wazuh-agent", "state": "started", "status": {"ActiveEnterTimestamp": "Wed 2024-05-22 08:01:44 UTC", 

PLAY RECAP ******************************************************************************************************
localhost                  : ok=24   changed=10   unreachable=0    failed=0    skipped=24   rescued=0    ignored=0   

root@ip-172-31-43-38:/home/ubuntu/wazuh-ansible/playbooks# 
```
</details>

<details><summary>:green_circle: Debian 12 - Wazuh agent</summary>

```console
root@ip-172-31-35-78:/home/admin/wazuh-ansible/playbooks# ansible-playbook wazuh-agent.yml -v
Using /home/admin/wazuh-ansible/playbooks/ansible.cfg as config file
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not
match 'all'

PLAY [localhost] ****************************************************************************************************

TASK [Gathering Facts] **********************************************************************************************
ok: [localhost]

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ************************************************************
ok: [localhost] => {"ansible_facts": {"packages_repository": "pre-release"}, "ansible_included_var_files": ["/home/admin/wazuh-ansible/roles/wazuh/ansible-wazuh-agent/tasks/../../vars/repo_vars.yml"], "changed": false}

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ************************************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ************************************************************
ok: [localhost] => {"ansible_facts": {"certs_gen_tool_url": "https://packages-dev.wazuh.com/{{ certs_gen_tool_version }}/wazuh-certs-tool.sh", "certs_gen_tool_version": 4.8, "filebeat_module_package_url": "https://packages-dev.wazuh.com/pre-release/filebeat", "wazuh_macos_arm_package_name": "wazuh-agent-{{ wazuh_agent_version }}-1.arm64.pkg", "wazuh_macos_arm_package_url": "https://packages-dev.wazuh.com/pre-release/macos/{{ wazuh_macos_arm_package_name }}", "wazuh_macos_intel_package_name": "wazuh-agent-{{ wazuh_agent_version }}-1.intel64.pkg", "wazuh_macos_intel_package_url": "https://packages-dev.wazuh.com/pre-release/{{ wazuh_macos_intel_package_name }}", "wazuh_repo": {"apt": "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages-dev.wazuh.com/pre-release/apt/ unstable main", "gpg": "https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH", "keyring_path": "/usr/share/keyrings/wazuh.gpg", "path": "/tmp/WAZUH-GPG-KEY", "yum": "https://packages-dev.wazuh.com/pre-release/yum/"}, "wazuh_winagent_config_url": "https://packages-dev.wazuh.com/pre-release/windows/wazuh-agent-{{ wazuh_agent_version }}-1.msi", "wazuh_winagent_package_name": "wazuh-agent-{{ wazuh_agent_version }}-1.msi", "wazuh_winagent_sha512_url": "https://packages-dev.wazuh.com/pre-release/checksums/wazuh/{{ wazuh_agent_version }}/wazuh-agent-{{ wazuh_agent_version }}-1.msi.sha512"}, "ansible_included_var_files": ["/home/admin/wazuh-ansible/roles/wazuh/ansible-wazuh-agent/tasks/../../vars/repo_pre-release.yml"], "changed": false}

TASK [../roles/wazuh/ansible-wazuh-agent : include_vars] ************************************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Overlay wazuh_agent_config on top of defaults] ***************************
ok: [localhost] => {"ansible_facts": {"wazuh_agent_config": {"active_response": {"ar_disabled": "no", "ca_store": "/var/ossec/etc/wpk_root.pem", "ca_store_macos": "etc/

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] ***********************************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] ***********************************************************
included: /home/admin/wazuh-ansible/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml for localhost

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] ***********************************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] ***********************************************************
included: /home/admin/wazuh-ansible/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml for localhost

TASK [../roles/wazuh/ansible-wazuh-agent : Update apt-get repo and cache] *******************************************
changed: [localhost] => {"cache_update_time": 1716378705, "cache_updated": true, "changed": true}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Install ca-certificates and gnupg] ***********************
ok: [localhost] => {"attempts": 1, "cache_update_time": 1716378705, "cache_updated": false, "changed": false}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Install apt-transport-https and acl] *********************
ok: [localhost] => {"attempts": 1, "cache_update_time": 1716378705, "cache_updated": false, "changed": false}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Installing Wazuh repository key (Ubuntu 14)] *************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Download Wazuh repository key] ***************************
ok: [localhost] => {"changed": false, "dest": "/tmp/WAZUH-GPG-KEY", "elapsed": 0, "gid": 0, "group": "root", "mode": "0644", "msg": "HTTP Error 304: Not Modified", "owner": "root", "size": 3141, "state": "file", "status_code": 304, "uid": 0, "url": "https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH"}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Import Wazuh GPG key] ************************************
ok: [localhost] => {"changed": false, "cmd": ["gpg", "--no-default-keyring", "--keyring", "gnupg-ring:/usr/share/keyrings/wazuh.gpg", "--import", "/tmp/WAZUH-GPG-KEY"], "delta": null, "end": null, "msg": "Did not run command since '/usr/share/keyrings/wazuh.gpg' exists", "rc": 0, "start": null, "stderr": "", "stderr_lines": [], "stdout": "skipped, since /usr/share/keyrings/wazuh.gpg exists", "stdout_lines": ["skipped, since /usr/share/keyrings/wazuh.gpg exists"]}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Set permissions for Wazuh GPG key] ***********************
ok: [localhost] => {"changed": false, "gid": 0, "group": "root", "mode": "0644", "owner": "root", "path": "/usr/share/keyrings/wazuh.gpg", "size": 2279, "state": "file", "uid": 0}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Add Wazuh repositories] **********************************
changed: [localhost] => {"changed": true, "repo": "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages-dev.wazuh.com/pre-release/apt/ unstable main", "state": "present"}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Set Distribution CIS filename for debian] ****************
ok: [localhost] => {"ansible_facts": {"cis_distribution_filename": "cis_debian_linux_rcl.txt"}, "changed": false}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Install OpenJDK-8 repo] **********************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Install OpenJDK 1.8] *************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Install OpenScap] ****************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Get OpenScap installed version] **************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Debian/Ubuntu | Check OpenScap version] **********************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] ***********************************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux CentOS/RedHat | Install wazuh-agent] *******************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux Debian | Install wazuh-agent] **************************************
changed: [localhost] => {"cache_update_time": 1716378716, "cache_updated": false, "changed": true, "stderr": "", "stderr_lines": [], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following NEW packages will be installed:\n  wazuh-agent\nPreconfiguring packages ...\n0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.\nNeed to get 0 B/10.3 MB of archives.\nAfter this operation, 34.0 MB of additional disk space will be used.\nSelecting previously unselected package wazuh-agent.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 59065 files and directories currently installed.)\r\nPreparing to unpack .../wazuh-agent_4.8.0-1_amd64.deb ...\r\nUnpacking wazuh-agent (4.8.0-1) ...\r\nSetting up wazuh-agent (4.8.0-1) ...\r\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "The following NEW packages will be installed:", "  wazuh-agent", "Preconfiguring packages ...", "0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.", "Need to get 0 B/10.3 MB of archives.", "After this operation, 34.0 MB of additional disk space will be used.", "Selecting previously unselected package wazuh-agent.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 59065 files and directories currently installed.)", "Preparing to unpack .../wazuh-agent_4.8.0-1_amd64.deb ...", "Unpacking wazuh-agent (4.8.0-1) ...", "Setting up wazuh-agent (4.8.0-1) ..."]}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux | Check if client.keys exists] *************************************
ok: [localhost] => {"changed": false, "stat": {"atime": 1716378720.0, "attr_flags": "e", "attributes": ["extents"], "block_size": 4096, "blocks": 0, "charset": "binary", "checksum": "da39a3ee5e6b4b0d3255bfef95601890afd80709", "ctime": 1716378721.699567, "dev": 66305, "device_type": 0, "executable": false, "exists": true, "gid": 109, "gr_name": "wazuh", "inode": 527156, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mimetype": "inode/x-empty", "mode": "0640", "mtime": 1715683196.0, "nlink": 1, "path": "/var/ossec/etc/client.keys", "pw_name": "root", "readable": true, "rgrp": true, "roth": false, "rusr": true, "size": 0, "uid": 0, "version": "3550913380", "wgrp": false, "woth": false, "writeable": true, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}}

TASK [../roles/wazuh/ansible-wazuh-agent : Copy CA root certificate to verify authd] ********************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Copy TLS/SSL certificate for agent verification] *************************
skipping: [localhost] => (item=)  => {"ansible_loop_var": "item", "changed": false, "item": "", "skip_reason": "Conditional result was False"}
skipping: [localhost] => (item=)  => {"ansible_loop_var": "item", "changed": false, "item": "", "skip_reason": "Conditional result was False"}
skipping: [localhost] => {"changed": false, "msg": "All items skipped"}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux | Register agent (via authd)] **************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux | Verify agent registration] ***************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Establish target Wazuh Manager for registration task] ********************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux | Obtain JWT Token] ************************************************
skipping: [localhost] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux | Create the agent key via rest-API] *******************************
skipping: [localhost] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux | Validate registered agent key matches manager record] ************
skipping: [localhost] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux | Import Key (via rest-API)] ***************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux | Agent registration via auto-enrollment] **************************
ok: [localhost] => {
    "msg": "Agent registration will be performed through enrollment option in templated ossec.conf"
}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux | Ensure group "wazuh" exists] *************************************
ok: [localhost] => {"changed": false, "gid": 109, "name": "wazuh", "state": "present", "system": false}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux | Installing agent configuration (ossec.conf)] *********************
changed: [localhost] => {"changed": true, "checksum": "a0d5392b4754067768fc48bdc3df024a17cad124", "dest": "/var/ossec/etc/ossec.conf", "gid": 109, "group": "wazuh", "md5sum": "ed36ecb0d8596305cd9b3b84ef9c65c1", "mode": "0644", "owner": "root", "size": 5750, "src": "/root/.ansible/tmp/ansible-tmp-1716378724.0761354-21060-172367020860574/source", "state": "file", "uid": 0}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux | Installing local_internal_options.conf] **************************
changed: [localhost] => {"changed": true, "checksum": "0836cd8eb65da2b28a8ce0256089c16a96b539f7", "dest": "/var/ossec/etc/local_internal_options.conf", "gid": 109, "group": "wazuh", "md5sum": "2946474af41ec939dfa232ef36773876", "mode": "0640", "owner": "root", "size": 575, "src": "/root/.ansible/tmp/ansible-tmp-1716378725.4287577-21100-89432515375527/source", "state": "file", "uid": 0}

TASK [../roles/wazuh/ansible-wazuh-agent : Create auto-enrollment password file] ************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : Linux | Ensure Wazuh Agent service is started and enabled] ***************
changed: [localhost] => {"changed": true, "enabled": true, "name": "wazuh-agent", "state": "started", "status": {"ActiveEnterTimestamp": "Wed 2024-05-22 07:50:17 UTC", 
TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] ***********************************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] ***********************************************************
included: /home/admin/wazuh-ansible/roles/wazuh/ansible-wazuh-agent/tasks/RMDebian.yml for localhost

TASK [../roles/wazuh/ansible-wazuh-agent : Remove Wazuh repository (and clean up left-over metadata)] ***************
ok: [localhost] => {"changed": false, "repo": "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages-dev.wazuh.com/pre-release/apt/ unstable main", "state": "absent"}

TASK [../roles/wazuh/ansible-wazuh-agent : include_tasks] ***********************************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

RUNNING HANDLER [../roles/wazuh/ansible-wazuh-agent : restart wazuh-agent] ******************************************
changed: [localhost] => {"changed": true, "enabled": true, "name": "wazuh-agent", "state": "started", "status": {"ActiveEnterTimestamp": "Wed 2024-05-22 11:52:14 UTC", 
PLAY RECAP **********************************************************************************************************
localhost                  : ok=24   changed=7    unreachable=0    failed=0    skipped=24   rescued=0    ignored=0   


```
</details>



The changes have been tested in a Demo deployment: 
https://ci.wazuh.info/job/Procedure_deploy_demo/414/consoleFull