### PR TITLE
Add agent-upgrade to wazuh-agent role

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -352,6 +352,17 @@ wazuh_agent_active_response:
   ca_store_macos: 'etc/wpk_root.pem'
   ca_verification: 'yes'
 
+## Agent Upgrade
+wazuh_agent_agent_upgrade:
+  enabled: 'yes'
+  notification_wait_start: '60s'
+  notification_wait_factor: '4'
+  notification_wait_max: '2h'
+  ca_verification: 'yes'
+  ca_store: "{{ wazuh_dir }}/etc/wpk_root.pem"
+  ca_store_win: 'wpk_root.pem'
+  ca_store_macos: 'etc/wpk_root.pem'
+
 ## Logging
 wazuh_agent_log_format: 'plain'
 
@@ -359,6 +370,7 @@ wazuh_agent_log_format: 'plain'
 wazuh_agent_config_defaults:
   repo: '{{ wazuh_repo }}'
   active_response: '{{ wazuh_agent_active_response }}'
+  agent_upgrade: '{{ wazuh_agent_agent_upgrade }}'
   log_format: '{{ wazuh_agent_log_format }}'
   client_buffer: '{{ wazuh_agent_client_buffer }}'
   syscheck: '{{ wazuh_agent_syscheck }}'

--- a/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
+++ b/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
@@ -472,9 +472,9 @@
   <active-response>
     <disabled>{{ wazuh_agent_config.active_response.ar_disabled|default('no') }}</disabled>
     <ca_verification>{{ wazuh_agent_config.active_response.ca_verification }}</ca_verification>
-    {% if ansible_system == "Windows" %}
+    {% if ansible_os_family == "Windows" %}
     <ca_store>{{ wazuh_agent_config.active_response.ca_store_win }}</ca_store>
-    {% elif ansible_system == "Darwin" %}
+    {% elif ansible_os_family == "Darwin" %}
     <ca_store>{{ wazuh_agent_config.active_response.ca_store_macos }}</ca_store>
     {% else %}
     <ca_store>{{ wazuh_agent_config.active_response.ca_store }}</ca_store>
@@ -484,5 +484,22 @@
   <logging>
     <log_format>{{ wazuh_agent_config.log_format }}</log_format>
   </logging>
+
+  <agent-upgrade>
+    <enabled>{{ wazuh_agent_config.agent_upgrade.enabled }}</enabled>
+    <notification_wait_start>{{ wazuh_agent_config.agent_upgrade.notification_wait_start }}</notification_wait_start>
+    <notification_wait_factor>{{ wazuh_agent_config.agent_upgrade.notification_wait_factor }}</notification_wait_factor>
+    <notification_wait_max>{{ wazuh_agent_config.agent_upgrade.notification_wait_max }}</notification_wait_max>
+    <ca_verification>
+      <enabled>{{ wazuh_agent_config.agent_upgrade.ca_verification }}</enabled>
+      {% if ansible_os_family == "Windows" %}
+      <ca_store>{{ wazuh_agent_config.agent_upgrade.ca_store_win }}</ca_store>
+      {% elif ansible_os_family == "Darwin" %}
+      <ca_store>{{ wazuh_agent_config.agent_upgrade.ca_store_macos }}</ca_store>
+      {% else %}
+      <ca_store>{{ wazuh_agent_config.agent_upgrade.ca_store }}</ca_store>
+      {% endif %}
+    </ca_verification>
+  </agent-upgrade>
 
 </ossec_config>

--- a/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
+++ b/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
@@ -471,16 +471,14 @@
 
   <active-response>
     <disabled>{{ wazuh_agent_config.active_response.ar_disabled|default('no') }}</disabled>
-    <ca_store>
-    {% if ansible_os_family == "Windows" %}{{ wazuh_agent_config.active_response.ca_store_win }}
-    {% else %}
-    {% if ansible_system == "Darwin" %}{{ wazuh_agent_config.active_response.ca_store_macos }}
-    {% else %}
-    {{ wazuh_agent_config.active_response.ca_store }}
-    {% endif %}
-    {% endif %}
-    </ca_store>
     <ca_verification>{{ wazuh_agent_config.active_response.ca_verification }}</ca_verification>
+    {% if ansible_system == "Windows" %}
+    <ca_store>{{ wazuh_agent_config.active_response.ca_store_win }}</ca_store>
+    {% elif ansible_system == "Darwin" %}
+    <ca_store>{{ wazuh_agent_config.active_response.ca_store_macos }}</ca_store>
+    {% else %}
+    <ca_store>{{ wazuh_agent_config.active_response.ca_store }}</ca_store>
+    {% endif %}
   </active-response>
 
   <logging>

--- a/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
+++ b/roles/wazuh/ansible-wazuh-agent/templates/var-ossec-etc-ossec-agent.conf.j2
@@ -83,7 +83,6 @@
       {% endif %}
     </enrollment>
   {% endif %}
-
   </client>
 
   <client_buffer>
@@ -121,11 +120,8 @@
     <windows_apps>./shared/win_applications_rcl.txt</windows_apps>
     <windows_malware>./shared/win_malware_rcl.txt</windows_malware>
     {% endif %}
-
-
   </rootcheck>
   {% endif %}
-
 
   {% if ansible_system == "Linux" and wazuh_agent_config.openscap.disable == 'no' %}
   <wodle name="open-scap">
@@ -256,8 +252,7 @@
   {% endif %}
   </sca>
 
-
-  <!-- Directories to check  (perform all possible verifications) -->
+  <!-- Directories to check (perform all possible verifications) -->
   {% if wazuh_agent_config.syscheck is defined %}
   <syscheck>
     <disabled>no</disabled>
@@ -359,7 +354,6 @@
   <!-- Files to monitor (localfiles) -->
   {% if ansible_system == "Linux" %}
   {% for localfile in wazuh_agent_config.localfiles.linux %}
-
   <localfile>
     <log_format>{{ localfile.format }}</log_format>
     {% if localfile.format == 'command' or localfile.format == 'full_command' %}
@@ -386,7 +380,6 @@
 
   {% if ansible_system == "Darwin" %}
   {% for localfile in wazuh_agent_config.localfiles.macos %}
-
   <localfile>
     <log_format>{{ localfile.format }}</log_format>
     {% if localfile.format == 'command' or localfile.format == 'full_command' %}
@@ -407,7 +400,6 @@
 
   {% if ansible_os_family == "Debian" %}
   {% for localfile in wazuh_agent_config.localfiles.debian %}
-
   <localfile>
       <log_format>{{ localfile.format }}</log_format>
     {% if localfile.format == 'command' or localfile.format == 'full_command' %}
@@ -430,7 +422,6 @@
 
   {% if ansible_os_family == "RedHat" %}
   {% for localfile in wazuh_agent_config.localfiles.centos %}
-
   <localfile>
       <log_format>{{ localfile.format }}</log_format>
     {% if localfile.format == 'command' or localfile.format == 'full_command' %}
@@ -453,7 +444,6 @@
 
   {% if ansible_os_family == "Windows" %}
   {% for localfile in wazuh_agent_config.localfiles.windows %}
-
   <localfile>
       <log_format>{{ localfile.format }}</log_format>
   {% if localfile.format == 'eventchannel' %}
@@ -471,13 +461,13 @@
   {% endfor %}
   {% endif %}
 
-{% if wazuh_agent_config.labels.enable == true %}
+  {% if wazuh_agent_config.labels.enable == true %}
   <labels>
   {% for label in wazuh_agent_config.labels.list %}
     <label key="{{ label.key }}"{% if label.hidden is defined %} hidden="{{ label.hidden }}"{% endif %}>{{ label.value }}</label>
   {% endfor %}
   </labels>
-{% endif %}
+  {% endif %}
 
   <active-response>
     <disabled>{{ wazuh_agent_config.active_response.ar_disabled|default('no') }}</disabled>


### PR DESCRIPTION
This allows deploying with the agent with Ansible, but upgrading centrally via the manager.

Incudes fix for #1501