### PR TITLE
Add gnupg dependency to indexer, filebeat-oss, and dashboard roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Update the Filebeat installation for arm64 to include revision ([#1616](https://github.com/wazuh/wazuh-ansible/pull/1616))
+- Add gnupg dependency to indexer, filebeat-oss, and dashboard roles ([#1623](https://github.com/wazuh/wazuh-ansible/pull/1623))
 
 ### Deleted
 

--- a/roles/wazuh/ansible-filebeat-oss/tasks/Debian.yml
+++ b/roles/wazuh/ansible-filebeat-oss/tasks/Debian.yml
@@ -1,10 +1,11 @@
 ---
-- name: Debian/Ubuntu | Install apt-transport-https, ca-certificates and acl
+- name: Debian/Ubuntu | Install apt-transport-https, ca-certificate, acl and gnupg
   apt:
     name:
       - apt-transport-https
       - ca-certificates
       - acl
+      - gnupg
     state: present
   register: filebeat_ca_packages_install
   until: filebeat_ca_packages_install is succeeded

--- a/roles/wazuh/wazuh-dashboard/tasks/Debian.yml
+++ b/roles/wazuh/wazuh-dashboard/tasks/Debian.yml
@@ -6,7 +6,13 @@
     get_url:
       url: "{{ wazuh_repo.gpg }}"
       dest: "{{ wazuh_repo.path }}"
-  
+
+  - name: Debian/Ubuntu | Install gnupg
+    apt:
+      name:
+        - gnupg
+      state: present
+
   - name: Import Wazuh repository GPG key
     command: "gpg --no-default-keyring --keyring gnupg-ring:{{ wazuh_repo.keyring_path }} --import {{ wazuh_repo.path }}"
     args:

--- a/roles/wazuh/wazuh-indexer/tasks/Debian.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/Debian.yml
@@ -5,16 +5,16 @@
   apt:
     update_cache: yes
 
-- name: Debian 9 (Stretch)
-  when: (ansible_facts['distribution'] == "Debian" and ansible_facts['distribution_major_version'] == "9")
-  block:
-
-    - name: Install Wazuh indexer dependencies
-      apt:
-        name: [
-          'unzip', 'wget', 'curl', 'apt-transport-https', software-properties-common
-        ]
-        state: present
+- name: Install Wazuh indexer dependencies
+  apt:
+    name:
+      - unzip
+      - wget
+      - curl
+      - apt-transport-https
+      - software-properties-common
+      - gnupg
+    state: present
 
 - name: Add Wazuh indexer repository
   block:
@@ -22,7 +22,7 @@
       get_url:
         url: "{{ wazuh_repo.gpg }}"
         dest: "{{ wazuh_repo.path }}"
-  
+
     - name: Import Wazuh repository GPG key
       command: "gpg --no-default-keyring --keyring gnupg-ring:{{ wazuh_repo.keyring_path }} --import {{ wazuh_repo.path }}"
       args:


### PR DESCRIPTION
# Description

This pull request seeks to incorporate the gnupg dependency into the indexer, filebeat-oss, and dashboard roles.

## Related issue

- #1622 