### PR TITLE
Add retries to the Create Custom User ansible task

### DIFF
--- a/roles/wazuh/wazuh-indexer/tasks/security_actions.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/security_actions.yml
@@ -112,8 +112,8 @@
     status_code: 200,201,401
     return_content: yes
     timeout: 4
+  register: result
+  until: result.status in [200,201,401]
   when:
     - indexer_custom_user is defined and indexer_custom_user
     - inventory_hostname == ansible_play_hosts[0]
-
-


### PR DESCRIPTION
### Description
This PR merges an enhancement that allows the `Create custom user task` to retry in case of failure

Further details can be found in the related issue: https://github.com/wazuh/wazuh-automation/issues/1843