### PR TITLE
Use fixed version of Ubuntu-22.04 in GHA runners instead of latest version

### DIFF
--- a/.github/workflows/al_aio.yml
+++ b/.github/workflows/al_aio.yml
@@ -4,7 +4,7 @@ on: [pull_request, workflow_dispatch, release]
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -49,7 +49,7 @@ jobs:
     needs:
       - start-runner # required to get output from the start-runner job
       - install-aio-single-instance # required to wait when the main job is done
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/al_wazuh.yml
+++ b/.github/workflows/al_wazuh.yml
@@ -4,7 +4,7 @@ on: [pull_request, workflow_dispatch, release]
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -49,7 +49,7 @@ jobs:
     needs:
       - start-runner # required to get output from the start-runner job
       - install-wazuh-single-instance # required to wait when the main job is done
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/centos_aio.yml
+++ b/.github/workflows/centos_aio.yml
@@ -4,7 +4,7 @@ on: [pull_request, workflow_dispatch, release]
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -58,7 +58,7 @@ jobs:
     needs:
       - start-runner # required to get output from the start-runner job
       - install-aio-single-instance # required to wait when the main job is done
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/centos_wazuh.yml
+++ b/.github/workflows/centos_wazuh.yml
@@ -4,7 +4,7 @@ on: [pull_request, workflow_dispatch, release]
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -58,7 +58,7 @@ jobs:
     needs:
       - start-runner # required to get output from the start-runner job
       - install-wazuh-single-instance # required to wait when the main job is done
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/ubuntu_aio.yml
+++ b/.github/workflows/ubuntu_aio.yml
@@ -4,7 +4,7 @@ on: [pull_request, workflow_dispatch, release]
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -58,7 +58,7 @@ jobs:
     needs:
       - start-runner # required to get output from the start-runner job
       - install-aio-single-instance # required to wait when the main job is done
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/ubuntu_wazuh.yml
+++ b/.github/workflows/ubuntu_wazuh.yml
@@ -4,7 +4,7 @@ on: [pull_request, workflow_dispatch, release]
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -58,7 +58,7 @@ jobs:
     needs:
       - start-runner # required to get output from the start-runner job
       - install-wazuh-single-instance # required to wait when the main job is done
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 
 - Update to [Wazuh v4.10.3](https://github.com/wazuh/wazuh/blob/v4.10.3/CHANGELOG.md#v4103)
 
+### Changed
+
+- Use fixed version of Ubuntu-22.04 in GHA runners instead of latest version ([#1479](https://github.com/wazuh/wazuh-ansible/pull/1479)) \- (PR Checks Workflows)
+
 ## [v4.10.2]
 
 ### Added


### PR DESCRIPTION
# Description
This PR aims to change all occurrences of `ubuntu-latest` in the workflow runners for a defined or fixed version of ubuntu, in order to avoid failures in the future. The new version to use is `ubuntu-22.04`.

Related issue: https://github.com/wazuh/wazuh-ansible/issues/1471