### PR TITLE
Use ansible_facts to reference facts

### DIFF
--- a/.github/playbooks/single-wazuh.yml
+++ b/.github/playbooks/single-wazuh.yml
@@ -34,4 +34,4 @@
           - gpg-agent
         state: present
         update_cache: yes
-      when: ansible_distribution == "Ubuntu"
+      when: ansible_facts.distribution == "Ubuntu"

--- a/roles/wazuh/ansible-filebeat-oss/tasks/main.yml
+++ b/roles/wazuh/ansible-filebeat-oss/tasks/main.yml
@@ -8,10 +8,10 @@
   when: packages_repository == 'pre-release'
 
 - include_tasks: RedHat.yml
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts.os_family == 'RedHat'
 
 - include_tasks: Debian.yml
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts.os_family == 'Debian'
 
 - name: Install Filebeat | Redhat
   yum:
@@ -21,7 +21,7 @@
   tags:
   - install
   - init
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts.os_family == 'RedHat'
 
 - name: Install Filebeat | Debian
   apt:
@@ -34,7 +34,7 @@
   until: "install is not failed"  
   retries: 10
   delay: 10
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts.os_family == 'Debian'
 
 - name: Checking if Filebeat Module folder file exists
   stat:
@@ -83,7 +83,7 @@
     enabled: true
 
 - include_tasks: "RMRedHat.yml"
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts.os_family == "RedHat"
 
 - include_tasks: "RMDebian.yml"
-  when: ansible_os_family == "Debian"
+  when: ansible_facts.os_family == "Debian"

--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -50,7 +50,7 @@ wazuh_agent_config_overlay: yes
 
 # This is a middle ground between breaking existing uses of wazuh_agent_nat
 # and allow working with agents having several network interfaces
-wazuh_agent_address: '{{ "any" if wazuh_agent_nat else ansible_default_ipv4.address }}'
+wazuh_agent_address: '{{ "any" if wazuh_agent_nat else ansible_facts.default_ipv4.address }}'
 
 # List of managers. The first one with register variable declared *and* set to true
 # is the one used to register the agent. Otherwise, the first one in the list will be used.

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
@@ -22,7 +22,7 @@
     state: present
   register: wazuh_agent_ca_package_install
   until: wazuh_agent_ca_package_install is succeeded
-  when: not (ansible_distribution == "Debian" and ansible_distribution_major_version in ['11'])
+  when: not (ansible_facts.distribution == "Debian" and ansible_facts.distribution_major_version in ['11'])
 
 - name: Debian/Ubuntu | Installing Wazuh repository key (Ubuntu 14)
   become: true
@@ -34,8 +34,8 @@
     executable: /bin/bash
   changed_when: false
   when:
-    - ansible_distribution == "Ubuntu"
-    - ansible_distribution_major_version | int == 14
+    - ansible_facts.distribution == "Ubuntu"
+    - ansible_facts.distribution_major_version | int == 14
     - not wazuh_custom_packages_installation_agent_enabled
 
 - name: Debian/Ubuntu | Download Wazuh repository key
@@ -43,13 +43,13 @@
     url: "{{ wazuh_agent_config.repo.gpg }}"
     dest: "{{ wazuh_agent_config.repo.path }}"
   when:
-    - not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int == 14)
+    - not (ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int == 14)
     - not wazuh_custom_packages_installation_agent_enabled
 
 - name: Debian/Ubuntu | Import Wazuh GPG key
   command: "gpg --no-default-keyring --keyring gnupg-ring:{{ wazuh_agent_config.repo.keyring_path }} --import {{ wazuh_agent_config.repo.path }}"
   when:
-    - not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int == 14)
+    - not (ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int == 14)
     - not wazuh_custom_packages_installation_agent_enabled
   args:
     creates: "{{ wazuh_agent_config.repo.keyring_path }}"
@@ -59,7 +59,7 @@
     path: "{{ wazuh_agent_config.repo.keyring_path }}"
     mode: '0644'
   when:
-    - not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int == 14)
+    - not (ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int == 14)
     - not wazuh_custom_packages_installation_agent_enabled
 
 - name: Debian/Ubuntu | Add Wazuh repositories
@@ -74,7 +74,7 @@
 - name: Debian/Ubuntu | Set Distribution CIS filename for debian
   set_fact:
     cis_distribution_filename: cis_debian_linux_rcl.txt
-  when: ansible_os_family == "Debian"
+  when: ansible_facts.os_family == "Debian"
 
 - name: Debian/Ubuntu | Install OpenJDK-8 repo
   apt_repository:
@@ -82,7 +82,7 @@
     state: present
     update_cache: true
   when:
-    - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int == 14)
+    - (ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int == 14)
 
 - when:
     - wazuh_agent_config.cis_cat.disable == 'no'

--- a/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
@@ -1,9 +1,9 @@
 ---
 - include_tasks: "RedHat.yml"
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts.os_family == "RedHat"
 
 - include_tasks: "Debian.yml"
-  when: ansible_os_family == "Debian"
+  when: ansible_facts.os_family == "Debian"
 
 - include_tasks: "installation_from_custom_packages.yml"
   when:
@@ -15,7 +15,7 @@
     state: present
     lock_timeout: '{{ wazuh_agent_yum_lock_timeout }}'
   when:
-    - ansible_os_family|lower == "redhat"
+    - ansible_facts.os_family|lower == "redhat"
     - not wazuh_custom_packages_installation_agent_enabled
   tags:
     - init
@@ -26,9 +26,9 @@
     state: present
     cache_valid_time: 3600
   when:
-    - ansible_os_family|lower != "redhat"
+    - ansible_facts.os_family|lower != "redhat"
     - not wazuh_custom_packages_installation_agent_enabled
-    - not ansible_check_mode
+    - not ansible_facts.check_mode
   tags:
     - init
 
@@ -88,7 +88,7 @@
       register: agent_auth_output
       notify: restart wazuh-agent
       vars:
-        agent_name: "{% if single_agent_name is defined %}{{ single_agent_name }}{% else %}{{ ansible_hostname }}{% endif %}"
+        agent_name: "{% if single_agent_name is defined %}{{ single_agent_name }}{% else %}{{ ansible_facts.hostname }}{% endif %}"
       when:
         - not client_keys_file.stat.exists or client_keys_file.stat.size == 0
         - wazuh_agent_authd.registration_address is not none
@@ -155,7 +155,7 @@
       changed_when: api_agent_post.json.error == 0
       register: api_agent_post
       vars:
-        agent_name: '{{ target_manager.agent_name | default(ansible_hostname) }}'
+        agent_name: '{{ target_manager.agent_name | default(ansible_facts.hostname) }}'
         jwt_token: '{{ api_jwt_result.json.data.token }}'
       tags:
         - config
@@ -197,7 +197,7 @@
         OSSEC_ACTION_CONFIRMED: y
       register: manage_agents_output
       vars:
-        agent_name: '{{ target_manager.agent_name | default(ansible_hostname) }}'
+        agent_name: '{{ target_manager.agent_name | default(ansible_facts.hostname) }}'
       notify: restart wazuh-agent
   when:
     - not ( wazuh_agent_authd.enable | bool )
@@ -264,8 +264,8 @@
 
 - include_tasks: "RMRedHat.yml"
   when:
-    - ansible_os_family == "RedHat"
+    - ansible_facts.os_family == "RedHat"
 
 - include_tasks: "RMDebian.yml"
   when:
-    - ansible_os_family == "Debian"
+    - ansible_facts.os_family == "Debian"

--- a/roles/wazuh/ansible-wazuh-agent/tasks/RedHat.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/RedHat.yml
@@ -8,8 +8,8 @@
     gpgcheck: true
   changed_when: false
   when:
-    - (ansible_facts['os_family']|lower == 'redhat') and (ansible_distribution|lower != 'amazon')
-    - (ansible_distribution_major_version|int <= 5)
+    - (ansible_facts['os_family']|lower == 'redhat') and (ansible_facts.distribution|lower != 'amazon')
+    - (ansible_facts.distribution_major_version|int <= 5)
     - not wazuh_custom_packages_installation_agent_enabled
   register: repo_v5_installed
 
@@ -36,26 +36,26 @@
 - name: Set Distribution CIS filename for RHEL5
   set_fact:
     cis_distribution_filename: cis_rhel5_linux_rcl.txt
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "5"
+  when: ansible_facts.os_family == "RedHat" and ansible_facts.distribution_major_version == "5"
 
 - name: Set Distribution CIS filename for RHEL6
   set_fact:
     cis_distribution_filename: cis_rhel6_linux_rcl.txt
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "6"
+  when: ansible_facts.os_family == "RedHat" and ansible_facts.distribution_major_version == "6"
 
 - name: Set Distribution CIS filename for RHEL7
   set_fact:
     cis_distribution_filename: cis_rhel7_linux_rcl.txt
   when:
-    - ansible_os_family == "RedHat"
-    - ansible_distribution_major_version == "7"
+    - ansible_facts.os_family == "RedHat"
+    - ansible_facts.distribution_major_version == "7"
 
 - name: Set Distribution CIS filename for RHEL7 (Amazon)
   set_fact:
     cis_distribution_filename: cis_rhel7_linux_rcl.txt
   when:
-    - ansible_distribution == "Amazon"
-    - ansible_distribution_major_version == "NA"
+    - ansible_facts.distribution == "Amazon"
+    - ansible_facts.distribution_major_version == "NA"
 
 - name: RedHat/CentOS/RedHat | Install openscap
   package: name=openscap-scanner state=present

--- a/roles/wazuh/ansible-wazuh-agent/tasks/installation_from_custom_packages.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/installation_from_custom_packages.yml
@@ -4,7 +4,7 @@
       deb: "{{ wazuh_custom_packages_installation_agent_deb_url }}"
       state: present
     when:
-      - ansible_os_family|lower == "debian"
+      - ansible_facts.os_family|lower == "debian"
       - wazuh_custom_packages_installation_agent_enabled
 
   - name: Install Wazuh Agent from .rpm packages | yum
@@ -12,17 +12,17 @@
       name: "{{ wazuh_custom_packages_installation_agent_rpm_url }}"
       state: present
     when:
-      - ansible_os_family|lower == "redhat"
+      - ansible_facts.os_family|lower == "redhat"
       - wazuh_custom_packages_installation_agent_enabled
-      - not (ansible_distribution|lower == "centos" and ansible_distribution_major_version >= "8")
-      - not (ansible_distribution|lower == "redhat" and ansible_distribution_major_version >= "8")
+      - not (ansible_facts.distribution|lower == "centos" and ansible_facts.distribution_major_version >= "8")
+      - not (ansible_facts.distribution|lower == "redhat" and ansible_facts.distribution_major_version >= "8")
 
   - name: Install Wazuh Agent from .rpm packages | dnf
     dnf:
       name: "{{ wazuh_custom_packages_installation_agent_rpm_url }}"
       state: present
     when:
-      - ansible_os_family|lower == "redhat"
+      - ansible_facts.os_family|lower == "redhat"
       - wazuh_custom_packages_installation_agent_enabled
-      - (ansible_distribution|lower == "centos" and ansible_distribution_major_version >= "8") or
-        (ansible_distribution|lower == "redhat" and ansible_distribution_major_version >= "8")
+      - (ansible_facts.distribution|lower == "centos" and ansible_facts.distribution_major_version >= "8") or
+        (ansible_facts.distribution|lower == "redhat" and ansible_facts.distribution_major_version >= "8")

--- a/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/macOS.yml
@@ -60,7 +60,7 @@
       register: agent_auth_output
       notify: macOS | Restart Wazuh Agent
       vars:
-        agent_name: "{% if single_agent_name is defined %}{{ single_agent_name }}{% else %}{{ ansible_hostname }}{% endif %}"
+        agent_name: "{% if single_agent_name is defined %}{{ single_agent_name }}{% else %}{{ ansible_facts.hostname }}{% endif %}"
       when:
         - not client_keys_file.stat.exists or client_keys_file.stat.size == 0
         - wazuh_agent_authd.registration_address is not none
@@ -125,7 +125,7 @@
       changed_when: api_agent_post.json.error == 0
       register: api_agent_post
       vars:
-        agent_name: '{{ target_manager.agent_name | default(ansible_hostname) }}'
+        agent_name: '{{ target_manager.agent_name | default(ansible_facts.hostname) }}'
         jwt_token: '{{ api_jwt_result.json.data.token }}'
       tags:
         - config
@@ -167,7 +167,7 @@
         OSSEC_ACTION_CONFIRMED: y
       register: manage_agents_output
       vars:
-        agent_name: '{{ target_manager.agent_name | default(ansible_hostname) }}'
+        agent_name: '{{ target_manager.agent_name | default(ansible_facts.hostname) }}'
       notify: macOS | Restart Wazuh Agent
   when:
     - not ( wazuh_agent_authd.enable | bool )

--- a/roles/wazuh/ansible-wazuh-agent/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/main.yml
@@ -19,10 +19,10 @@
   when: wazuh_agent_config_overlay | bool
 
 - include_tasks: "Windows.yml"
-  when: ansible_os_family == "Windows"
+  when: ansible_facts.os_family == "Windows"
 
 - include_tasks: "Linux.yml"
-  when: ansible_system == "Linux"
+  when: ansible_facts.system == "Linux"
 
 - include_tasks: "macOS.yml"
-  when: ansible_system == "Darwin"
+  when: ansible_facts.system == "Darwin"

--- a/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
+++ b/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
@@ -1,5 +1,5 @@
 #jinja2: lstrip_blocks: True
-<!-- {{ ansible_managed }} -->
+<!-- {{ ansible_facts.managed }} -->
 <!--
   Wazuh - Agent
   More info at: https://documentation.wazuh.com
@@ -24,13 +24,13 @@
     </server>
     {% endfor %}
     {% if wazuh_profile_centos is not none or wazuh_profile_ubuntu is not none %}
-    {% if ansible_distribution == 'CentOS' %}
+    {% if ansible_facts.distribution == 'CentOS' %}
     <config-profile>{{ wazuh_profile_centos }}</config-profile>
-    {% elif ansible_distribution == "Ubuntu" %}
+    {% elif ansible_facts.distribution == "Ubuntu" %}
     <config-profile>{{ wazuh_profile_ubuntu }}</config-profile>
     {% endif %}
     {% endif %}
-    {% if ansible_system == "Darwin" %}
+    {% if ansible_facts.system == "Darwin" %}
     <config-profile>{{ wazuh_profile_macos }}</config-profile>
     {% endif %}
     {% if wazuh_notify_time is not none and wazuh_time_reconnect is not none %}
@@ -67,7 +67,7 @@
       {% if wazuh_agent_config.enrollment.agent_key_path | length > 0 %}
       <agent_key_path>{{ wazuh_agent_config.enrollment.agent_key_path }}</agent_key_path>
       {% endif %}
-      {% if wazuh_agent_config.enrollment.authorization_pass_path | length > 0 and ansible_system != "Darwin" %}
+      {% if wazuh_agent_config.enrollment.authorization_pass_path | length > 0 and ansible_facts.system != "Darwin" %}
       <authorization_pass_path>{{ wazuh_agent_config.enrollment.authorization_pass_path }}</authorization_pass_path>
       {% else %}
       <authorization_pass_path>{{ wazuh_agent_config.enrollment.authorization_pass_path_macos }}</authorization_pass_path>
@@ -96,7 +96,7 @@
   {% if wazuh_agent_config.rootcheck is defined %}
   <rootcheck>
     <disabled>no</disabled>
-    {% if ansible_system == "Linux" or ansible_system == "Darwin" %}
+    {% if ansible_facts.system == "Linux" or ansible_facts.system == "Darwin" %}
     <check_files>yes</check_files>
     <check_trojans>yes</check_trojans>
     <check_dev>yes</check_dev>
@@ -108,7 +108,7 @@
     <!-- Frequency that rootcheck is executed - every 12 hours -->
     <frequency>{{ wazuh_agent_config.rootcheck.frequency }}</frequency>
 
-    {% if ansible_system == "Darwin" %}
+    {% if ansible_facts.system == "Darwin" %}
     <rootkit_files>etc/shared/rootkit_files.txt</rootkit_files>
     <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
     {% else %}
@@ -117,7 +117,7 @@
     {% endif %}
     <skip_nfs>yes</skip_nfs>
     {% endif %}
-    {% if ansible_os_family == "Windows" %}
+    {% if ansible_facts.os_family == "Windows" %}
     <windows_apps>./shared/win_applications_rcl.txt</windows_apps>
     <windows_malware>./shared/win_malware_rcl.txt</windows_malware>
     {% endif %}
@@ -127,61 +127,61 @@
   {% endif %}
 
 
-  {% if ansible_system == "Linux" and wazuh_agent_config.openscap.disable == 'no' %}
+  {% if ansible_facts.system == "Linux" and wazuh_agent_config.openscap.disable == 'no' %}
   <wodle name="open-scap">
     <disabled>{{ wazuh_agent_config.openscap.disable }}</disabled>
     <timeout>{{ wazuh_agent_config.openscap.timeout }}</timeout>
     <interval>{{ wazuh_agent_config.openscap.interval }}</interval>
     <scan-on-start>{{ wazuh_agent_config.openscap.scan_on_start }}</scan-on-start>
-    {% if ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'xenial' %}
+    {% if ansible_facts.distribution == 'Ubuntu' and ansible_facts.distribution_release == 'xenial' %}
     <content type="xccdf" path="ssg-ubuntu-1604-ds.xml">
       <profile>xccdf_org.ssgproject.content_profile_common</profile>
     </content>
-    {% elif ansible_distribution == 'Debian' %}
-    {% if ansible_distribution_release == 'jessie' %}
+    {% elif ansible_facts.distribution == 'Debian' %}
+    {% if ansible_facts.distribution_release == 'jessie' %}
     {% if openscap_version_valid.stdout == "0" %}
     <content type="xccdf" path="ssg-debian-8-ds.xml">
       <profile>xccdf_org.ssgproject.content_profile_common</profile>
     </content>
     <content type="oval" path="cve-debian-8-oval.xml"/>
     {% endif %}
-    {% elif ansible_distribution_release == 'stretch' %}
+    {% elif ansible_facts.distribution_release == 'stretch' %}
     <content type="oval" path="cve-debian-9-oval.xml"/>
     {% endif %}
-    {% elif ansible_distribution == 'CentOS' %}
-      {% if ansible_distribution_major_version == '8' %}
+    {% elif ansible_facts.distribution == 'CentOS' %}
+      {% if ansible_facts.distribution_major_version == '8' %}
         {# Policy not available #}
-      {% elif ansible_distribution_major_version == '7' %}
+      {% elif ansible_facts.distribution_major_version == '7' %}
       <content type="xccdf" path="ssg-centos-7-ds.xml">
         <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
         <profile>xccdf_org.ssgproject.content_profile_common</profile>
       </content>
-      {% elif ansible_distribution_major_version == '6' %}
+      {% elif ansible_facts.distribution_major_version == '6' %}
       <content type="xccdf" path="ssg-centos-6-ds.xml">
         <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
         <profile>xccdf_org.ssgproject.content_profile_common</profile>
       </content>
       {% endif %}
-    {% elif ansible_distribution == 'RedHat' %}
-      {% if ansible_distribution_major_version == '8' %}
+    {% elif ansible_facts.distribution == 'RedHat' %}
+      {% if ansible_facts.distribution_major_version == '8' %}
         {# Policy not available #}
-      {% elif ansible_distribution_major_version == '7' %}
+      {% elif ansible_facts.distribution_major_version == '7' %}
       <content type="xccdf" path="ssg-rhel-7-ds.xml">
         <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
         <profile>xccdf_org.ssgproject.content_profile_common</profile>
       </content>
-      {% elif ansible_distribution_major_version == '6' %}
+      {% elif ansible_facts.distribution_major_version == '6' %}
       <content type="xccdf" path="ssg-rhel-6-ds.xml">
         <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
         <profile>xccdf_org.ssgproject.content_profile_common</profile>
       </content>
       {% endif %}
-      {% if ansible_distribution_major_version == '7' %}
+      {% if ansible_facts.distribution_major_version == '7' %}
       <content type="oval" path="cve-redhat-7-ds.xml"/>
-      {% elif ansible_distribution_major_version == '6' %}
+      {% elif ansible_facts.distribution_major_version == '6' %}
       <content type="oval" path="cve-redhat-6-ds.xml"/>
       {% endif %}
-    {% elif ansible_distribution == 'Fedora' %}
+    {% elif ansible_facts.distribution == 'Fedora' %}
       <content type="xccdf" path="ssg-fedora-ds.xml">
         <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
         <profile>xccdf_org.ssgproject.content_profile_common</profile>
@@ -190,20 +190,20 @@
   </wodle>
   {% endif %}
 
-  {% if ansible_system != "Darwin" %}
+  {% if ansible_facts.system != "Darwin" %}
   <wodle name="cis-cat">
     <disabled>{{ wazuh_agent_config.cis_cat.disable }}</disabled>
     <timeout>{{ wazuh_agent_config.cis_cat.timeout }}</timeout>
     <interval>{{ wazuh_agent_config.cis_cat.interval }}</interval>
     <scan-on-start>{{ wazuh_agent_config.cis_cat.scan_on_start }}</scan-on-start>
-    {% if wazuh_agent_config.cis_cat.install_java == 'yes' and ansible_system == "Linux" %}
+    {% if wazuh_agent_config.cis_cat.install_java == 'yes' and ansible_facts.system == "Linux" %}
     <java_path>/usr/bin</java_path>
-    {% elif ansible_os_family == "Windows" %}
+    {% elif ansible_facts.os_family == "Windows" %}
     <java_path>{{ wazuh_agent_config.cis_cat.java_path_win }}</java_path>
     {% else %}
     <java_path>{{ wazuh_agent_config.cis_cat.java_path }}</java_path>
     {% endif %}
-    <ciscat_path>{% if ansible_os_family == "Windows" %}{{ wazuh_agent_config.cis_cat.ciscat_path_win }}{% else %}{{ wazuh_agent_config.cis_cat.ciscat_path }}{% endif %}</ciscat_path>
+    <ciscat_path>{% if ansible_facts.os_family == "Windows" %}{{ wazuh_agent_config.cis_cat.ciscat_path_win }}{% else %}{{ wazuh_agent_config.cis_cat.ciscat_path }}{% endif %}</ciscat_path>
   </wodle>
   {% endif %}
 
@@ -211,11 +211,11 @@
   <wodle name="osquery">
     <disabled>{{ wazuh_agent_config.osquery.disable }}</disabled>
     <run_daemon>{{ wazuh_agent_config.osquery.run_daemon }}</run_daemon>
-    {% if ansible_os_family == "Windows" %}
+    {% if ansible_facts.os_family == "Windows" %}
     <bin_path>{{ wazuh_agent_config.osquery.bin_path_win }}</bin_path>
     {% endif %}
-    <log_path>{% if ansible_os_family == "Windows" %}{{ wazuh_agent_config.osquery.log_path_win }}{% else %}{{ wazuh_agent_config.osquery.log_path }}{% endif %}</log_path>
-    <config_path>{% if ansible_os_family == "Windows" %}{{ wazuh_agent_config.osquery.config_path_win }}{% else %}{{ wazuh_agent_config.osquery.config_path }}{% endif %}</config_path>
+    <log_path>{% if ansible_facts.os_family == "Windows" %}{{ wazuh_agent_config.osquery.log_path_win }}{% else %}{{ wazuh_agent_config.osquery.log_path }}{% endif %}</log_path>
+    <config_path>{% if ansible_facts.os_family == "Windows" %}{{ wazuh_agent_config.osquery.config_path_win }}{% else %}{{ wazuh_agent_config.osquery.config_path }}{% endif %}</config_path>
     <add_labels>{{ wazuh_agent_config.osquery.add_labels }}</add_labels>
   </wodle>
 
@@ -262,14 +262,14 @@
   <syscheck>
     <disabled>no</disabled>
     <frequency>{{ wazuh_agent_config.syscheck.frequency }}</frequency>
-    {% if ansible_system == "Linux" or ansible_system == "Darwin" %}
+    {% if ansible_facts.system == "Linux" or ansible_facts.system == "Darwin" %}
     <scan_on_start>{{ wazuh_agent_config.syscheck.scan_on_start }}</scan_on_start>
     <!-- Directories to check  (perform all possible verifications) -->
-    {% if wazuh_agent_config.syscheck.directories is defined and ansible_system == "Linux" %}
+    {% if wazuh_agent_config.syscheck.directories is defined and ansible_facts.system == "Linux" %}
     {% for directory in wazuh_agent_config.syscheck.directories %}
     <directories {{ directory.checks }}>{{ directory.dirs }}</directories>
     {% endfor %}
-    {% elif ansible_system == "Darwin" %}
+    {% elif ansible_facts.system == "Darwin" %}
     {% for directory in wazuh_agent_config.syscheck.macos_directories %}
     <directories {{ directory.checks }}>{{ directory.dirs }}</directories>
     {% endfor %}
@@ -277,14 +277,14 @@
     {% endif %}
 
     <!-- Directories to check  (perform all possible verifications) -->
-    {% if wazuh_agent_config.syscheck.win_directories is defined and ansible_os_family == "Windows" %}
+    {% if wazuh_agent_config.syscheck.win_directories is defined and ansible_facts.os_family == "Windows" %}
     {% for directory in wazuh_agent_config.syscheck.win_directories %}
     <directories {{ directory.checks }}>{{ directory.dirs }}</directories>
     {% endfor %}
     {% endif %}
 
     <!-- Files/directories to ignore -->
-    {% if wazuh_agent_config.syscheck.ignore is defined and (ansible_system == "Linux" or ansible_system == "Darwin") %}
+    {% if wazuh_agent_config.syscheck.ignore is defined and (ansible_system == "Linux" or ansible_facts.system == "Darwin") %}    
     {% for ignore in wazuh_agent_config.syscheck.ignore %}
     <ignore>{{ ignore }}</ignore>
     {% endfor %}
@@ -297,13 +297,13 @@
     {% endfor %}
     {% endif %}
 
-    {% if wazuh_agent_config.syscheck.ignore is defined and ansible_os_family == "Windows" %}
+    {% if wazuh_agent_config.syscheck.ignore is defined and ansible_facts.os_family == "Windows" %}
     {% for ignore in wazuh_agent_config.syscheck.ignore_win %}
     <ignore type="sregex">{{ ignore }}</ignore>
     {% endfor %}
     {% endif %}
 
-    {% if ansible_system == "Linux" or ansible_system == "Darwin" %}
+    {% if ansible_facts.system == "Linux" or ansible_facts.system == "Darwin" %}
     <!-- Files no diff -->
     {% for no_diff in wazuh_agent_config.syscheck.no_diff %}
     <nodiff>{{ no_diff }}</nodiff>
@@ -315,7 +315,7 @@
     <skip_sys>{{ wazuh_agent_config.syscheck.skip_sys }}</skip_sys>
     {% endif %}
 
-    {% if ansible_os_family == "Windows" %}
+    {% if ansible_facts.os_family == "Windows" %}
     {% for registry_key in wazuh_agent_config.syscheck.windows_registry %}
     {% if registry_key.arch is defined %}
     <windows_registry arch="{{ registry_key.arch }}">{{ registry_key.key }}</windows_registry>
@@ -325,7 +325,7 @@
     {% endfor %}
     {% endif %}
 
-    {% if ansible_os_family == "Windows" %}
+    {% if ansible_facts.os_family == "Windows" %}
     {% for registry_key in wazuh_agent_config.syscheck.windows_registry_ignore %}
     {% if registry_key.type is defined %}
     <registry_ignore type="{{ registry_key.type }}">{{ registry_key.key }}</registry_ignore>
@@ -335,7 +335,7 @@
     {% endfor %}
     {% endif %}
 
-    {% if ansible_os_family == "Windows" %}
+    {% if ansible_facts.os_family == "Windows" %}
     <!-- Frequency for ACL checking (seconds) -->
     <windows_audit_interval>{{ wazuh_agent_config.syscheck.win_audit_interval }}</windows_audit_interval>
     {% endif %}
@@ -357,7 +357,7 @@
   {% endif %}
 
   <!-- Files to monitor (localfiles) -->
-  {% if ansible_system == "Linux" %}
+  {% if ansible_facts.system == "Linux" %}
   {% for localfile in wazuh_agent_config.localfiles.linux %}
 
   <localfile>
@@ -384,7 +384,7 @@
   </localfile>
   {% endif %}
 
-  {% if ansible_system == "Darwin" %}
+  {% if ansible_facts.system == "Darwin" %}
   {% for localfile in wazuh_agent_config.localfiles.macos %}
 
   <localfile>
@@ -405,7 +405,7 @@
   {% endfor %}
   {% endif %}
 
-  {% if ansible_os_family == "Debian" %}
+  {% if ansible_facts.os_family == "Debian" %}
   {% for localfile in wazuh_agent_config.localfiles.debian %}
 
   <localfile>
@@ -428,7 +428,7 @@
   {% endfor %}
   {% endif %}
 
-  {% if ansible_os_family == "RedHat" %}
+  {% if ansible_facts.os_family == "RedHat" %}
   {% for localfile in wazuh_agent_config.localfiles.centos %}
 
   <localfile>
@@ -451,7 +451,7 @@
   {% endfor %}
   {% endif %}
 
-  {% if ansible_os_family == "Windows" %}
+  {% if ansible_facts.os_family == "Windows" %}
   {% for localfile in wazuh_agent_config.localfiles.windows %}
 
   <localfile>
@@ -482,9 +482,9 @@
   <active-response>
     <disabled>{{ wazuh_agent_config.active_response.ar_disabled|default('no') }}</disabled>
     <ca_store>
-    {% if ansible_os_family == "Windows" %}{{ wazuh_agent_config.active_response.ca_store_win }}
+    {% if ansible_facts.os_family == "Windows" %}{{ wazuh_agent_config.active_response.ca_store_win }}
     {% else %}
-    {% if ansible_system == "Darwin" %}{{ wazuh_agent_config.active_response.ca_store_macos }}
+    {% if ansible_facts.system == "Darwin" %}{{ wazuh_agent_config.active_response.ca_store_macos }}
     {% else %}
     {{ wazuh_agent_config.active_response.ca_store }}
     {% endif %}

--- a/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/Debian.yml
@@ -22,8 +22,8 @@
     executable: /bin/bash
   changed_when: false
   when:
-    - ansible_distribution == "Ubuntu"
-    - ansible_distribution_major_version | int == 14
+    - ansible_facts.distribution == "Ubuntu"
+    - ansible_facts.distribution_major_version | int == 14
     - not wazuh_custom_packages_installation_manager_enabled
 
 - name: Debian/Ubuntu | Download Wazuh repository key
@@ -31,13 +31,13 @@
     url: "{{ wazuh_manager_config.repo.gpg }}"
     dest: "{{ wazuh_manager_config.repo.path }}"
   when:
-    - not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int == 14)
+    - not (ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int == 14)
     - not wazuh_custom_packages_installation_manager_enabled
 
 - name: Debian/Ubuntu | Import Wazuh GPG key
   command: "gpg --no-default-keyring --keyring gnupg-ring:{{ wazuh_manager_config.repo.keyring_path }} --import {{ wazuh_manager_config.repo.path }}"
   when:
-    - not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int == 14)
+    - not (ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int == 14)
     - not wazuh_custom_packages_installation_manager_enabled
   args:
     creates: "{{ wazuh_manager_config.repo.keyring_path }}"
@@ -47,7 +47,7 @@
     path: "{{ wazuh_manager_config.repo.keyring_path }}"
     mode: '0644'
   when:
-    - not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int == 14)
+    - not (ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int == 14)
     - not wazuh_custom_packages_installation_manager_enabled
 
 - name: Debian/Ubuntu | Add Wazuh repositories
@@ -70,7 +70,7 @@
     state: present
     update_cache: true
   when:
-    - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int == 14)
+    - (ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int == 14)
 
 - when:
     - wazuh_manager_config.cis_cat.disable == 'no'

--- a/roles/wazuh/ansible-wazuh-manager/tasks/RedHat.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/RedHat.yml
@@ -8,8 +8,8 @@
     gpgcheck: true
   changed_when: false
   when:
-    - (ansible_os_family|lower == 'redhat') and (ansible_distribution|lower != 'amazon')
-    - (ansible_distribution_major_version|int <= 5)
+    - (ansible_os_family|lower == 'redhat') and (ansible_facts.distribution|lower != 'amazon')
+    - (ansible_facts.distribution_major_version|int <= 5)
     - not wazuh_custom_packages_installation_manager_enabled
   register: repo_v5_manager_installed
 
@@ -33,15 +33,15 @@
   until: wazuh_manager_openscp_packages_installed is succeeded
   tags:
     - init
-  when: not (ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA") and
-        not (ansible_distribution == "CentOS" and ansible_distribution_major_version == "8")
+  when: not (ansible_facts.distribution == "Amazon" and ansible_facts.distribution_major_version == "NA") and
+        not (ansible_facts.distribution == "CentOS" and ansible_facts.distribution_major_version == "8")
 
 - name: CentOS 6 | Install Software Collections (SCL) Repository
   package: name=centos-release-scl state=present
   register: wazuh_manager_scl_packages_installed
   until: wazuh_manager_scl_packages_installed is succeeded
   when:
-    - ansible_distribution == 'CentOS' and ansible_distribution_major_version == '6'
+    - ansible_facts.distribution == 'CentOS' and ansible_facts.distribution_major_version == '6'
     - wazuh_manager_config.cluster.disable != 'yes'
 
 - name: RedHat 6 | Enabling Red Hat Software Collections (RHSCL)
@@ -50,7 +50,7 @@
     - rhui-REGION-rhel-server-rhscl
     - rhel-server-rhscl-6-rpms
   when:
-    - ansible_distribution == 'RedHat' and  ansible_distribution_major_version == '6'
+    - ansible_facts.distribution == 'RedHat' and  ansible_facts.distribution_major_version == '6'
     - wazuh_manager_config.cluster.disable != 'yes'
 
 - name: CentOS/RedHat 6 | Install Python 2.7
@@ -58,7 +58,7 @@
   register: wazuh_manager_python_package_installed
   until: wazuh_manager_python_package_installed is succeeded
   when:
-    - ( ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat' ) and ansible_distribution_major_version == '6'
+    - ( ansible_facts.distribution == 'CentOS' or ansible_facts.distribution == 'RedHat' ) and ansible_facts.distribution_major_version == '6'
     - wazuh_manager_config.cluster.disable != 'yes'
 
 - name: RedHat/CentOS/Fedora | Install OpenJDK 1.8
@@ -72,24 +72,24 @@
 - name: Set Distribution CIS filename for RHEL5/CentOS-5
   set_fact:
     cis_distribution_filename: cis_rhel5_linux_rcl.txt
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '5'
+  when: ansible_facts.os_family == "RedHat" and ansible_facts.distribution_major_version == '5'
 
 - name: Set Distribution CIS filename for RHEL6/CentOS-6
   set_fact:
     cis_distribution_filename: cis_rhel6_linux_rcl.txt
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '6'
+  when: ansible_facts.os_family == "RedHat" and ansible_facts.distribution_major_version == '6'
 
 - name: Set Distribution CIS filename for RHEL7/CentOS-7
   set_fact:
     cis_distribution_filename: cis_rhel7_linux_rcl.txt
   when:
-    - ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'
+    - ansible_facts.os_family == "RedHat" and ansible_facts.distribution_major_version == '7'
 
 - name: Set Distribution CIS filename for RHEL7/CentOS-7 (Amazon)
   set_fact:
     cis_distribution_filename: cis_rhel7_linux_rcl.txt
   when:
-    - ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA"
+    - ansible_facts.distribution == "Amazon" and ansible_facts.distribution_major_version == "NA"
 
 - name: CentOS/RedHat/Amazon | Install wazuh-manager
   package:
@@ -98,7 +98,7 @@
   register: wazuh_manager_main_packages_installed
   until: wazuh_manager_main_packages_installed is succeeded
   when:
-    - ansible_os_family|lower == "redhat"
+    - ansible_facts.os_family|lower == "redhat"
     - not wazuh_custom_packages_installation_manager_enabled
   tags:
     - init
@@ -113,7 +113,7 @@
     regexp: 'echo -n "Starting Wazuh-manager: "'
     replace: "echo -n \"Starting Wazuh-manager (EL6): \"; source /opt/rh/python27/enable; export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:{{ wazuh_dir }}/framework/lib"
   when:
-    - ansible_distribution in ['CentOS', 'RedHat', 'Amazon'] and ansible_distribution_major_version|int == 6
+    - ansible_facts.distribution in ['CentOS', 'RedHat', 'Amazon'] and ansible_facts.distribution_major_version|int == 6
     - wazuh_manager_config.cluster.disable != 'yes'
 
 - name: Install expect (EL5)
@@ -125,7 +125,7 @@
   register: wazuh_manager_main_packages_installed
   until: wazuh_manager_main_packages_installed is succeeded
   when:
-    - ansible_os_family|lower == "RedHat"
-    - ansible_distribution_major_version|int < 6
+    - ansible_facts.os_family|lower == "RedHat"
+    - ansible_facts.distribution_major_version|int < 6
   tags:
     - init

--- a/roles/wazuh/ansible-wazuh-manager/tasks/installation_from_custom_packages.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/installation_from_custom_packages.yml
@@ -7,7 +7,7 @@
         when:
           - wazuh_custom_packages_installation_manager_enabled
     when:
-      - ansible_os_family|lower == "debian"
+      - ansible_facts.os_family|lower == "debian"
 
   - block:
     - name: Install Wazuh Manager from .rpm packages | yum
@@ -16,8 +16,8 @@
         state: present
       when:
         - wazuh_custom_packages_installation_manager_enabled
-        - not (ansible_distribution|lower == "centos" and ansible_distribution_major_version >= "8")
-        - not (ansible_distribution|lower == "redhat" and ansible_distribution_major_version >= "8")
+        - not (ansible_facts.distribution|lower == "centos" and ansible_facts.distribution_major_version >= "8")
+        - not (ansible_facts.distribution|lower == "redhat" and ansible_facts.distribution_major_version >= "8")
 
     - name: Install Wazuh Manager from .rpm packages | dnf
       dnf:
@@ -25,7 +25,7 @@
         state: present
       when:
         - wazuh_custom_packages_installation_manager_enabled
-        - (ansible_distribution|lower == "centos" and ansible_distribution_major_version >= "8") or
-          (ansible_distribution|lower == "redhat" and ansible_distribution_major_version >= "8")
+        - (ansible_facts.distribution|lower == "centos" and ansible_facts.distribution_major_version >= "8") or
+          (ansible_facts.distribution|lower == "redhat" and ansible_facts.distribution_major_version >= "8")
     when:
-      - ansible_os_family|lower == "redhat"
+      - ansible_facts.os_family|lower == "redhat"

--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -18,7 +18,7 @@
       package:
         name: curl
         state: present
-      when: ansible_distribution != "Amazon" and ansible_distribution_version != "2023"
+      when: ansible_facts.distribution != "Amazon" and ansible_facts.distribution_version != "2023"
       register: package_status
       until: "package_status is not failed"  
       retries: 10
@@ -28,7 +28,7 @@
       package:
         name: curl-minimal
         state: present
-      when: ansible_distribution == "Amazon" and ansible_distribution_version == "2023"
+      when: ansible_facts.distribution == "Amazon" and ansible_facts.distribution_version == "2023"
       register: package_status
       until: "package_status is not failed"  
       retries: 10
@@ -53,10 +53,10 @@
   when: wazuh_manager_config_overlay | bool
 
 - include_tasks: "RedHat.yml"
-  when: (ansible_os_family == "RedHat" and ansible_distribution_major_version|int > 5) or (ansible_os_family  == "RedHat" and ansible_distribution == "Amazon")
+  when: (ansible_os_family == "RedHat" and ansible_facts.distribution_major_version|int > 5) or (ansible_os_family  == "RedHat" and ansible_facts.distribution == "Amazon")
 
 - include_tasks: "Debian.yml"
-  when: ansible_os_family == "Debian"
+  when: ansible_facts.os_family == "Debian"
 
 - name: Generate the wazuh-keystore (username)
   shell: >
@@ -79,8 +79,8 @@
     name: expect
     state: "{{ wazuh_manager_package_state }}"
   when:
-    - not (ansible_os_family|lower == "redhat" and ansible_distribution_major_version|int < 6) and
-      not (ansible_distribution|lower == "centos" and ansible_distribution_major_version|int == 8)
+    - not (ansible_os_family|lower == "redhat" and ansible_facts.distribution_major_version|int < 6) and
+      not (ansible_facts.distribution|lower == "centos" and ansible_facts.distribution_major_version|int == 8)
   tags: init
 
 - name: Generate SSL files for authd

--- a/roles/wazuh/ansible-wazuh-manager/tasks/uninstall.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/uninstall.yml
@@ -5,11 +5,11 @@
     repo: "{{ wazuh_manager_config.repo.apt }}"
     state: absent
   changed_when: false
-  when: ansible_os_family == "Debian"
+  when: ansible_facts.os_family == "Debian"
 
 - name: RedHat/CentOS/Fedora | Remove Wazuh repository (and clean up left-over metadata)
   yum_repository:
     name: wazuh_repo
     state: absent
   changed_when: false
-  when: ansible_os_family == "RedHat" or ansible_os_family == "Amazon"
+  when: ansible_facts.os_family == "RedHat" or ansible_facts.os_family == "Amazon"

--- a/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/var-ossec-etc-ossec-server.conf.j2
@@ -136,61 +136,61 @@
     <skip_nfs>yes</skip_nfs>
   </rootcheck>
 
-    {% if ansible_system == "Linux" and wazuh_manager_config.openscap.disable == 'no' %}
+    {% if ansible_facts.system == "Linux" and wazuh_manager_config.openscap.disable == 'no' %}
   <wodle name="open-scap">
     <disabled>no</disabled>
     <timeout>{{ wazuh_manager_config.openscap.timeout }}</timeout>
     <interval>{{ wazuh_manager_config.openscap.interval }}</interval>
     <scan-on-start>{{ wazuh_manager_config.openscap.scan_on_start }}</scan-on-start>
-    {% if ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'xenial' %}
+    {% if ansible_facts.distribution == 'Ubuntu' and ansible_facts.distribution_release == 'xenial' %}
     <content type="xccdf" path="ssg-ubuntu-1604-ds.xml">
       <profile>xccdf_org.ssgproject.content_profile_common</profile>
     </content>
-    {% elif ansible_distribution == 'Debian' %}
-    {% if ansible_distribution_release == 'jessie' %}
+    {% elif ansible_facts.distribution == 'Debian' %}
+    {% if ansible_facts.distribution_release == 'jessie' %}
     {% if openscap_version_valid.stdout == "0" %}
     <content type="xccdf" path="ssg-debian-8-ds.xml">
       <profile>xccdf_org.ssgproject.content_profile_common</profile>
     </content>
     <content type="oval" path="cve-debian-8-oval.xml"/>
     {% endif %}
-    {% elif ansible_distribution_release == 'stretch' %}
+    {% elif ansible_facts.distribution_release == 'stretch' %}
     <content type="oval" path="cve-debian-9-oval.xml"/>
     {% endif %}
-    {% elif ansible_distribution == 'CentOS' %}
-      {% if ansible_distribution_major_version == '8' %}
+    {% elif ansible_facts.distribution == 'CentOS' %}
+      {% if ansible_facts.distribution_major_version == '8' %}
         {# Policy not available #}
-      {% elif ansible_distribution_major_version == '7' %}
+      {% elif ansible_facts.distribution_major_version == '7' %}
       <content type="xccdf" path="ssg-centos-7-ds.xml">
         <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
         <profile>xccdf_org.ssgproject.content_profile_common</profile>
       </content>
-      {% elif ansible_distribution_major_version == '6' %}
+      {% elif ansible_facts.distribution_major_version == '6' %}
       <content type="xccdf" path="ssg-centos-6-ds.xml">
         <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
         <profile>xccdf_org.ssgproject.content_profile_common</profile>
       </content>
       {% endif %}
-    {% elif ansible_distribution == 'RedHat' %}
-      {% if ansible_distribution_major_version == '8' %}
+    {% elif ansible_facts.distribution == 'RedHat' %}
+      {% if ansible_facts.distribution_major_version == '8' %}
         {# Policy not available #}
-      {% elif ansible_distribution_major_version == '7' %}
+      {% elif ansible_facts.distribution_major_version == '7' %}
       <content type="xccdf" path="ssg-rhel-7-ds.xml">
         <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
         <profile>xccdf_org.ssgproject.content_profile_common</profile>
       </content>
-      {% elif ansible_distribution_major_version == '6' %}
+      {% elif ansible_facts.distribution_major_version == '6' %}
       <content type="xccdf" path="ssg-rhel-6-ds.xml">
         <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
         <profile>xccdf_org.ssgproject.content_profile_common</profile>
       </content>
       {% endif %}
-      {% if ansible_distribution_major_version == '7' %}
+      {% if ansible_facts.distribution_major_version == '7' %}
       <content type="oval" path="cve-redhat-7-ds.xml"/>
-      {% elif ansible_distribution_major_version == '6' %}
+      {% elif ansible_facts.distribution_major_version == '6' %}
       <content type="oval" path="cve-redhat-6-ds.xml"/>
       {% endif %}
-    {% elif ansible_distribution == 'Fedora' %}
+    {% elif ansible_facts.distribution == 'Fedora' %}
       <content type="xccdf" path="ssg-fedora-ds.xml">
         <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
         <profile>xccdf_org.ssgproject.content_profile_common</profile>
@@ -431,7 +431,7 @@
   </localfile>
 {% endfor %}
 
-{% if ansible_os_family == "Debian" %}
+{% if ansible_facts.os_family == "Debian" %}
 {% for localfile in wazuh_manager_config.localfiles.debian %}
 
   <localfile>
@@ -470,7 +470,7 @@
 {% endfor %}
 {% endif -%}
 
-{% if ansible_os_family == "RedHat" %}
+{% if ansible_facts.os_family == "RedHat" %}
 {% for localfile in wazuh_manager_config.localfiles.centos %}
 
   <localfile>

--- a/roles/wazuh/wazuh-dashboard/tasks/main.yml
+++ b/roles/wazuh/wazuh-dashboard/tasks/main.yml
@@ -11,10 +11,10 @@
   when: packages_repository == 'staging'
 
 - import_tasks: RedHat.yml
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts.os_family == 'RedHat'
 
 - import_tasks: Debian.yml
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts.os_family == 'Debian'
 
 - name: Remove Dashboard configuration file
   file:
@@ -96,4 +96,4 @@
     state: started
 
 - import_tasks: RMRedHat.yml
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts.os_family == 'RedHat'

--- a/roles/wazuh/wazuh-indexer/tasks/Debian.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/Debian.yml
@@ -6,7 +6,7 @@
     update_cache: yes
 
 - name: Debian 9 (Stretch)
-  when: (ansible_facts['distribution'] == "Debian" and ansible_facts['distribution_major_version'] == "9")
+  when: (ansible_facts['distribution'] == "Debian" and ansible_facts.facts['distribution_major_version'] == "9")
   block:
 
     - name: Install Wazuh indexer dependencies

--- a/roles/wazuh/wazuh-indexer/tasks/RedHat.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/RedHat.yml
@@ -19,8 +19,8 @@
           name: amazon-linux-extras
           state: present
         when: 
-          - ansible_distribution == 'Amazon'
-          - ansible_distribution_major_version == '2'
+          - ansible_facts.distribution == 'Amazon'
+          - ansible_facts.distribution_major_version == '2'
 
       - name: Configure vm.max_map_count
         lineinfile:
@@ -35,7 +35,7 @@
         become: yes
 
     when:
-      - ansible_distribution == 'Amazon'
+      - ansible_facts.distribution == 'Amazon'
 
   - name: RedHat/CentOS/Fedora | Install Indexer dependencies
     yum:

--- a/roles/wazuh/wazuh-indexer/tasks/main.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/main.yml
@@ -16,10 +16,10 @@
 
 - block:
     - import_tasks: RedHat.yml
-      when: ansible_os_family == 'RedHat'
+      when: ansible_facts.os_family == 'RedHat'
 
     - import_tasks: Debian.yml
-      when: ansible_os_family == 'Debian'
+      when: ansible_facts.os_family == 'Debian'
 
     - name: Remove performance analyzer plugin from Wazuh indexer
       become: true
@@ -130,7 +130,7 @@
         - hostvars[inventory_hostname]['private_ip'] is defined and hostvars[inventory_hostname]['private_ip']
 
     - import_tasks: "RMRedHat.yml"
-      when: ansible_os_family == "RedHat"
+      when: ansible_facts.os_family == "RedHat"
 
     - name: Reload systemd configuration
       systemd:

--- a/roles/wazuh/wazuh-indexer/tasks/security_actions.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/security_actions.yml
@@ -94,7 +94,7 @@
     register: result
     until: result.rc == 0
 
-  when: inventory_hostname == ansible_play_hosts[0]
+  when: inventory_hostname == ansible_facts.play_hosts[0]
 
 - name: Create custom user
   uri:
@@ -116,4 +116,4 @@
   until: result.status in [200,201,401]
   when:
     - indexer_custom_user is defined and indexer_custom_user
-    - inventory_hostname == ansible_play_hosts[0]
+    - inventory_hostname == ansible_facts.play_hosts[0]

--- a/roles/wazuh/wazuh-indexer/templates/jvm.options.j2
+++ b/roles/wazuh/wazuh-indexer/templates/jvm.options.j2
@@ -28,9 +28,9 @@
 -Xmx32000m
 {% endif %}
 {% else %}
--Xms{% if ansible_memtotal_mb < 64000 %}{{ ((ansible_memtotal_mb|int)/2)|int }}m{% else %}32000m{% endif %}
+-Xms{% if ansible_facts.memtotal_mb < 64000 %}{{ ((ansible_memtotal_mb|int)/2)|int }}m{% else %}32000m{% endif %}
 
--Xmx{% if ansible_memtotal_mb < 64000 %}{{ ((ansible_memtotal_mb|int)/2)|int }}m{% else %}32000m{% endif %}
+-Xmx{% if ansible_facts.memtotal_mb < 64000 %}{{ ((ansible_memtotal_mb|int)/2)|int }}m{% else %}32000m{% endif %}
 {% endif %}
 
 


### PR DESCRIPTION
By default, Ansible injects a variable for every fact, prefixed with
ansible_. This can result in a large number of variables for each host,
which at scale can incur a performance penalty. Ansible provides a
configuration option [0] that can be set to False to prevent this
injection of facts. In this case, facts should be referenced via
ansible_facts..

This change updates all references to Ansible facts from using
individual fact variables to using the items in the
ansible_facts dictionary. This allows users to disable fact variable
injection in their Ansible configuration, which may provide some
performance improvement.

[0] https://docs.ansible.com/ansible/latest/reference_appendices/config.html#inject-facts-as-vars

This patch was already merged into branch 4.4 [here](https://github.com/wazuh/wazuh-ansible/pull/893) but never make it to master branch. I am very eager to incorporate this into master, so please let me know what needs to be done to achieve this. 