### PR TITLE
Wwazuh-Indexer: Set index data path using the existing indexer_index_path var

### DIFF
--- a/roles/wazuh/wazuh-indexer/tasks/main.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/main.yml
@@ -49,6 +49,15 @@
         force: yes
       tags: install
 
+    - name: Creates index directory
+      file:
+        path: "{{ indexer_index_path }}"
+        state: directory
+        owner: root
+        group: wazuh-indexer
+        mode: 0775
+        recurse: yes
+
     - include_tasks: security_actions.yml
       tags:
         - security

--- a/roles/wazuh/wazuh-indexer/templates/opensearch.yml.j2
+++ b/roles/wazuh/wazuh-indexer/templates/opensearch.yml.j2
@@ -19,7 +19,7 @@ cluster.name: {{ indexer_cluster_name }}
 http.port: 9200-9299
 transport.tcp.port: 9300-9399
 node.max_local_storage_nodes: "3"
-path.data: /var/lib/wazuh-indexer
+path.data: {{ indexer_index_path }}
 path.logs: /var/log/wazuh-indexer
 
 


### PR DESCRIPTION
Indexer path is currently set via a var in **wazuh-indexer/defaults/main.yml** `indexer_index_path: /var/lib/wazuh-indexer/`

This PR ensures that:
1. The directory specified by the var exists
2. Configures **opensearch.yml.j2** `path.data` to use this var, instead of a hardcoded path.