### PR TITLE
fix(debian): use curl for Wazuh repo GPG key on Debian 13 to avoid ur…

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
@@ -44,6 +44,26 @@
     dest: "{{ wazuh_agent_config.repo.path }}"
   when:
     - not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int == 14)
+    - not (ansible_distribution == "Debian" and ansible_distribution_major_version | int == 13)
+    - not wazuh_custom_packages_installation_agent_enabled
+
+- name: Debian 13 | Download Wazuh repository key (curl)
+  ansible.builtin.command:
+    argv:
+      - curl
+      - -fsSL
+      - --retry
+      - "5"
+      - --connect-timeout
+      - "10"
+      - "{{ wazuh_agent_config.repo.gpg }}"
+      - -o
+      - "{{ wazuh_agent_config.repo.path }}"
+  args:
+    creates: "{{ wazuh_agent_config.repo.path }}"
+  when:
+    - ansible_distribution == "Debian"
+    - (ansible_distribution_major_version | int) == 13
     - not wazuh_custom_packages_installation_agent_enabled
 
 - name: Debian/Ubuntu | Import Wazuh GPG key


### PR DESCRIPTION
On Debian 13 (Trixie), Ansible's `get_url` can fail downloading the Wazuh GPG key
with: `HTTPSConnection.__init__() got an unexpected keyword argument 'cert_file'`
(due to a requests/urllib3 incompatibility). This prevents repository setup.

Changes:
- Skip the `get_url` path on Debian 13 and fetch the key with `curl` (`-fsSL`,
  `--retry 5`, `--connect-timeout 10`).
- Keep the original `get_url` task for other Debian/Ubuntu versions.
- Make the `curl` task idempotent via `creates: {{ wazuh_agent_config.repo.path }}`.
- Preserve the existing guard for Ubuntu 14 and `wazuh_custom_packages_installation_agent_enabled`.

Scope:
- File: `roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml`
- Adds Debian-13 specific task “Download Wazuh repository key (curl)”
- Extends the `when` of the original task to exclude Debian 13

Impact:
- Debian 13 hosts successfully obtain the repo GPG key without hitting the urllib3 error.
- No behavior change for other supported Debian/Ubuntu versions.

Testing:
- Debian 13: first run downloads the key with `curl`; subsequent runs are `ok` due to `creates:`.
- Ubuntu 22.04/24.04 and Debian ≤12: still use `get_url` and remain idempotent.

Notes:
- Key path and subsequent import step remain unchanged.
- This is a tactical fix; long-term we may revisit with a unified, dearmored keyring flow (Deb822 + Signed-By).

The sample Error:
- fatal: [hos-1]: FAILED! => {"changed": false, "dest": "/tmp/WAZUH-GPG-KEY", "elapsed": 0, "gid": 0, "group": "root", "mode": "0640", "msg": "An unknown error occurred: HTTPSConnection.__init__() got an unexpected keyword argument 'cert_file'", "owner": "root", "size": 3141, "state": "file", "uid": 0, "url": "https://packages.wazuh.com/key/GPG-KEY-WAZUH"