### PR TITLE
ansible-wazuh-agent - force creation of local wazuh agent configuration files

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/Linux.yml
@@ -211,6 +211,7 @@
     owner: root
     group: wazuh
     mode: 0644
+    force: true
   notify: restart wazuh-agent
   tags:
     - init
@@ -223,6 +224,7 @@
     owner: root
     group: wazuh
     mode: 0640
+    force: true
   notify: restart wazuh-agent
   tags:
     - init
@@ -234,6 +236,7 @@
     dest: "{{ wazuh_dir }}/etc/authd.pass"
     owner: wazuh
     group: wazuh
+    force: true
     mode: 0640
   when:
     - wazuh_agent_config.enrollment.enabled == 'yes'


### PR DESCRIPTION
Add `force: true` flag on **create config file tasks** to ensure the creation/overwrite of agent configuration files succeeds on future re-runs of this role.