### PR TITLE
Add the possibility to set options in the agents internal configuration

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/README.md
+++ b/roles/wazuh/ansible-wazuh-agent/README.md
@@ -21,6 +21,7 @@ Role Variables
 
 * `wazuh_managers`: Collection of Wazuh Managers' IP address, port, and protocol used by the agent
 * `wazuh_agent_authd`: Collection with the settings to register an agent using authd.
+* `wazuh_agent_local_options`: Optional dictionary of settings to be configured in the local_internal_options.conf file.
 
 Playbook example
 ----------------
@@ -44,6 +45,9 @@ The following is an example of how this role can be used:
            port: 1515
            ssl_agent_ca: null
            ssl_auto_negotiate: 'no'
+         wazuh_agent_local_options:
+           logcollector.remote_commands: '0'
+           wazuh_command.remote_commands: '1'
 
 
 License and copyright

--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -374,3 +374,8 @@ wazuh_agent_config_defaults:
 
   labels: '{{ wazuh_agent_labels }}'
   enrollment: '{{ wazuh_agent_enrollment }}'
+
+# additional configuration options for the internal_options.conf file
+wazuh_agent_local_options: {}
+wazuh_agent_local_options_defaults:
+  'logcollector.remote_commands': '1'

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
@@ -236,6 +236,8 @@
     owner: root
     group: wazuh
     mode: 0640
+  vars:
+    local_internal_options: '{{ wazuh_agent_local_options_defaults | combine(wazuh_agent_local_options) }}'
   notify: restart wazuh-agent
   tags:
     - init

--- a/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-local-internal-options.conf.j2
+++ b/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-local-internal-options.conf.j2
@@ -12,5 +12,6 @@
 # In this file you could include the configuration settings for your agents
 
 # Logcollector - If it should accept remote commands from the manager
-logcollector.remote_commands=1
-
+{% for _option in local_internal_options %}
+{{ _option }}={{ local_internal_options[_option] }}
+{% endfor %}


### PR DESCRIPTION
Add a new dictionary to set options to be included in the local-internal-options.conf file
Fixes #1365 