### PR TITLE
Allow to override any template or file from calling playbook

### DIFF
--- a/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
+++ b/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
@@ -27,3 +27,5 @@ filebeatrepo:
   yum: 'https://packages.wazuh.com/5.x/yum/'
   gpg: 'https://packages.wazuh.com/key/GPG-KEY-WAZUH'
   path: '/tmp/WAZUH-GPG-KEY'
+
+filebeat_config_template: 'filebeat.yml.j2'

--- a/roles/wazuh/ansible-filebeat-oss/tasks/config.yml
+++ b/roles/wazuh/ansible-filebeat-oss/tasks/config.yml
@@ -2,7 +2,7 @@
 - block:
   - name: Copy Filebeat configuration.
     template:
-      src: filebeat.yml.j2
+      src: "{{ filebeat_config_template }}"
       dest: "/etc/filebeat/filebeat.yml"
       owner: root
       group: root

--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -374,3 +374,7 @@ wazuh_agent_config_defaults:
 
   labels: '{{ wazuh_agent_labels }}'
   enrollment: '{{ wazuh_agent_enrollment }}'
+
+wazuh_agent_ossec_configuration_template: 'var-ossec-etc-ossec-agent.conf.j2'
+wazuh_agent_ossec_local_internal_options_template: 'var-ossec-etc-local-internal-options.conf.j2'
+wazuh_agent_ossec_authdpass_template: 'authd_pass.j2'

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
@@ -219,7 +219,7 @@
 
 - name: Linux | Installing agent configuration (ossec.conf)
   template:
-    src: var-ossec-etc-ossec-agent.conf.j2
+    src: "{{ wazuh_agent_ossec_configuration_template }}"
     dest: "{{ wazuh_dir }}/etc/ossec.conf"
     owner: root
     group: wazuh
@@ -231,7 +231,7 @@
 
 - name: Linux | Installing local_internal_options.conf
   template:
-    src: var-ossec-etc-local-internal-options.conf.j2
+    src: "{{ wazuh_agent_ossec_local_internal_options_template }}"
     dest: "{{ wazuh_dir }}/etc/local_internal_options.conf"
     owner: root
     group: wazuh
@@ -243,7 +243,7 @@
 
 - name: Create auto-enrollment password file
   template:
-    src: authd_pass.j2
+    src: "{{ wazuh_agent_ossec_authdpass_template }}"
     dest: "{{ wazuh_dir }}/etc/authd.pass"
     owner: wazuh
     group: wazuh

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Windows.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Windows.yml
@@ -89,7 +89,7 @@
 
 - name: Windows | Installing agent configuration (ossec.conf)
   template: # noqa 208
-    src: var-ossec-etc-ossec-agent.conf.j2
+    src: "{{ wazuh_agent_ossec_configuration_template }}"
     dest: "{{ wazuh_agent_win_path }}ossec.conf"
   notify: Windows | Restart Wazuh Agent
   tags:
@@ -97,7 +97,7 @@
 
 - name: Windows | Installing local_internal_options.conf
   template:
-    src: var-ossec-etc-local-internal-options.conf.j2
+    src: "{{ wazuh_agent_ossec_local_internal_options_template }}"
     dest: "{{ wazuh_agent_win_path }}local_internal_options.conf"
   notify: Windows | Restart Wazuh Agent
   tags:

--- a/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml
@@ -189,7 +189,7 @@
 
 - name: macOS | Installing agent configuration (ossec.conf)
   template:
-    src: var-ossec-etc-ossec-agent.conf.j2
+    src: "{{ wazuh_agent_ossec_configuration_template }}"
     dest: "{{ wazuh_macos_config.install_dir }}/etc/ossec.conf"
     owner: root
     group: wazuh
@@ -201,7 +201,7 @@
 
 - name: macOS | Installing local_internal_options.conf
   template:
-    src: var-ossec-etc-local-internal-options.conf.j2
+    src: "{{ wazuh_agent_ossec_local_internal_options_template }}"
     dest: "{{ wazuh_macos_config.install_dir }}/etc/local_internal_options.conf"
     owner: root
     group: wazuh
@@ -213,7 +213,7 @@
 
 - name: Create auto-enrollment password file
   template:
-    src: authd_pass.j2
+    src: "{{ wazuh_agent_ossec_authdpass_template }}"
     dest: "{{ wazuh_macos_config.install_dir }}/etc/authd.pass"
     owner: wazuh
     group: wazuh

--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -464,3 +464,13 @@ wazuh_manager_config_defaults:
 #         format: 'eventchannel'
 #       - location: 'System'
 #         format: 'eventlog'
+
+wazuh_manager_ossec_local_rules_template: 'var-ossec-rules-local_rules.xml.j2'
+wazuh_manager_ossec_local_decoder_template: 'var-ossec-rules-local_decoder.xml.j2'
+wazuh_manager_ossec_shared_agent_template: 'var-ossec-etc-shared-agent.conf.j2'
+wazuh_manager_ossec_local_internal_options_template: 'var-ossec-etc-local-internal-options.conf.j2'
+wazuh_manager_ossec_server_template: 'var-ossec-etc-ossec-server.conf.j2'
+wazuh_manager_ossec_authdpass_template: 'authd_pass.j2'
+wazuh_manager_adminjson_template: 'admin.json.j2'
+wazuh_manager_agentless_template: 'agentless.j2'
+wazuh_manager_create_user_script_file: 'create_user.py'

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -133,7 +133,7 @@
     - config
 
 - name: Installing the local_rules.xml (default local_rules.xml)
-  template: src=var-ossec-rules-local_rules.xml.j2
+  template: src="{{ wazuh_manager_ossec_local_rules_template }}"
             dest="{{ wazuh_dir }}/etc/rules/local_rules.xml"
             owner=wazuh
             group=wazuh
@@ -157,7 +157,7 @@
     - rules
 
 - name: Installing the local_decoder.xml
-  template: src=var-ossec-rules-local_decoder.xml.j2
+  template: src="{{ wazuh_manager_ossec_local_decoder_template }}"
             dest="{{ wazuh_dir }}/etc/decoders/local_decoder.xml"
             owner=wazuh
             group=wazuh
@@ -182,7 +182,7 @@
 
 - name: Configure the shared-agent.conf
   template:
-    src: var-ossec-etc-shared-agent.conf.j2
+    src: "{{ wazuh_manager_ossec_shared_agent_template }}"
     dest: "{{ wazuh_dir }}/etc/shared/default/agent.conf"
     owner: wazuh
     group: wazuh
@@ -196,7 +196,7 @@
     - shared_agent_config is defined
 
 - name: Installing the local_internal_options.conf
-  template: src=var-ossec-etc-local-internal-options.conf.j2
+  template: src="{{ wazuh_manager_ossec_local_internal_options_template }}"
             dest="{{ wazuh_dir }}/etc/local_internal_options.conf"
             owner=root
             group=wazuh
@@ -279,7 +279,7 @@
 
 - name: Configure ossec.conf
   template:
-    src: var-ossec-etc-ossec-server.conf.j2
+    src: "{{ wazuh_manager_ossec_server_template }}"
     dest: "{{ wazuh_dir }}/etc/ossec.conf"
     owner: root
     group: wazuh
@@ -291,7 +291,7 @@
 
 - name: Ossec-authd password
   template:
-    src: authd_pass.j2
+    src: "{{ wazuh_manager_ossec_authdpass_template }}"
     dest: "{{ wazuh_dir }}/etc/authd.pass"
     owner: wazuh
     group: wazuh
@@ -308,7 +308,7 @@
   block:
     - name: Copy create_user script
       copy:
-        src: create_user.py
+        src: "{{ wazuh_manager_create_user_script_file }}"
         dest: "{{ wazuh_dir }}/framework/scripts/create_user.py"
         owner: root
         group: wazuh
@@ -316,7 +316,7 @@
 
     - name: Create admin.json
       template:
-        src: templates/admin.json.j2
+        src: "{{ wazuh_manager_adminjson_template }}"
         dest: "{{ wazuh_dir }}/api/configuration/admin.json"
         owner: wazuh
         group: wazuh
@@ -344,7 +344,7 @@
 
 - name: Agentless Hosts & Passwd
   template:
-    src: agentless.j2
+    src: "{{ wazuh_manager_agentless_template }}"
     dest: "{{ wazuh_dir }}/agentless/.passlist_tmp"
     owner: root
     group: root

--- a/roles/wazuh/wazuh-dashboard/defaults/main.yml
+++ b/roles/wazuh/wazuh-dashboard/defaults/main.yml
@@ -29,3 +29,6 @@ indexer_admin_password: changeme
 dashboard_user: kibanaserver
 dashboard_password: changeme
 local_certs_path: "{{ playbook_dir }}/indexer/certificates"
+
+wazuh_dashboard_configuration_template: 'opensearch_dashboards.yml.j2'
+wazuh_dashboard_wazuh_plugin_template: 'wazuh.yml.j2'

--- a/roles/wazuh/wazuh-dashboard/tasks/main.yml
+++ b/roles/wazuh/wazuh-dashboard/tasks/main.yml
@@ -27,7 +27,7 @@
 
 - name: Copy Configuration File
   template:
-    src: "templates/opensearch_dashboards.yml.j2"
+    src: "{{ wazuh_dashboard_configuration_template }}"
     dest: "{{ dashboard_conf_path }}/opensearch_dashboards.yml"
     group: wazuh-dashboard
     owner: wazuh-dashboard
@@ -75,7 +75,7 @@
 
 - name: Configure Wazuh Dashboard Plugin
   template:
-    src: wazuh.yml.j2
+    src: "{{ wazuh_dashboard_wazuh_plugin_template }}"
     dest: /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml
     owner: wazuh-dashboard
     group: wazuh-dashboard

--- a/roles/wazuh/wazuh-indexer/defaults/main.yml
+++ b/roles/wazuh/wazuh-indexer/defaults/main.yml
@@ -51,3 +51,8 @@ indexer_nolog_sensible: true
 
 # Docker image for certificates generation on macOS
 wazuh_certs_tool_docker: "wazuh/wazuh-cert-tool:{{ indexer_version }}"
+
+wazuh_indexer_internal_users_template: 'internal_users.yml.j2'
+wazuh_indexer_jvm_options_template: 'jvm.options.j2'
+wazuh_indexer_opensearch_config_template: 'opensearch.yml.j2'
+wazuh_indexer_certificates_generation_template: 'config.yml.j2'

--- a/roles/wazuh/wazuh-indexer/tasks/local_actions.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/local_actions.yml
@@ -30,7 +30,7 @@
 
   - name: Local action | Prepare the certificates generation template file
     template:
-      src: "templates/config.yml.j2"
+      src: "{{ wazuh_indexer_certificates_generation_template }}"
       dest: "{{ local_certs_path }}/config.yml"
       mode: 0644
     register: tlsconfig_template

--- a/roles/wazuh/wazuh-indexer/tasks/main.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/main.yml
@@ -41,7 +41,7 @@
 
     - name: Copy Opensearch Configuration File
       template:
-        src: "templates/opensearch.yml.j2"
+        src: "{{ wazuh_indexer_opensearch_config_template }}"
         dest: "{{ indexer_conf_path }}/opensearch.yml"
         owner: root
         group: wazuh-indexer
@@ -54,9 +54,9 @@
         - security
 
 
-    - name: Configure Wazuh indexer JVM memmory.
+    - name: Configure Wazuh indexer JVM memory.
       template:
-        src: "templates/jvm.options.j2"
+        src: "{{ wazuh_indexer_jvm_options_template }}"
         dest: "{{ indexer_conf_path }}/jvm.options"
         owner: root
         group: wazuh-indexer

--- a/roles/wazuh/wazuh-indexer/tasks/security_actions.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/security_actions.yml
@@ -40,7 +40,7 @@
 
 - name: Copy the Opensearch security internal users template
   template:
-    src: "templates/internal_users.yml.j2"
+    src: "{{ wazuh_indexer_internal_users_template }}"
     dest: "{{ indexer_sec_plugin_conf_path }}/internal_users.yml"
     mode: 0644
   run_once: true


### PR DESCRIPTION
Convert all `template` and `copy` sources to variables, so any configuration file be overrided from calling playbook to extend or make any adjustment the roles doesn't enable.

Fix #1336