### PR TITLE
Added support for deploying to an Ansible node on macOS

### DIFF
--- a/playbooks/wazuh-production-ready.yml
+++ b/playbooks/wazuh-production-ready.yml
@@ -43,6 +43,7 @@
             name: node-6
             ip: "{{ hostvars.dashboard.private_ip }}"
             role: dashboard
+        macos_localhost: false
       tags:
         - generate-certs
 

--- a/playbooks/wazuh-single.yml
+++ b/playbooks/wazuh-single.yml
@@ -13,6 +13,7 @@
           name: node-1       # Important: must be equal to indexer_node_name.
           ip: 127.0.0.1
           role: indexer
+      macos_localhost: false
     tags:
       - generate-certs
 # Single node

--- a/roles/wazuh/wazuh-indexer/defaults/main.yml
+++ b/roles/wazuh/wazuh-indexer/defaults/main.yml
@@ -48,3 +48,6 @@ generate_certs: true
 perform_installation: true
 
 indexer_nolog_sensible: true
+
+# Docker image for certificates generation on macOS
+wazuh_certs_tool_docker: "wazuh/wazuh-cert-tool:{{ indexer_version }}"

--- a/roles/wazuh/wazuh-indexer/tasks/local_actions.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/local_actions.yml
@@ -21,12 +21,13 @@
     stat:
       path: "{{ local_certs_path }}/wazuh-certs-tool.sh"
     register: tool_package
+    when: ansible_os_family != 'Darwin' or ansible_os_family != 'Windows'
 
   - name: Local action | Download certificates generation tool
     get_url:
       url: "{{ certs_gen_tool_url }}"
       dest: "{{ local_certs_path }}/wazuh-certs-tool.sh"
-    when: not tool_package.stat.exists
+    when: not tool_package.stat.exists and ansible_os_family != 'Darwin' or ansible_os_family != 'Windows'
 
   - name: Local action | Prepare the certificates generation template file
     template:
@@ -34,10 +35,57 @@
       dest: "{{ local_certs_path }}/config.yml"
       mode: 0644
     register: tlsconfig_template
+    when: ansible_os_family != 'Darwin' or ansible_os_family != 'Windows'
 
   - name: Local action | Generate the node & admin certificates in local
     command: >-
       bash {{ local_certs_path }}/wazuh-certs-tool.sh -A
+    when: ansible_os_family != 'Darwin' or ansible_os_family != 'Windows'
+
+  - name: Local action | Check for Docker installation on macOS
+    command: docker --version
+    register: docker_check
+    when: os_family == 'Darwin'
+    ignore_errors: yes
+
+  - name: Local action | Check for Docker installation on Windows
+    win_shell: docker --version
+    register: docker_check
+    when: os_family == 'Windows'
+    ignore_errors: yes
+
+  - name: Local action | Fail if Docker is not installed
+    fail:
+      msg: "Docker is not installed on this host."
+    when: docker_check.rc != 0 and ansible_os_family == 'Darwin' or ansible_os_family == 'Windows'
+
+  - name: Local action | Run Docker container on macOS
+    community.docker.docker_container:
+      name: wazuh-cert-tool
+      image: "wazuh/wazuh-cert-tool"
+      state: started
+      auto_remove: true
+      volumes:
+        - "{{ local_certs_path }}/config.yml:/config/certs.yml"
+        - "{{ local_certs_path }}/wazuh-certificates:/certificates/"
+    when: os_family == 'Darwin'
+
+  - name: Local action | Run Docker container on Windows
+    community.docker.docker_container:
+      name: wazuh-cert-tool
+      image: "wazuh/wazuh-cert-tool"
+      state: started
+      auto_remove: true
+      volumes:
+        - "C:/{{ local_certs_path }}/config.yml:/config/certs.yml"
+        - "{{ local_certs_path }}/wazuh-certificates:C:/certificates/"
+    when: os_family == 'Windows'
+
+  - name: Remove Docker image after execution
+    community.docker.docker_image:
+      name: "wazuh/wazuh-cert-tool"
+      state: absent
+    when: os_family == 'Darwin' or os_family == 'Windows'
 
   run_once: true
   delegate_to: localhost

--- a/roles/wazuh/wazuh-indexer/tasks/local_actions.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/local_actions.yml
@@ -55,7 +55,7 @@
   - name: Local action | Run Docker container on macOS
     community.docker.docker_container:
       name: wazuh-cert-tool
-      image: "wazuh-certs-tool"
+      image: "wazuh/wazuh-cert-tool"
       state: started
       auto_remove: true
       volumes:
@@ -65,7 +65,7 @@
 
   - name: Local action | Remove Docker image after execution
     community.docker.docker_image:
-      name: "wazuh-certs-tool"
+      name: "wazuh/wazuh-cert-tool"
       state: absent
       force_absent: yes
     when: ansible_os_family == 'Darwin'

--- a/roles/wazuh/wazuh-indexer/tasks/local_actions.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/local_actions.yml
@@ -35,7 +35,6 @@
       dest: "{{ local_certs_path }}/config.yml"
       mode: 0644
     register: tlsconfig_template
-    when: ansible_os_family != 'Darwin'
 
   - name: Local action | Generate the node & admin certificates in local
     command: >-
@@ -56,18 +55,19 @@
   - name: Local action | Run Docker container on macOS
     community.docker.docker_container:
       name: wazuh-cert-tool
-      image: "wazuh/wazuh-cert-tool"
+      image: "wazuh-certs-tool"
       state: started
       auto_remove: true
       volumes:
         - "{{ local_certs_path }}/config.yml:/config/certs.yml"
-        - "{{ local_certs_path }}/wazuh-certificates:/certificates/"
+        - "{{ local_certs_path }}/wazuh-certificates/:/certificates/"
     when: ansible_os_family == 'Darwin'
 
   - name: Local action | Remove Docker image after execution
     community.docker.docker_image:
-      name: "wazuh/wazuh-cert-tool"
+      name: "wazuh-certs-tool"
       state: absent
+      force_absent: yes
     when: ansible_os_family == 'Darwin'
 
   run_once: true

--- a/roles/wazuh/wazuh-indexer/tasks/local_actions.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/local_actions.yml
@@ -21,13 +21,13 @@
     stat:
       path: "{{ local_certs_path }}/wazuh-certs-tool.sh"
     register: tool_package
-    when: ansible_os_family == 'Darwin'
+    when: ansible_os_family != 'Darwin'
 
   - name: Local action | Download certificates generation tool
     get_url:
       url: "{{ certs_gen_tool_url }}"
       dest: "{{ local_certs_path }}/wazuh-certs-tool.sh"
-    when: not (tool_package.stat.exists | default(1)) and ansible_os_family == 'Darwin'
+    when: not tool_package.stat.exists and ansible_os_family != 'Darwin'
 
   - name: Local action | Prepare the certificates generation template file
     template:
@@ -35,23 +35,23 @@
       dest: "{{ local_certs_path }}/config.yml"
       mode: 0644
     register: tlsconfig_template
-    when: ansible_os_family == 'Darwin'
+    when: ansible_os_family != 'Darwin'
 
   - name: Local action | Generate the node & admin certificates in local
     command: >-
       bash {{ local_certs_path }}/wazuh-certs-tool.sh -A
-    when: ansible_os_family == 'Darwin'
+    when: ansible_os_family != 'Darwin'
 
   - name: Local action | Check for Docker installation on macOS
     command: docker --version
     register: docker_check
-    when: ansible_os_family != 'Darwin'
+    when: ansible_os_family == 'Darwin'
     ignore_errors: yes
 
   - name: Local action | Fail if Docker is not installed
     fail:
       msg: "Docker is not installed on this host."
-    when: (docker_check.rc | default(1)) != 0 and ansible_os_family != 'Darwin'
+    when: (docker_check.rc | default(1)) != 0 and ansible_os_family == 'Darwin'
 
   - name: Local action | Run Docker container on macOS
     community.docker.docker_container:
@@ -62,13 +62,13 @@
       volumes:
         - "{{ local_certs_path }}/config.yml:/config/certs.yml"
         - "{{ local_certs_path }}/wazuh-certificates:/certificates/"
-    when: ansible_os_family != 'Darwin'
+    when: ansible_os_family == 'Darwin'
 
   - name: Local action | Remove Docker image after execution
     community.docker.docker_image:
       name: "wazuh/wazuh-cert-tool"
       state: absent
-    when: ansible_os_family != 'Darwin'
+    when: ansible_os_family == 'Darwin'
 
   run_once: true
   delegate_to: localhost

--- a/roles/wazuh/wazuh-indexer/tasks/local_actions.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/local_actions.yml
@@ -21,13 +21,13 @@
     stat:
       path: "{{ local_certs_path }}/wazuh-certs-tool.sh"
     register: tool_package
-    when: ansible_os_family != 'Darwin' or ansible_os_family != 'Windows'
+    when: ansible_os_family == 'Darwin'
 
   - name: Local action | Download certificates generation tool
     get_url:
       url: "{{ certs_gen_tool_url }}"
       dest: "{{ local_certs_path }}/wazuh-certs-tool.sh"
-    when: not tool_package.stat.exists and ansible_os_family != 'Darwin' or ansible_os_family != 'Windows'
+    when: not (tool_package.stat.exists | default(1)) and ansible_os_family == 'Darwin'
 
   - name: Local action | Prepare the certificates generation template file
     template:
@@ -35,29 +35,23 @@
       dest: "{{ local_certs_path }}/config.yml"
       mode: 0644
     register: tlsconfig_template
-    when: ansible_os_family != 'Darwin' or ansible_os_family != 'Windows'
+    when: ansible_os_family == 'Darwin'
 
   - name: Local action | Generate the node & admin certificates in local
     command: >-
       bash {{ local_certs_path }}/wazuh-certs-tool.sh -A
-    when: ansible_os_family != 'Darwin' or ansible_os_family != 'Windows'
+    when: ansible_os_family == 'Darwin'
 
   - name: Local action | Check for Docker installation on macOS
     command: docker --version
     register: docker_check
-    when: os_family == 'Darwin'
-    ignore_errors: yes
-
-  - name: Local action | Check for Docker installation on Windows
-    win_shell: docker --version
-    register: docker_check
-    when: os_family == 'Windows'
+    when: ansible_os_family != 'Darwin'
     ignore_errors: yes
 
   - name: Local action | Fail if Docker is not installed
     fail:
       msg: "Docker is not installed on this host."
-    when: docker_check.rc != 0 and ansible_os_family == 'Darwin' or ansible_os_family == 'Windows'
+    when: (docker_check.rc | default(1)) != 0 and ansible_os_family != 'Darwin'
 
   - name: Local action | Run Docker container on macOS
     community.docker.docker_container:
@@ -68,24 +62,13 @@
       volumes:
         - "{{ local_certs_path }}/config.yml:/config/certs.yml"
         - "{{ local_certs_path }}/wazuh-certificates:/certificates/"
-    when: os_family == 'Darwin'
+    when: ansible_os_family != 'Darwin'
 
-  - name: Local action | Run Docker container on Windows
-    community.docker.docker_container:
-      name: wazuh-cert-tool
-      image: "wazuh/wazuh-cert-tool"
-      state: started
-      auto_remove: true
-      volumes:
-        - "C:/{{ local_certs_path }}/config.yml:/config/certs.yml"
-        - "{{ local_certs_path }}/wazuh-certificates:C:/certificates/"
-    when: os_family == 'Windows'
-
-  - name: Remove Docker image after execution
+  - name: Local action | Remove Docker image after execution
     community.docker.docker_image:
       name: "wazuh/wazuh-cert-tool"
       state: absent
-    when: os_family == 'Darwin' or os_family == 'Windows'
+    when: ansible_os_family != 'Darwin'
 
   run_once: true
   delegate_to: localhost

--- a/roles/wazuh/wazuh-indexer/tasks/local_actions.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/local_actions.yml
@@ -21,13 +21,12 @@
     stat:
       path: "{{ local_certs_path }}/wazuh-certs-tool.sh"
     register: tool_package
-    when: ansible_os_family != 'Darwin'
 
   - name: Local action | Download certificates generation tool
     get_url:
       url: "{{ certs_gen_tool_url }}"
       dest: "{{ local_certs_path }}/wazuh-certs-tool.sh"
-    when: not tool_package.stat.exists and ansible_os_family != 'Darwin'
+    when: not tool_package.stat.exists and not macos_localhost
 
   - name: Local action | Prepare the certificates generation template file
     template:
@@ -39,36 +38,36 @@
   - name: Local action | Generate the node & admin certificates in local
     command: >-
       bash {{ local_certs_path }}/wazuh-certs-tool.sh -A
-    when: ansible_os_family != 'Darwin'
+    when: not macos_localhost
 
   - name: Local action | Check for Docker installation on macOS
     command: docker --version
     register: docker_check
-    when: ansible_os_family == 'Darwin'
+    when: macos_localhost
     ignore_errors: yes
 
   - name: Local action | Fail if Docker is not installed
     fail:
       msg: "Docker is not installed on this host."
-    when: (docker_check.rc | default(1)) != 0 and ansible_os_family == 'Darwin'
+    when: (docker_check.rc | default(1)) != 0 and macos_localhost
 
   - name: Local action | Run Docker container on macOS
     community.docker.docker_container:
       name: wazuh-cert-tool
-      image: "wazuh/wazuh-cert-tool"
+      image: "{{ wazuh_certs_tool_docker }}"
       state: started
       auto_remove: true
       volumes:
         - "{{ local_certs_path }}/config.yml:/config/certs.yml"
         - "{{ local_certs_path }}/wazuh-certificates/:/certificates/"
-    when: ansible_os_family == 'Darwin'
+    when: macos_localhost
 
   - name: Local action | Remove Docker image after execution
     community.docker.docker_image:
-      name: "wazuh/wazuh-cert-tool"
+      name: "{{ wazuh_certs_tool_docker }}"
       state: absent
       force_absent: yes
-    when: ansible_os_family == 'Darwin'
+    when: macos_localhost
 
   run_once: true
   delegate_to: localhost


### PR DESCRIPTION
related: https://github.com/wazuh/wazuh-ansible/issues/1115

The necessary changes are made so that if it is run on an Ansible node with macOS, the certificates can be created with the Docker image that contains the Wazuh certificates tool


### Tests

Single node with variable in false: https://github.com/wazuh/wazuh-ansible/issues/1115#issuecomment-2196972337
Single node with variable in true: https://github.com/wazuh/wazuh-ansible/issues/1115#issuecomment-2197009711
Multi node with variable in false: https://github.com/wazuh/wazuh-ansible/issues/1115#issuecomment-2197115290
Multi node with variable in true: https://github.com/wazuh/wazuh-ansible/issues/1115#issuecomment-2197202569