### PR TITLE
Add package URLs role for AIO and distributed setups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
-*.retry
-*.pyc
-.mypy_cache
-Pipfile.lock
-*.swp
-molecule/**/es_certs/
-molecule/**/opendistro/
+roles/vars/urls.yml
+deployment-config-files/
+*.pem
+*.ini

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Add package URLs role for AIO and distributed setups ([#1588](https://github.com/wazuh/wazuh-ansible/pull/1588))
 - Refactor of the wazuh-distributed playbook ([#1584](https://github.com/wazuh/wazuh-ansible/pull/1584))
 - Refactor of the wazuh-aio playbook ([#1585](https://github.com/wazuh/wazuh-ansible/pull/1585))
 - Refactor of the wazuh-server ansible role ([#1579](https://github.com/wazuh/wazuh-ansible/pull/1579))

--- a/roles/package-urls/defaults/main.yml
+++ b/roles/package-urls/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+source: "production"
+package_urls_file_uri: "packages.wazuh.com/{{ wazuh_major_minor_version }}/package_urls.txt"
+package_urls_file_uri_prerelease: "packages-dev.wazuh.com/{{ wazuh_major_minor_version }}/package_urls.txt"

--- a/roles/package-urls/tasks/main.yml
+++ b/roles/package-urls/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+
+- include_vars: ../../vars/main.yml
+
+- name: Download package URLs file
+  get_url:
+    url: "https://{{ package_urls_file_uri_prerelease if source == 'prerelease' else package_urls_file_uri }}"
+    dest: "{{ playbook_dir }}/roles/vars/urls.yml"
+  when: source in ['production', 'prerelease']
+  run_once: true
+  delegate_to: localhost
+  become: no

--- a/wazuh-aio.yml
+++ b/wazuh-aio.yml
@@ -3,6 +3,7 @@
 - hosts: aio
   become: yes
   roles:
+    - role: package-urls
     - role: wazuh-indexer
     - role: wazuh-server
     - role: wazuh-dashboard

--- a/wazuh-distributed.yml
+++ b/wazuh-distributed.yml
@@ -1,7 +1,14 @@
 ---
 
+- hosts: localhost
+  roles:
+    - role: package-urls
+  run_once: true
+  become: no
+
 - hosts: wi_cluster
   roles:
+    - role: package-urls
     - role: wazuh-indexer
   become: yes
   vars:


### PR DESCRIPTION
# Description

This PR aims to merge changes introducing a new Ansible role capable of generating a file with the URLs for the packages of each Wazuh component.

## Related issue

- #1587 