### PR TITLE
Update apt cache before install packages

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/main.yml
@@ -2,6 +2,12 @@
 
 - name: "Install dependencies"
   block:
+    - name: Update apt cache on Debian based systems
+      apt:
+        update_cache: true
+        cache_valid_time: 3600
+      when: ansible_os_family == "Debian"
+
     - name: "Install common dependencies"
       package:
         name:


### PR DESCRIPTION
This change fixes an issue with installing base packages when the apt cache is not updated. In such cases, packages cannot be downloaded.

Example error:

text
Err:2 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 curl amd64 8.5.0-2ubuntu10.1  404  Not Found

Ansible checks the date of the last apt cache update and refreshes it when it is outdated.

This change applies only to Debian-based distributions.