### PR TITLE
Packages-dev bucket migration to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Replace OpenSearch deprecated settings ([#1699](https://github.com/wazuh/wazuh-ansible/pull/1699))
+
+- Bucket migrate from packages-dev.wazuh.com to xdrsiem-packages-dev ([#1714](https://github.com/wazuh/wazuh-ansible/pull/1714))- Replace OpenSearch deprecated settings ([#1699](https://github.com/wazuh/wazuh-ansible/pull/1699))
 
 ### Fixed
 

--- a/roles/wazuh/check-packages/scripts/check_packages.sh
+++ b/roles/wazuh/check-packages/scripts/check_packages.sh
@@ -19,7 +19,7 @@ checkPackages(){
         CHECK_WIN_PACKAGE=$(grep windows ../files/packages_uri_new.txt)
         echo $CHECK_WIN_PACKAGE
         if [ -n "$CHECK_WIN_PACKAGE" ]; then
-            WIN_AGENT_NAME=$(aws s3 ls s3://packages-dev.wazuh.com/staging/windows/wazuh-agent-$VERSION --region=us-west-1 | tail -1 | awk '{printf $4}')
+            WIN_AGENT_NAME=$(aws s3 ls s3://xdrsiem-packages-dev/staging/windows/wazuh-agent-$VERSION --region=us-west-1 | tail -1 | awk '{printf $4}')
             if [ -z $WIN_AGENT_NAME ]; then
                 echo "Windows agent package for version " $VERSION " does not exist in the staging repository"
                 exit 1


### PR DESCRIPTION
Related to https://github.com/wazuh/internal-devel-requests/issues/2577

### Description

The objective of this PR is to migrate the packages-dev.wazuh.com bucket to xdrsiem-packages-dev new bucket name.