### PR TITLE
Fix Ansible filebeat_node_name variable assignment in the production-ready playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,10 +204,10 @@ The hereunder example playbook uses the `wazuh-ansible` role to provision a prod
       roles:
         - role: "../roles/wazuh/ansible-wazuh-manager"
         - role: "../roles/wazuh/ansible-filebeat-oss"
-          filebeat_node_name: node-4
       become: yes
       become_user: root
       vars:
+        filebeat_node_name: node-4
         wazuh_manager_config:
           connection:
               - type: 'secure'
@@ -236,10 +236,10 @@ The hereunder example playbook uses the `wazuh-ansible` role to provision a prod
       roles:
         - role: "../roles/wazuh/ansible-wazuh-manager"
         - role: "../roles/wazuh/ansible-filebeat-oss"
-          filebeat_node_name: node-5
       become: yes
       become_user: root
       vars:
+        filebeat_node_name: node-5
         wazuh_manager_config:
           connection:
               - type: 'secure'

--- a/playbooks/wazuh-production-ready.yml
+++ b/playbooks/wazuh-production-ready.yml
@@ -98,10 +98,10 @@
       roles:
         - role: "../roles/wazuh/ansible-wazuh-manager"
         - role: "../roles/wazuh/ansible-filebeat-oss"
-          filebeat_node_name: node-4
       become: yes
       become_user: root
       vars:
+        filebeat_node_name: node-4
         wazuh_manager_config:
           connection:
               - type: 'secure'
@@ -130,10 +130,10 @@
       roles:
         - role: "../roles/wazuh/ansible-wazuh-manager"
         - role: "../roles/wazuh/ansible-filebeat-oss"
-          filebeat_node_name: node-5
       become: yes
       become_user: root
       vars:
+        filebeat_node_name: node-5
         wazuh_manager_config:
           connection:
               - type: 'secure'


### PR DESCRIPTION
# Description

This PR merges several changes to fix the `filebeat_node_name` variable assignment, in the distributed and production ready playbook `playbooks/wazuh-production-ready.yml`

More information can be found in the related issue: https://github.com/wazuh/wazuh-ansible/issues/1384