### PR TITLE
Update security_actions of indexer-role to work with Ansible 12

### DIFF
--- a/roles/wazuh/wazuh-indexer/tasks/security_actions.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/security_actions.yml
@@ -114,5 +114,5 @@
   register: result
   until: result.status in [200,201,401]
   when:
-    - indexer_custom_user is defined and indexer_custom_user
+    - indexer_custom_user is defined and indexer_custom_user != ""
     - inventory_hostname == ansible_play_hosts[0]


### PR DESCRIPTION
this is my first PR ever. no idea if I am doing it completely right - feedback appreciated.

Ansible 12 changes how conditionals work - https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_12.html

using the 4.14.1 branch and the ansible install guide in the documentation the indexer role fails when running the playbook.

> Error: [ERROR]: Task failed: Conditional result (False) was derived from value of type 'str' at '[...]/wazuh-ansible/roles/wazuh/wazuh-indexer/defaults/main.yml:35:22'. Conditionals must have a boolean result.

> Origin: [...]/wazuh-ansible/roles/wazuh/wazuh-indexer/tasks/security_actions.yml:117:7
>
>115   until: result.status in [200,201,401]
116   when:
117     - indexer_custom_user is defined and indexer_custom_user
          ^ column 7

suggested changes are based on my conclusion, that the aim of the check is "exists and is not empty" (in contrast to "exists and is faulty"). I might be wrong.

**sidenote:** I found another occurrence "roles/wazuh/ansible-wazuh-manager/tasks/main.yml:245" where I did not understand the context enough to dare a PR