### PR TITLE
Refactor of the wazuh-aio playbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Refactor of the wazuh-aio playbook ([#1585](https://github.com/wazuh/wazuh-ansible/pull/1585))
 - Refactor of the wazuh-server ansible role ([#1579](https://github.com/wazuh/wazuh-ansible/pull/1579))
 - Refactor of the wazuh-dashboard ansible role ([#1565](https://github.com/wazuh/wazuh-ansible/pull/1565))
 - Corrections for wazuh-indexer role refactoring ([#1563](https://github.com/wazuh/wazuh-ansible/pull/1563))

--- a/wazuh-aio.yml
+++ b/wazuh-aio.yml
@@ -1,1 +1,15 @@
+---
 
+- hosts: aio
+  become: yes
+  roles:
+    - role: wazuh-indexer
+    - role: wazuh-server
+    - role: wazuh-dashboard
+  vars:
+    single_node: true
+    instances:
+      aio:
+        name: node-1
+        ip: "{{ hostvars.aio.private_ip }}"
+        role: aio


### PR DESCRIPTION
# Description

This PR aims to introduce a new Ansible playbook, `wazuh-aio.yml`, designed to facilitate the setup of a single-node Wazuh cluster. 

## Related Issues
- #1525
