### PR TITLE
support multiple users

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -326,10 +326,8 @@
     - name: Execute create_user script
       script:
         chdir: "{{ wazuh_dir }}/framework/scripts/"
-        cmd: create_user.py --username "{{ item.username }}" --password "{{ item.password }}"
+        cmd: create_user.py
         executable: "{{ wazuh_dir }}/framework/python/bin/python3"
-      with_items:
-        - "{{ wazuh_api_users }}"
 
     - name: Delete create_user script
       file:

--- a/roles/wazuh/ansible-wazuh-manager/templates/admin.json.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/admin.json.j2
@@ -1,4 +1,5 @@
-
-{% for api in wazuh_api_users %}
-{"username":"{{ api['username'] }}", "password": "{{ api['password'] }}"}
-{% endfor %}
+[
+    {% for api in wazuh_api_users %}
+    {"username":"{{ api['username'] }}", "password": "{{ api['password'] }}"}{% if not loop.last %},{% endif %}
+    {% endfor %}
+]


### PR DESCRIPTION
roles/wazuh/ansible-wazuh-manager/templates/admin.json.j2
Template does not support multiple users despite the variable wazuh_api_users being able to support multiple entries.
Change: List + valid json by adding ',' between each object in list

roles/wazuh/ansible-wazuh-manager/tasks/main.yml
Definition of the task "Execute create_user script" is misleading as create_user.py does not read the command line parameters.
Change: Removed unused command line parameters + loop of items. Conditional when: is still present

roles/wazuh/ansible-wazuh-manager/files/create_user.py
Only supports one username and password when reading from admin.json file
Change: Loops through the users within defined in admin.json 