### PR TITLE
Fix cert gen tool version variable assignment

### DIFF
--- a/roles/wazuh/vars/repo.yml
+++ b/roles/wazuh/vars/repo.yml
@@ -14,7 +14,7 @@ wazuh_macos_arm_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.arm64.pkg
 wazuh_macos_intel_package_url: "https://packages.wazuh.com/4.x/macos/{{ wazuh_macos_intel_package_name }}"
 wazuh_macos_arm_package_url: "https://packages.wazuh.com/4.x/macos/{{ wazuh_macos_arm_package_name }}"
 
-certs_gen_tool_version: 4.10
+certs_gen_tool_version: "4.10"
 
 # Url of certificates generator tool
 certs_gen_tool_url: "https://packages.wazuh.com/{{ certs_gen_tool_version }}/wazuh-certs-tool.sh"

--- a/roles/wazuh/vars/repo_pre-release.yml
+++ b/roles/wazuh/vars/repo_pre-release.yml
@@ -14,7 +14,7 @@ wazuh_macos_arm_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.arm64.pkg
 wazuh_macos_intel_package_url: "https://packages-dev.wazuh.com/pre-release/{{ wazuh_macos_intel_package_name }}"
 wazuh_macos_arm_package_url: "https://packages-dev.wazuh.com/pre-release/macos/{{ wazuh_macos_arm_package_name }}"
 
-certs_gen_tool_version: 4.10
+certs_gen_tool_version: "4.10"
 
 # Url of certificates generator tool
 certs_gen_tool_url: "https://packages-dev.wazuh.com/{{ certs_gen_tool_version }}/wazuh-certs-tool.sh"

--- a/roles/wazuh/vars/repo_staging.yml
+++ b/roles/wazuh/vars/repo_staging.yml
@@ -15,7 +15,7 @@ wazuh_macos_arm_package_name: "wazuh-agent-{{ wazuh_agent_version }}-1.arm64.pkg
 wazuh_macos_intel_package_url: "https://packages-dev.wazuh.com/staging/macos/{{ wazuh_macos_intel_package_name }}"
 wazuh_macos_arm_package_url: "https://packages-dev.wazuh.com/staging/macos/{{ wazuh_macos_arm_package_name }}"
 
-certs_gen_tool_version: 4.10
+certs_gen_tool_version: "4.10"
 
 # Url of certificates generator tool
 certs_gen_tool_url: "https://packages-dev.wazuh.com/{{ certs_gen_tool_version }}/wazuh-certs-tool.sh"


### PR DESCRIPTION
# Description

This PR merges a few changes to avoid mishandling of the `certs_gen_tool_version` variable across multiple files.
More information can be found in the related issue: https://github.com/wazuh/wazuh-automation/issues/1913