### PR TITLE
Add missing `malicious-ioc` ruleset lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Add missing malicious-ioc ruleset lists ([#1685](https://github.com/wazuh/wazuh-ansible/pull/1685))
 - Integrate bumper script via GitHub action. ([#1676](https://github.com/wazuh/wazuh-ansible/pull/1676))
 - Added repository_bumper.sh script. ([#1621](https://github.com/wazuh/wazuh-ansible/pull/1621))
 

--- a/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
@@ -296,6 +296,9 @@ wazuh_manager_ruleset:
     - 'audit-keys'
     - 'security-eventchannel'
     - 'amazon/aws-eventnames'
+    - 'malicious-ioc/malicious-ip'
+    - 'malicious-ioc/malicious-domains'
+    - 'malicious-ioc/malware-hashes'
 
 wazuh_manager_rule_exclude:
   - '0215-policy_rules.xml'


### PR DESCRIPTION
# Description

This PR aims to add the new lists to the `ossec.conf` section of ossec.conf

## Tests 

- https://github.com/wazuh/wazuh-ansible/issues/1684#issuecomment-2957063502