### PR TITLE
Fixed API deployment issue for wazuh-single.yml default config

### DIFF
--- a/roles/wazuh/wazuh-dashboard/defaults/main.yml
+++ b/roles/wazuh/wazuh-dashboard/defaults/main.yml
@@ -18,7 +18,7 @@ dashboard_version: "4.9.1"
 # API credentials
 wazuh_api_credentials:
   - id: "default"
-    url: "https://localhost"
+    url: "https://127.0.0.1"
     port: 55000
     username: "wazuh"
     password: "wazuh"


### PR DESCRIPTION
This pull request will resolve a deployment issue for wazuh single that would prevent the api being reachable. The fix is to use the localhost ip `127.0.0.1` instead of the `localhost` alias.