### PR TITLE
Allow multiple api users to configured for ansible-wazuh-manager

### DIFF
--- a/roles/wazuh/ansible-wazuh-manager/templates/admin.json.j2
+++ b/roles/wazuh/ansible-wazuh-manager/templates/admin.json.j2
@@ -1,4 +1,9 @@
-
+[
 {% for api in wazuh_api_users %}
-{"username":"{{ api['username'] }}", "password": "{{ api['password'] }}"}
+  {
+    "username": "{{ api.username }}",
+    "password": "{{ api.password }}"
+  }{% if not loop.last %},{% endif %}
+
 {% endfor %}
+]


### PR DESCRIPTION
As describe in https://github.com/wazuh/wazuh-ansible/issues/1132 the current ansible-wazuh-manager role will not accept multiple users being indicated in the var `wazuh_api_users` 

If more than one key is supplied to this var, the `admin.json.j2` will generate invalid JSON, and the `create_users.py` will be unable to process the file. 

This PR changes these two files to fully support configuring multiple users in `wazuh_api_users`