### PR TITLE
Remove root-ca.key from the list of certificates copied to indexer nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this project will be documented in this file.
 
 ### Deleted
 
-- None
+- Remove root-ca.key from the list of certificates copied to indexer nodes ([#1653](https://github.com/wazuh/wazuh-ansible/pull/1653))
 
 ## [4.12.1]
 

--- a/roles/wazuh/wazuh-indexer/tasks/security_actions.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/security_actions.yml
@@ -27,7 +27,6 @@
     mode: 0400
   with_items:
     - root-ca.pem
-    - root-ca.key
     - "{{ indexer_node_name }}-key.pem"
     - "{{ indexer_node_name }}.pem"
     - admin-key.pem


### PR DESCRIPTION
## Related issue 

- #1578