### PR TITLE
Correct  re-register of filebeat_module_folder

### DIFF
--- a/roles/wazuh/ansible-filebeat-oss/tasks/main.yml
+++ b/roles/wazuh/ansible-filebeat-oss/tasks/main.yml
@@ -28,24 +28,24 @@
 - name: Checking if Filebeat Module folder file exists
   stat:
     path: "{{ filebeat_module_folder }}"
-  register: filebeat_module_folder
+  register: filebeat_module_folder_info
 
 - name: Download Filebeat module package
   get_url:
     url: "{{ filebeat_module_package_url }}/{{ filebeat_module_package_name }}"
     dest: "{{ filebeat_module_package_path }}"
-  when: not filebeat_module_folder.stat.exists
+  when: not filebeat_module_folder_info.stat.exists
 
 - name: Unpack Filebeat module package
   unarchive:
     src: "{{ filebeat_module_package_path }}/{{ filebeat_module_package_name }}"
     dest: "{{ filebeat_module_destination }}"
     remote_src: yes
-  when: not filebeat_module_folder.stat.exists
+  when: not filebeat_module_folder_info.stat.exists
 
 - name: Setting 0755 permission for Filebeat module folder
   file: dest={{ filebeat_module_folder }} mode=u=rwX,g=rwX,o=rwX recurse=yes
-  when: not filebeat_module_folder.stat.exists
+  when: not filebeat_module_folder_info.stat.exists
 
 - name: Checking if Filebeat Module package file exists
   stat:


### PR DESCRIPTION
The variable ``filebeat_module_folder`` was re-registered as its stat output, leading to an incorrect filepath being used later on.