### PR TITLE
Fix wazuh-single installation bugs in AL2023

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -1,17 +1,38 @@
 ---
 
 - name: "Install dependencies"
-  package:
-    name:
-      - unzip
-      - openssl
-      - tar
-      - curl
-    state: present
-  register: package_status
-  until: "package_status is not failed"  
-  retries: 10
-  delay: 10
+  block:
+    - name: "Install common dependencies"
+      package:
+        name:
+          - unzip
+          - openssl
+          - tar
+        state: present
+      register: package_status
+      until: "package_status is not failed"  
+      retries: 10
+      delay: 10
+
+    - name: "Install curl"
+      package:
+        name: curl
+        state: present
+      when: ansible_distribution != "Amazon" or (ansible_distribution == "Amazon" and ansible_distribution_version != "2023")
+      register: package_status
+      until: "package_status is not failed"  
+      retries: 10
+      delay: 10
+
+    - name: "Install curl minimal in AL2023"
+      package:
+        name: curl-minimal
+        state: present
+      when: ansible_distribution == "Amazon" and ansible_distribution_version == "2023"
+      register: package_status
+      until: "package_status is not failed"  
+      retries: 10
+      delay: 10
 
 - include_vars: ../../vars/repo_vars.yml
 

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -18,7 +18,7 @@
       package:
         name: curl
         state: present
-      when: ansible_distribution != "Amazon" or (ansible_distribution == "Amazon" and ansible_distribution_version != "2023")
+      when: ansible_distribution != "Amazon" and ansible_distribution_version != "2023"
       register: package_status
       until: "package_status is not failed"  
       retries: 10

--- a/roles/wazuh/wazuh-indexer/tasks/RedHat.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/RedHat.yml
@@ -12,12 +12,15 @@
 
 
 
-  - name: Amazon Linux | Install Amazon extras
+  - name: Amazon Linux | Configure system settings
     block:
-      - name: Install Amazon extras
+      - name: Install Amazon extras in Amazon Linux 2
         yum:
           name: amazon-linux-extras
           state: present
+        when: 
+          - ansible_distribution == 'Amazon'
+          - ansible_distribution_major_version == '2'
 
       - name: Configure vm.max_map_count
         lineinfile:


### PR DESCRIPTION
# Description

When installing an AIO from the `wazuh-single` playbook, there was a problem installing `amazon-linux-extras` in AL2023. For this, a new condition has been added so that it is only installed on AL2 and skips it for AL2023.

In addition, it was also trying to install `curl` on AL2023 while AL2023 already had `curl-minimal` installed, and getting an error when having a different version of curl already installed. For this, new tasks have been added for:
- Get common dependencies for all OS.
- Get curl for all non-AL2023 OS.
- Get curl-minimal for AL2023.

These changes fix bugs encountered during the execution of `wazuh-single` on AL2023.

## Tests

### Playbook execution

<details><summary>Deploy</summary>

```console
root@ip-172-31-35-66:/home/ubuntu/wazuh-ansible# sudo ansible-playbook playbooks/wazuh-single.yml

PLAY [aio] *******************************************************************************************************

TASK [Gathering Facts] *******************************************************************************************
[WARNING]: Platform linux on host 172.31.42.199 is using the discovered Python interpreter at /usr/bin/python3.9,
but future installation of another Python interpreter could change the meaning of that path. See
https://docs.ansible.com/ansible-core/2.16/reference_appendices/interpreter_discovery.html for more information.
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : include_vars] ***************************************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : include_vars] ***************************************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : include_vars] ***************************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : include_vars] ***************************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Check if certificates already exists] ***************************************
ok: [172.31.42.199 -> localhost]

TASK [../roles/wazuh/wazuh-indexer : Local action | Create local temporary directory for certificates generation] ***
changed: [172.31.42.199 -> localhost]

TASK [../roles/wazuh/wazuh-indexer : Local action | Check that the generation tool exists] ***********************
ok: [172.31.42.199 -> localhost]

TASK [../roles/wazuh/wazuh-indexer : Local action | Download certificates generation tool] ***********************
changed: [172.31.42.199 -> localhost]

TASK [../roles/wazuh/wazuh-indexer : Local action | Prepare the certificates generation template file] ***********
changed: [172.31.42.199 -> localhost]

TASK [../roles/wazuh/wazuh-indexer : Local action | Generate the node & admin certificates in local] *************
changed: [172.31.42.199 -> localhost]

TASK [../roles/wazuh/wazuh-indexer : RedHat/CentOS/Fedora | Add Wazuh indexer repo] ******************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Install Amazon extras in Amazon Linux 2] ************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Configure vm.max_map_count] *************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Update vm.max_map_count] ****************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : RedHat/CentOS/Fedora | Install Indexer dependencies] ************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Install Wazuh indexer] ******************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Update cache] ***************************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Install Wazuh indexer dependencies] *****************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Add apt repository signing key] *********************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Import Wazuh repository GPG key] ********************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Set permissions for Wazuh repository GPG key] *******************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Add Wazuh indexer repository] ***********************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Install Wazuh indexer] ******************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Remove performance analyzer plugin from Wazuh indexer] **********************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Remove Opensearch configuration file] ***************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Copy Opensearch Configuration File] *****************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : include_tasks] **************************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Configure Wazuh indexer JVM memmory.] ***************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Ensure extra time for Wazuh indexer to start on reboots] ********************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Index files to remove] ******************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Remove Index Files] *********************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Ensure Wazuh indexer started and enabled] ***********************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Wait for Wazuh indexer API] *************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Wait for Wazuh indexer API (Private IP)] ************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : RedHat/CentOS/Fedora | Remove Wazuh indexer repository (and clean up left-over metadata)] ***
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Reload systemd configuration] ***********************************************
skipping: [172.31.42.199]

PLAY [aio] *******************************************************************************************************

TASK [Gathering Facts] *******************************************************************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : include_vars] ***************************************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : include_vars] ***************************************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : include_vars] ***************************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : include_vars] ***************************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Check if certificates already exists] ***************************************
ok: [172.31.42.199 -> localhost]

TASK [../roles/wazuh/wazuh-indexer : Local action | Create local temporary directory for certificates generation] ***
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Local action | Check that the generation tool exists] ***********************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Local action | Download certificates generation tool] ***********************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Local action | Prepare the certificates generation template file] ***********
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Local action | Generate the node & admin certificates in local] *************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : RedHat/CentOS/Fedora | Add Wazuh indexer repo] ******************************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Install Amazon extras in Amazon Linux 2] ************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Configure vm.max_map_count] *************************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Update vm.max_map_count] ****************************************************
changed: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : RedHat/CentOS/Fedora | Install Indexer dependencies] ************************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Install Wazuh indexer] ******************************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Update cache] ***************************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Install Wazuh indexer dependencies] *****************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Add apt repository signing key] *********************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Import Wazuh repository GPG key] ********************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Set permissions for Wazuh repository GPG key] *******************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Add Wazuh indexer repository] ***********************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Install Wazuh indexer] ******************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Remove performance analyzer plugin from Wazuh indexer] **********************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Remove Opensearch configuration file] ***************************************
changed: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Copy Opensearch Configuration File] *****************************************
changed: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : include_tasks] **************************************************************
included: /home/ubuntu/wazuh-ansible/roles/wazuh/wazuh-indexer/tasks/security_actions.yml for 172.31.42.199

TASK [../roles/wazuh/wazuh-indexer : Configure IP (Private address)] *********************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Configure IP (Public address)] **********************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Ensure Indexer certificates directory permissions.] *************************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Copy the node & admin certificates to Wazuh indexer cluster] ****************
changed: [172.31.42.199] => (item=root-ca.pem)
changed: [172.31.42.199] => (item=root-ca.key)
changed: [172.31.42.199] => (item=node-1-key.pem)
changed: [172.31.42.199] => (item=node-1.pem)
changed: [172.31.42.199] => (item=admin-key.pem)
changed: [172.31.42.199] => (item=admin.pem)

TASK [../roles/wazuh/wazuh-indexer : Restart Wazuh indexer with security configuration] **************************
changed: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Copy the Opensearch security internal users template] ***********************
changed: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Hashing the custom admin password] ******************************************
changed: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Set the Admin user password] ************************************************
changed: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Hash the kibanaserver role/user pasword] ************************************
changed: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Set the kibanaserver user password] *****************************************
changed: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Initialize the Opensearch security index in Wazuh indexer] ******************
changed: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Create custom user] *********************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Configure Wazuh indexer JVM memmory.] ***************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Ensure extra time for Wazuh indexer to start on reboots] ********************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Index files to remove] ******************************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Remove Index Files] *********************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Ensure Wazuh indexer started and enabled] ***********************************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Wait for Wazuh indexer API] *************************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Wait for Wazuh indexer API (Private IP)] ************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : RedHat/CentOS/Fedora | Remove Wazuh indexer repository (and clean up left-over metadata)] ***
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-indexer : Reload systemd configuration] ***********************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Install common dependencies] ****************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Install curl] *******************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Install curl minimal in AL2023] *************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : include_vars] *******************************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : include_vars] *******************************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : include_vars] *******************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : include_vars] *******************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Overlay wazuh_manager_config on top of defaults] ********************
ok: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : include_tasks] ******************************************************
included: /home/ubuntu/wazuh-ansible/roles/wazuh/ansible-wazuh-manager/tasks/RedHat.yml for 172.31.42.199

TASK [../roles/wazuh/ansible-wazuh-manager : RedHat/CentOS 5 | Install Wazuh repo] *******************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : RedHat/CentOS/Fedora | Install Wazuh repo] **************************
ok: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : RedHat/CentOS/Fedora | Install openscap] ****************************
changed: [172.31.42.199] => (item=openscap-scanner)

TASK [../roles/wazuh/ansible-wazuh-manager : CentOS 6 | Install Software Collections (SCL) Repository] ***********
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : RedHat 6 | Enabling Red Hat Software Collections (RHSCL)] ***********
skipping: [172.31.42.199] => (item=rhui-REGION-rhel-server-rhscl)
skipping: [172.31.42.199] => (item=rhel-server-rhscl-6-rpms)
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : CentOS/RedHat 6 | Install Python 2.7] *******************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : RedHat/CentOS/Fedora | Install OpenJDK 1.8] *************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Set Distribution CIS filename for RHEL5/CentOS-5] *******************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Set Distribution CIS filename for RHEL6/CentOS-6] *******************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Set Distribution CIS filename for RHEL7/CentOS-7] *******************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Set Distribution CIS filename for RHEL7/CentOS-7 (Amazon)] **********
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : CentOS/RedHat/Amazon | Install wazuh-manager] ***********************
 changed: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : include_tasks] ******************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : CentOS/RedHat 6 | Enabling python2.7 and sqlite3] *******************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Install expect (EL5)] ***********************************************
skipping: [172.31.42.199] => (item=expect)
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : include_tasks] ******************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Generate the wazuh-keystore (username)] *****************************
changed: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Generate the wazuh-keystore (password)] *****************************
changed: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Install expect] *****************************************************
changed: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Generate SSL files for authd] ***************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Copy CA, SSL key and cert for authd] ********************************
skipping: [172.31.42.199] => (item=)
skipping: [172.31.42.199] => (item=sslmanager.cert)
skipping: [172.31.42.199] => (item=sslmanager.key)
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Verifying for old init authd service] *******************************
ok: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Verifying for old systemd authd service] ****************************
ok: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Ensure ossec-authd service is disabled] *****************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Removing old init authd services] ***********************************
skipping: [172.31.42.199] => (item=/etc/init.d/ossec-authd)
skipping: [172.31.42.199] => (item=/lib/systemd/system/ossec-authd.service)
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Installing the local_rules.xml (default local_rules.xml)] ***********
changed: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Adding local rules files] *******************************************
changed: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Installing the local_decoder.xml] ***********************************
changed: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Adding local decoders files] ****************************************
changed: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Configure the shared-agent.conf] ************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Installing the local_internal_options.conf] *************************
changed: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Retrieving Agentless Credentials] ***********************************
ok: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Retrieving authd Credentials] ***************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Check if syslog output is enabled] **********************************
skipping: [172.31.42.199] => (item={'server': None, 'port': None, 'format': None})
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Check if client-syslog is enabled] **********************************
ok: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Enable client-syslog] ***********************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Check if ossec-agentlessd is enabled] *******************************
ok: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Enable ossec-agentlessd] ********************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Checking alert log output settings] *********************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Configure ossec.conf] ***********************************************
changed: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Ossec-authd password] ***********************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Copy create_user script] ********************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Create admin.json] **************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Execute create_user script] *****************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Delete create_user script] ******************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Agentless Hosts & Passwd] *******************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Encode the secret] **************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Ensure Wazuh Manager service is started and enabled.] ***************
changed: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Create agent groups] ************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : Run uninstall tasks] ************************************************
included: /home/ubuntu/wazuh-ansible/roles/wazuh/ansible-wazuh-manager/tasks/uninstall.yml for 172.31.42.199

TASK [../roles/wazuh/ansible-wazuh-manager : Debian/Ubuntu | Remove Wazuh repository.] ***************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-wazuh-manager : RedHat/CentOS/Fedora | Remove Wazuh repository (and clean up left-over metadata)] ***
ok: [172.31.42.199]

TASK [../roles/wazuh/ansible-filebeat-oss : include_vars] ********************************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/ansible-filebeat-oss : include_vars] ********************************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/ansible-filebeat-oss : include_vars] ********************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-filebeat-oss : include_tasks] *******************************************************
included: /home/ubuntu/wazuh-ansible/roles/wazuh/ansible-filebeat-oss/tasks/RedHat.yml for 172.31.42.199

TASK [../roles/wazuh/ansible-filebeat-oss : RedHat/CentOS/Fedora/Amazon Linux | Install Filebeats repo] **********
ok: [172.31.42.199]

TASK [../roles/wazuh/ansible-filebeat-oss : include_tasks] *******************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-filebeat-oss : Install Filebeat | Redhat] *******************************************
changed: [172.31.42.199]

TASK [../roles/wazuh/ansible-filebeat-oss : Install Filebeat | Debian] *******************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/ansible-filebeat-oss : Checking if Filebeat Module folder file exists] **********************
ok: [172.31.42.199]

TASK [../roles/wazuh/ansible-filebeat-oss : Download Filebeat module package] ************************************
changed: [172.31.42.199]

TASK [../roles/wazuh/ansible-filebeat-oss : Unpack Filebeat module package] **************************************
changed: [172.31.42.199]

TASK [../roles/wazuh/ansible-filebeat-oss : Setting 0755 permission for Filebeat module folder] ******************
changed: [172.31.42.199]

TASK [../roles/wazuh/ansible-filebeat-oss : Checking if Filebeat Module package file exists] *********************
ok: [172.31.42.199]

TASK [../roles/wazuh/ansible-filebeat-oss : Delete Filebeat module package file] *********************************
changed: [172.31.42.199]

TASK [../roles/wazuh/ansible-filebeat-oss : Copy Filebeat configuration.] ****************************************
changed: [172.31.42.199]

TASK [../roles/wazuh/ansible-filebeat-oss : Fetch latest Wazuh alerts template] **********************************
changed: [172.31.42.199]

TASK [../roles/wazuh/ansible-filebeat-oss : include_tasks] *******************************************************
included: /home/ubuntu/wazuh-ansible/roles/wazuh/ansible-filebeat-oss/tasks/security_actions.yml for 172.31.42.199

TASK [../roles/wazuh/ansible-filebeat-oss : Ensure Filebeat SSL key pair directory exists.] **********************
changed: [172.31.42.199]

TASK [../roles/wazuh/ansible-filebeat-oss : Copy the certificates from local to the Manager instance] ************
changed: [172.31.42.199] => (item=node-1-key.pem)
changed: [172.31.42.199] => (item=node-1.pem)
changed: [172.31.42.199] => (item=root-ca.pem)

TASK [../roles/wazuh/ansible-filebeat-oss : Ensure Filebeat is started and enabled at boot.] *********************
changed: [172.31.42.199]

TASK [../roles/wazuh/ansible-filebeat-oss : include_tasks] *******************************************************
included: /home/ubuntu/wazuh-ansible/roles/wazuh/ansible-filebeat-oss/tasks/RMRedHat.yml for 172.31.42.199

TASK [../roles/wazuh/ansible-filebeat-oss : RedHat/CentOS/Fedora | Remove Filebeat repository (and clean up left-over metadata)] ***
ok: [172.31.42.199]

TASK [../roles/wazuh/ansible-filebeat-oss : include_tasks] *******************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-dashboard : include_vars] *************************************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-dashboard : include_vars] *************************************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-dashboard : include_vars] *************************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-dashboard : include_vars] *************************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-dashboard : RedHat/CentOS/Fedora | Add Wazuh dashboard repo] **************************
changed: [172.31.42.199]

TASK [../roles/wazuh/wazuh-dashboard : Install Wazuh dashboard] **************************************************
changed: [172.31.42.199]

TASK [../roles/wazuh/wazuh-dashboard : include_vars] *************************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-dashboard : Download apt repository signing key] **************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-dashboard : Import Wazuh repository GPG key] ******************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-dashboard : Set permissions for Wazuh repository GPG key] *****************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-dashboard : Debian systems | Add Wazuh dashboard repo] ********************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-dashboard : Install Wazuh dashboard] **************************************************
skipping: [172.31.42.199]

TASK [../roles/wazuh/wazuh-dashboard : Remove Dashboard configuration file] **************************************
changed: [172.31.42.199]

TASK [../roles/wazuh/wazuh-dashboard : Ensure Dashboard certificates directory permissions.] *********************
changed: [172.31.42.199]

TASK [../roles/wazuh/wazuh-dashboard : Copy the certificates from local to the Wazuh dashboard instance] *********
changed: [172.31.42.199] => (item=root-ca.pem)
changed: [172.31.42.199] => (item=node-1-key.pem)
changed: [172.31.42.199] => (item=node-1.pem)

TASK [../roles/wazuh/wazuh-dashboard : Copy Configuration File] **************************************************
changed: [172.31.42.199]

TASK [../roles/wazuh/wazuh-dashboard : Ensuring Wazuh dashboard directory owner] *********************************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-dashboard : Wait for Wazuh-Indexer port] **********************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-dashboard : Select correct API protocol] **********************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-dashboard : Attempting to delete legacy Wazuh index if exists] ************************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-dashboard : Create Wazuh Plugin config directory] *************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-dashboard : Configure Wazuh Dashboard Plugin] *****************************************
ok: [172.31.42.199]

TASK [../roles/wazuh/wazuh-dashboard : Configure opensearch.password in opensearch_dashboards.keystore] **********
changed: [172.31.42.199]

TASK [../roles/wazuh/wazuh-dashboard : Ensure Wazuh dashboard started and enabled] *******************************
changed: [172.31.42.199]

TASK [../roles/wazuh/wazuh-dashboard : Remove Wazuh dashboard repository (and clean up left-over metadata)] ******
ok: [172.31.42.199]

RUNNING HANDLER [../roles/wazuh/ansible-wazuh-manager : restart wazuh-manager] ***********************************
changed: [172.31.42.199]

RUNNING HANDLER [../roles/wazuh/ansible-filebeat-oss : restart filebeat] *****************************************
changed: [172.31.42.199]

RUNNING HANDLER [../roles/wazuh/wazuh-dashboard : restart wazuh-dashboard] ***************************************
changed: [172.31.42.199]

PLAY RECAP *******************************************************************************************************
172.31.42.199              : ok=105  changed=48   unreachable=0    failed=0    skipped=93   rescued=0    ignored=0
```

</details>

### Status validation

<details><summary>Manager status</summary>

```console
[root@ip-172-31-42-199 ec2-user]# systemctl status wazuh-manager
● wazuh-manager.service - Wazuh manager
     Loaded: loaded (/usr/lib/systemd/system/wazuh-manager.service; enabled; preset: disabled)
     Active: active (running) since Tue 2024-07-09 09:19:48 UTC; 3min 53s ago
    Process: 46706 ExecStart=/usr/bin/env /var/ossec/bin/wazuh-control start (code=exited, status=0/SUCCESS)
      Tasks: 153 (limit: 9375)
     Memory: 1.1G
        CPU: 1min 30.421s
     CGroup: /system.slice/wazuh-manager.service
             ├─46769 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
             ├─46770 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
             ├─46773 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
             ├─46776 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
             ├─46820 /var/ossec/bin/wazuh-authd
             ├─46837 /var/ossec/bin/wazuh-db
             ├─46862 /var/ossec/bin/wazuh-execd
             ├─46878 /var/ossec/bin/wazuh-analysisd
             ├─46892 /var/ossec/bin/wazuh-syscheckd
             ├─46939 /var/ossec/bin/wazuh-remoted
             ├─46974 /var/ossec/bin/wazuh-logcollector
             ├─46994 /var/ossec/bin/wazuh-monitord
             └─47015 /var/ossec/bin/wazuh-modulesd

Jul 09 09:19:40 ip-172-31-42-199.ec2.internal env[46706]: Started wazuh-analysisd...
Jul 09 09:19:41 ip-172-31-42-199.ec2.internal env[46706]: Started wazuh-syscheckd...
Jul 09 09:19:43 ip-172-31-42-199.ec2.internal env[46706]: Started wazuh-remoted...
Jul 09 09:19:44 ip-172-31-42-199.ec2.internal env[46706]: Started wazuh-logcollector...
Jul 09 09:19:45 ip-172-31-42-199.ec2.internal env[46706]: Started wazuh-monitord...
Jul 09 09:19:45 ip-172-31-42-199.ec2.internal env[47012]: 2024/07/09 09:19:45 wazuh-modulesd:router: INFO: Loaded>
Jul 09 09:19:45 ip-172-31-42-199.ec2.internal env[47012]: 2024/07/09 09:19:45 wazuh-modulesd:content_manager: INF>
Jul 09 09:19:46 ip-172-31-42-199.ec2.internal env[46706]: Started wazuh-modulesd...
Jul 09 09:19:48 ip-172-31-42-199.ec2.internal env[46706]: Completed.
Jul 09 09:19:48 ip-172-31-42-199.ec2.internal systemd[1]: Started wazuh-manager.service - Wazuh manager.
```

</details>

<details><summary>Indexer status</summary>

```console
[root@ip-172-31-42-199 ec2-user]# systemctl status wazuh-indexer
● wazuh-indexer.service - wazuh-indexer
     Loaded: loaded (/usr/lib/systemd/system/wazuh-indexer.service; enabled; preset: disabled)
     Active: active (running) since Tue 2024-07-09 09:11:01 UTC; 12min ago
       Docs: https://documentation.wazuh.com
   Main PID: 10492 (java)
      Tasks: 64 (limit: 9375)
     Memory: 4.2G
        CPU: 1min 19.236s
     CGroup: /system.slice/wazuh-indexer.service
             └─10492 /usr/share/wazuh-indexer/jdk/bin/java -Xshare:auto -Dopensearch.networkaddress.cache.ttl=60 >

Jul 09 09:10:41 ip-172-31-42-199.ec2.internal systemd-entrypoint[10492]: WARNING: System::setSecurityManager has >
Jul 09 09:10:41 ip-172-31-42-199.ec2.internal systemd-entrypoint[10492]: WARNING: Please consider reporting this >
Jul 09 09:10:41 ip-172-31-42-199.ec2.internal systemd-entrypoint[10492]: WARNING: System::setSecurityManager will>
Jul 09 09:10:42 ip-172-31-42-199.ec2.internal systemd-entrypoint[10492]: Jul 09, 2024 9:10:42 AM sun.util.locale.>
Jul 09 09:10:42 ip-172-31-42-199.ec2.internal systemd-entrypoint[10492]: WARNING: COMPAT locale provider will be >
Jul 09 09:10:43 ip-172-31-42-199.ec2.internal systemd-entrypoint[10492]: WARNING: A terminally deprecated method >
Jul 09 09:10:43 ip-172-31-42-199.ec2.internal systemd-entrypoint[10492]: WARNING: System::setSecurityManager has >
Jul 09 09:10:43 ip-172-31-42-199.ec2.internal systemd-entrypoint[10492]: WARNING: Please consider reporting this >
Jul 09 09:10:43 ip-172-31-42-199.ec2.internal systemd-entrypoint[10492]: WARNING: System::setSecurityManager will>
Jul 09 09:11:01 ip-172-31-42-199.ec2.internal systemd[1]: Started wazuh-indexer.service - wazuh-indexer.
```

</details>

<details><summary>Dashboard status</summary>

```console
[root@ip-172-31-42-199 ec2-user]# systemctl status wazuh-dashboard
● wazuh-dashboard.service - wazuh-dashboard
     Loaded: loaded (/etc/systemd/system/wazuh-dashboard.service; enabled; preset: disabled)
     Active: active (running) since Tue 2024-07-09 09:19:51 UTC; 4min 3s ago
   Main PID: 47776 (node)
      Tasks: 11 (limit: 9375)
     Memory: 212.4M
        CPU: 15.966s
     CGroup: /system.slice/wazuh-dashboard.service
             └─47776 /usr/share/wazuh-dashboard/node/bin/node /usr/share/wazuh-dashboard/src/cli/dist -c /etc/waz>
```

</details>

<details><summary>Filebeat output</summary>

```console
[root@ip-172-31-42-199 ec2-user]# filebeat test output
elasticsearch: https://127.0.0.1:9200...
  parse url... OK
  connection...
    parse host... OK
    dns lookup... OK
    addresses: 127.0.0.1
    dial up... OK
  TLS...
    security: server's certificate chain verification is enabled
    handshake... OK
    TLS version: TLSv1.3
    dial up... OK
  talk to server... OK
  version: 7.10.2
```

</details>

### Dashboard connection

![Captura de pantalla 2024-07-09 a las 11 23 18](https://github.com/wazuh/wazuh-ansible/assets/74021522/c1b460d9-27f5-411e-8ddb-8ff48b345300)
