### PR TITLE
Fix 'Wazuh cluster' nodes deployment issue for wazuh-production-ready.yml

### DIFF
--- a/playbooks/wazuh-production-ready.yml
+++ b/playbooks/wazuh-production-ready.yml
@@ -102,6 +102,7 @@
       become: yes
       become_user: root
       vars:
+        filebeat_node_name: node-4
         wazuh_manager_config:
           connection:
               - type: 'secure'
@@ -134,6 +135,7 @@
       become: yes
       become_user: root
       vars:
+        filebeat_node_name: node-5
         wazuh_manager_config:
           connection:
               - type: 'secure'


### PR DESCRIPTION
Make 'filebeat_node_name' as a variable for 'hosts: manager' and 'hosts: worker' in wazuh-production-ready.yml,  which overwrites fixed vaule 'filebeat_node_name: node-1'  in roles/wazuh/ansible-wazuh-manager/defaults/main.yml and 'roles/wazuh/ansible-filebeat-oss/defaults/main.yml'.