### PR TITLE
Add ansible-galaxy support with galaxy.yml and runtime.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,0 +1,64 @@
+### REQUIRED
+# The namespace of the collection. This can be a company/brand/organization or product namespace under which all
+# content lives. May only contain alphanumeric lowercase characters and underscores. Namespaces cannot start with
+# underscores or numbers and cannot contain consecutive underscores
+namespace: wazuh
+
+# The name of the collection. Has the same character restrictions as 'namespace'
+name: wazuh
+
+# The version of the collection. Must be compatible with semantic versioning
+version: 5.0.0
+
+# The path to the Markdown (.md) readme file. This path is relative to the root of the collection
+readme: README.md
+
+# A list of the collection's content authors. Can be just the name or in the format 'Full Name <email> (url)
+# @nicks:irc/im.site#channel'
+authors:
+  - Wazuh Team
+  - Wazuh Community
+
+### OPTIONAL but strongly recommended
+# A short summary description of the collection
+description: Installing, deploying and configuring Wazuh Manager.
+
+# The path to the license file for the collection. This path is relative to the root of the collection. This key is
+# mutually exclusive with 'license'
+license_file: 'LICENSE'
+
+# A list of tags you want to associate with the collection for indexing/searching. A tag name has the same character
+# requirements as 'namespace' and 'name'
+tags:
+  - security
+  - monitoring
+  - siem
+  - wazuh
+  - log-collection
+  - intrusion-detection
+  - compliance
+  - ossim
+
+# Collections that this collection requires to be installed for it to be usable. The key of the dict is the
+# collection label 'namespace.name'. The value is a version range
+# L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
+# range specifiers can be set and are separated by ','
+dependencies: {}
+
+# The URL of the originating SCM repository
+repository: https://github.com/wazuh/wazuh-ansible
+
+# The URL to any online docs
+documentation: https://github.com/wazuh/wazuh-ansible/blob/main/README.md
+
+# The URL to the homepage of the collection/project
+homepage: https://wazuh.com
+
+# The URL to the collection issue tracker
+issues: https://github.com/wazuh/wazuh-ansible/issues
+
+# A list of file glob-like patterns used to filter any files or directories that should not be included in the build
+# artifact. A pattern is matched from the relative path of the file or directory of the collection directory. This
+# uses 'fnmatch' to match the files or directories. Some directories and files like 'galaxy.yml', '*.pyc', '*.retry',
+# and '.git' are always filtered
+build_ignore: []

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,52 @@
+---
+# Collections must specify a minimum required ansible version to upload
+# to galaxy
+requires_ansible: '>=2.9.10'
+
+# Content that Ansible needs to load from another location or that has
+# been deprecated/removed
+# plugin_routing:
+#   action:
+#     redirected_plugin_name:
+#       redirect: ns.col.new_location
+#     deprecated_plugin_name:
+#       deprecation:
+#         removal_version: "4.0.0"
+#         warning_text: |
+#           See the porting guide on how to update your playbook to
+#           use ns.col.another_plugin instead.
+#     removed_plugin_name:
+#       tombstone:
+#         removal_version: "2.0.0"
+#         warning_text: |
+#           See the porting guide on how to update your playbook to
+#           use ns.col.another_plugin instead.
+#   become:
+#   cache:
+#   callback:
+#   cliconf:
+#   connection:
+#   doc_fragments:
+#   filter:
+#   httpapi:
+#   inventory:
+#   lookup:
+#   module_utils:
+#   modules:
+#   netconf:
+#   shell:
+#   strategy:
+#   terminal:
+#   test:
+#   vars:
+
+# Python import statements that Ansible needs to load from another location
+# import_redirection:
+#   ansible_collections.ns.col.plugins.module_utils.old_location:
+#     redirect: ansible_collections.ns.col.plugins.module_utils.new_location
+
+# Groups of actions/modules that take a common set of options
+# action_groups:
+#   group_name:
+#     - module1
+#     - module2


### PR DESCRIPTION
Adds required dependancy to allow role to be installed with ansible-galaxy:

* Added galaxy.yml with role metadata and tags
* Added meta/runtime.yml to define minimal supported Ansible version