### PR TITLE
Add Yum lock timeout to Ansible task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- None
+- Add Yum lock timeout to Ansible task ([#1511](https://github.com/wazuh/wazuh-ansible/pull/1511))
 
 ### Fixed
 

--- a/roles/wazuh/ansible-filebeat-oss/tasks/main.yml
+++ b/roles/wazuh/ansible-filebeat-oss/tasks/main.yml
@@ -17,6 +17,7 @@
   yum:
     name: "filebeat-{{ filebeat_version }}"
     state: present
+    lock_timeout: 200
   register: install
   tags:
   - install
@@ -31,7 +32,7 @@
   tags:
   - install
   - init
-  until: "install is not failed"  
+  until: "install is not failed"
   retries: 10
   delay: 10
   when: ansible_os_family == 'Debian'

--- a/roles/wazuh/ansible-wazuh-agent/tasks/installation_from_custom_packages.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/installation_from_custom_packages.yml
@@ -11,6 +11,7 @@
     yum:
       name: "{{ wazuh_custom_packages_installation_agent_rpm_url }}"
       state: present
+      lock_timeout: 200
     when:
       - ansible_os_family|lower == "redhat"
       - wazuh_custom_packages_installation_agent_enabled

--- a/roles/wazuh/ansible-wazuh-manager/tasks/RedHat.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/RedHat.yml
@@ -62,7 +62,10 @@
     - wazuh_manager_config.cluster.disable != 'yes'
 
 - name: RedHat/CentOS/Fedora | Install OpenJDK 1.8
-  yum: name=java-1.8.0-openjdk state=present
+  yum:
+    name: java-1.8.0-openjdk
+    state: present
+    lock_timeout: 200
   when:
     - wazuh_manager_config.cis_cat.disable == 'no'
     - wazuh_manager_config.cis_cat.install_java == 'yes'

--- a/roles/wazuh/ansible-wazuh-manager/tasks/installation_from_custom_packages.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/installation_from_custom_packages.yml
@@ -14,6 +14,7 @@
       yum:
         name: "{{ wazuh_custom_packages_installation_manager_rpm_url }}"
         state: present
+        lock_timeout: 200
       when:
         - wazuh_custom_packages_installation_manager_enabled
         - not (ansible_distribution|lower == "centos" and ansible_distribution_major_version >= "8")

--- a/roles/wazuh/wazuh-indexer/tasks/RedHat.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/RedHat.yml
@@ -18,7 +18,8 @@
         yum:
           name: amazon-linux-extras
           state: present
-        when: 
+          lock_timeout: 200
+        when:
           - ansible_distribution == 'Amazon'
           - ansible_distribution_major_version == '2'
 
@@ -40,6 +41,8 @@
   - name: RedHat/CentOS/Fedora | Install Indexer dependencies
     yum:
       name: "{{ packages }}"
+      state: present
+      lock_timeout: 200
     vars:
       packages:
       - wget


### PR DESCRIPTION
### Description

This PR addresses the issue encountered during the training deployment related to YUM lock when installing packages. The error message indicated that the YUM lockfile was held by another process. 

Find more information about this in the 
Related Issue: https://github.com/wazuh/wazuh-automation/issues/2060
