### PR TITLE
Fix incorrect directory creation in the single node Ansible workflow

### DIFF
--- a/roles/wazuh/ansible-filebeat-oss/tasks/main.yml
+++ b/roles/wazuh/ansible-filebeat-oss/tasks/main.yml
@@ -39,24 +39,24 @@
 - name: Checking if Filebeat Module folder file exists
   stat:
     path: "{{ filebeat_module_folder }}"
-  register: filebeat_module_folder
+  register: filebeat_module_folder_info
 
 - name: Download Filebeat module package
   get_url:
     url: "{{ filebeat_module_package_url }}/{{ filebeat_module_package_name }}"
     dest: "{{ filebeat_module_package_path }}"
-  when: not filebeat_module_folder.stat.exists
+  when: not filebeat_module_folder_info.stat.exists
 
 - name: Unpack Filebeat module package
   unarchive:
     src: "{{ filebeat_module_package_path }}/{{ filebeat_module_package_name }}"
     dest: "{{ filebeat_module_destination }}"
     remote_src: yes
-  when: not filebeat_module_folder.stat.exists
+  when: not filebeat_module_folder_info.stat.exists
 
 - name: Setting 0755 permission for Filebeat module folder
   file: dest={{ filebeat_module_folder }} mode=u=rwX,g=rwX,o=rwX recurse=yes
-  when: not filebeat_module_folder.stat.exists
+  when: not filebeat_module_folder_info.stat.exists
 
 - name: Checking if Filebeat Module package file exists
   stat:


### PR DESCRIPTION
### Description

This PR merges the changes for fixing the incorrect directory creation in the single-node deployment
Related issue: https://github.com/wazuh/wazuh-ansible/issues/1376