### PR TITLE
fix: resolve ansible lint warnings for wazuh-dashboard role

### DIFF
--- a/.github/playbooks/aio-wazuh.yml
+++ b/.github/playbooks/aio-wazuh.yml
@@ -51,7 +51,7 @@
     # 3. Wazuh dashboard
     - role: ../../roles/wazuh/wazuh-dashboard
       vars:
-        dashboard_node_name: "wazuh-dash01"
+        wazuh_dashboard_node_name: "wazuh-dash01"
   vars:
     instances:
       node1:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The hereunder example playbook uses the `wazuh-ansible` role to provision a prod
       roles:
         - role: ../roles/wazuh/wazuh-indexer
           indexer_network_host: "{{ private_ip }}"
-          indexer_cluster_nodes:
+          wazuh_indexer_cluster_nodes:
             - "{{ hostvars.wi1.private_ip }}"
             - "{{ hostvars.wi2.private_ip }}"
             - "{{ hostvars.wi3.private_ip }}"
@@ -124,7 +124,7 @@ The hereunder example playbook uses the `wazuh-ansible` role to provision a prod
       become: yes
       become_user: root
       vars:
-        indexer_cluster_nodes:
+        wazuh_indexer_cluster_nodes:
           - "{{ hostvars.wi1.private_ip }}"
           - "{{ hostvars.wi2.private_ip }}"
           - "{{ hostvars.wi3.private_ip }}"
@@ -231,7 +231,7 @@ The hereunder example playbook uses the `wazuh-ansible` role to provision a prod
       become_user: root
       vars:
         indexer_network_host: "{{ hostvars.wi1.private_ip }}"
-        dashboard_node_name: node-6
+        wazuh_dashboard_node_name: node-6
         wazuh_api_credentials:
           - id: default
             url: https://{{ hostvars.manager.private_ip }}

--- a/playbooks/wazuh-production-ready.yml
+++ b/playbooks/wazuh-production-ready.yml
@@ -4,7 +4,7 @@
       roles:
         - role: ../roles/wazuh/wazuh-indexer
           indexer_network_host: "{{ private_ip }}"
-          indexer_cluster_nodes:
+          wazuh_indexer_cluster_nodes:
             - "{{ hostvars.wi1.private_ip }}"
             - "{{ hostvars.wi2.private_ip }}"
             - "{{ hostvars.wi3.private_ip }}"
@@ -55,7 +55,7 @@
       become: yes
       become_user: root
       vars:
-        indexer_cluster_nodes:
+        wazuh_indexer_cluster_nodes:
           - "{{ hostvars.wi1.private_ip }}"
           - "{{ hostvars.wi2.private_ip }}"
           - "{{ hostvars.wi3.private_ip }}"
@@ -162,11 +162,11 @@
       become_user: root
       vars:
         indexer_network_host: "{{ hostvars.wi1.private_ip }}"
-        indexer_cluster_nodes:
+        wazuh_indexer_cluster_nodes:
           - "{{ hostvars.wi1.private_ip }}"
           - "{{ hostvars.wi2.private_ip }}"
           - "{{ hostvars.wi3.private_ip }}"
-        dashboard_node_name: node-6
+        wazuh_dashboard_node_name: node-6
         wazuh_api_credentials:
           - id: default
             url: https://{{ hostvars.manager.private_ip }}

--- a/roles/opendistro/opendistro-kibana/defaults/main.yml
+++ b/roles/opendistro/opendistro-kibana/defaults/main.yml
@@ -43,7 +43,7 @@ kibana_telemetry_enabled: "false"
 opendistro_admin_password: changeme
 opendistro_kibana_user: kibanaserver
 opendistro_kibana_password: changeme
-local_certs_path: "{{ playbook_dir }}/opendistro/certificates"
+wazuh_local_certs_path: "{{ playbook_dir }}/opendistro/certificates"
 
 # Nodejs
 nodejs:

--- a/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
+++ b/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
@@ -19,4 +19,4 @@ filebeat_security: true
 filebeat_ssl_dir: /etc/pki/filebeat
 
 # Local path to store the generated certificates (Opensearch security plugin)
-local_certs_path: "{{ playbook_dir }}/indexer/certificates"
+wazuh_local_certs_path: "{{ playbook_dir }}/indexer/certificates"

--- a/roles/wazuh/ansible-filebeat-oss/tasks/security_actions.yml
+++ b/roles/wazuh/ansible-filebeat-oss/tasks/security_actions.yml
@@ -10,7 +10,7 @@
 
   - name: Copy the certificates from local to the Manager instance
     copy:
-      src: "{{ local_certs_path }}/wazuh-certificates/{{ item }}"
+      src: "{{ wazuh_local_certs_path }}/wazuh-certificates/{{ item }}"
       dest: "{{ filebeat_ssl_dir }}"
       owner: root
       group: root

--- a/roles/wazuh/wazuh-dashboard/defaults/main.yml
+++ b/roles/wazuh/wazuh-dashboard/defaults/main.yml
@@ -1,19 +1,19 @@
 ---
 
 # Dashboard configuration
-indexer_http_port: 9200
-indexer_api_protocol: https
-dashboard_conf_path: /etc/wazuh-dashboard/
-dashboard_node_name: node-1
-dashboard_server_host: "0.0.0.0"
-dashboard_server_port: "443"
-dashboard_server_name: "dashboard"
-wazuh_version: 4.14.2
-indexer_cluster_nodes:
+wazuh_indexer_http_port: 9200
+wazuh_indexer_api_protocol: https
+wazuh_dashboard_conf_path: /etc/wazuh-dashboard/
+wazuh_dashboard_node_name: node-1
+wazuh_dashboard_server_host: "0.0.0.0"
+wazuh_dashboard_server_port: "443"
+wazuh_dashboard_server_name: "dashboard"
+wazuh_version: 4.14.1
+wazuh_indexer_cluster_nodes:
   - 127.0.0.1
 
 # The Wazuh dashboard package repository
-dashboard_version: "4.14.2"
+wazuh_dashboard_version: "4.14.1"
 
 # API credentials
 wazuh_api_credentials:
@@ -24,8 +24,8 @@ wazuh_api_credentials:
     password: "wazuh"
 
 # Dashboard Security
-dashboard_security: true
-indexer_admin_password: changeme
-dashboard_user: kibanaserver
-dashboard_password: changeme
-local_certs_path: "{{ playbook_dir }}/indexer/certificates"
+wazuh_dashboard_security: true
+wazuh_indexer_admin_password: changeme
+wazuh_dashboard_user: kibanaserver
+wazuh_dashboard_password: changeme
+wazuh_local_certs_path: "{{ playbook_dir }}/indexer/certificates"

--- a/roles/wazuh/wazuh-dashboard/handlers/main.yml
+++ b/roles/wazuh/wazuh-dashboard/handlers/main.yml
@@ -1,3 +1,5 @@
 ---
-- name: restart wazuh-dashboard
-  service: name=wazuh-dashboard state=restarted
+- name: Restart wazuh-dashboard
+  ansible.builtin.service:
+    name: wazuh-dashboard
+    state: restarted

--- a/roles/wazuh/wazuh-dashboard/tasks/Debian.yml
+++ b/roles/wazuh/wazuh-dashboard/tasks/Debian.yml
@@ -1,40 +1,50 @@
 ---
-- block:
-
-  - include_vars: debian.yml
-  - name: Download apt repository signing key
-    get_url:
-      url: "{{ wazuh_repo.gpg }}"
-      dest: "{{ wazuh_repo.path }}"
-
-  - name: Debian/Ubuntu | Install gnupg
-    apt:
-      name:
-        - gnupg
-      state: present
-
-  - name: Import Wazuh repository GPG key
-    command: "gpg --no-default-keyring --keyring gnupg-ring:{{ wazuh_repo.keyring_path }} --import {{ wazuh_repo.path }}"
-    args:
-      creates: "{{ wazuh_repo.keyring_path }}"
-
-  - name: Set permissions for Wazuh repository GPG key
-    file:
-      path: "{{ wazuh_repo.keyring_path }}"
-      mode: '0644'
-
-  - name: Debian systems | Add Wazuh dashboard repo
-    apt_repository:
-      repo: "{{ wazuh_repo.apt }}"
-      state: present
-      update_cache: yes
-
-  - name: Install Wazuh dashboard
-    apt:
-      name: "wazuh-dashboard={{ dashboard_version }}-*"
-      state: present
-      update_cache: yes
-    register: install
-
+- name: Debian/Ubuntu | Install Wazuh Dashboard
   tags:
     - install
+  block:
+    - name: Include Debian Variables
+      ansible.builtin.include_vars: debian.yml
+
+    - name: Download apt repository signing key
+      ansible.builtin.get_url:
+        url: "{{ wazuh_repo.gpg }}"
+        dest: "{{ wazuh_repo.path }}"
+        owner: root
+        group: root
+        mode: "0660"
+      become: true
+
+    - name: Debian/Ubuntu | Install gnupg
+      ansible.builtin.apt:
+        name:
+          - gnupg
+        state: present
+      become: true
+
+    - name: Import Wazuh repository GPG key
+      ansible.builtin.command: "gpg --no-default-keyring --keyring gnupg-ring:{{ wazuh_repo.keyring_path }} --import {{ wazuh_repo.path }}"
+      args:
+        creates: "{{ wazuh_repo.keyring_path }}"
+      become: true
+
+    - name: Set permissions for Wazuh repository GPG key
+      ansible.builtin.file:
+        path: "{{ wazuh_repo.keyring_path }}"
+        mode: '0644'
+      become: true
+
+    - name: Debian systems | Add Wazuh dashboard repo
+      ansible.builtin.apt_repository:
+        repo: "{{ wazuh_repo.apt }}"
+        state: present
+        update_cache: true
+      become: true
+
+    - name: Install Wazuh dashboard
+      ansible.builtin.apt:
+        name: "wazuh-dashboard={{ wazuh_dashboard_version }}-*"
+        state: present
+        update_cache: true
+      register: install
+      become: true

--- a/roles/wazuh/wazuh-dashboard/tasks/RMRedHat.yml
+++ b/roles/wazuh/wazuh-dashboard/tasks/RMRedHat.yml
@@ -1,6 +1,6 @@
 ---
 - name: Remove Wazuh dashboard repository (and clean up left-over metadata)
-  yum_repository:
+  ansible.builtin.yum_repository:
     name: wazuh_repo
     state: absent
   changed_when: false

--- a/roles/wazuh/wazuh-dashboard/tasks/RedHat.yml
+++ b/roles/wazuh/wazuh-dashboard/tasks/RedHat.yml
@@ -1,20 +1,19 @@
 ---
-- block:
-
-  - name: RedHat/CentOS/Fedora | Add Wazuh dashboard repo
-    yum_repository:
-      name: wazuh_repo
-      description: Wazuh yum repository
-      baseurl: "{{ wazuh_repo.yum }}"
-      gpgkey: "{{ wazuh_repo.gpg }}"
-      gpgcheck: true
-
-  - name: Install Wazuh dashboard
-    package:
-      name: "wazuh-dashboard-{{ dashboard_version }}"
-      state: present
-      update_cache: yes
-    register: install
-
+- name: Install Wazuh Dashboard
   tags:
     - install
+  block:
+    - name: RedHat/CentOS/Fedora | Add Wazuh dashboard repo
+      ansible.builtin.yum_repository:
+        name: wazuh_repo
+        description: Wazuh yum repository
+        baseurl: "{{ wazuh_repo.yum }}"
+        gpgkey: "{{ wazuh_repo.gpg }}"
+        gpgcheck: true
+
+    - name: Install Wazuh dashboard
+      ansible.builtin.package:
+        name: "wazuh-dashboard-{{ wazuh_dashboard_version }}"
+        state: present
+        update_cache: true
+      register: install

--- a/roles/wazuh/wazuh-dashboard/tasks/main.yml
+++ b/roles/wazuh/wazuh-dashboard/tasks/main.yml
@@ -1,99 +1,109 @@
 ---
-- include_vars: ../../vars/repo_vars.yml
+- name: Include Repository Variables
+  ansible.builtin.include_vars: ../../vars/repo_vars.yml
 
-- include_vars: ../../vars/repo.yml
+- name: Include Production Repository Variables
+  ansible.builtin.include_vars: ../../vars/repo.yml
   when: packages_repository == 'production'
 
-- include_vars: ../../vars/repo_pre-release.yml
+- name: Include Pre-Release Repository Variables
+  ansible.builtin.include_vars: ../../vars/repo_pre-release.yml
   when: packages_repository == 'pre-release'
 
-- include_vars: ../../vars/repo_staging.yml
+- name: Include Staging Repository Variables
+  ansible.builtin.include_vars: ../../vars/repo_staging.yml
   when: packages_repository == 'staging'
 
-- import_tasks: RedHat.yml
+- name: Red Hat/Centos | Install Wazuh Dashboard
+  ansible.builtin.import_tasks: RedHat.yml
   when: ansible_os_family == 'RedHat'
 
-- import_tasks: Debian.yml
+- name: Debian/Ubuntu | Install Wazuh Dashboard
+  ansible.builtin.import_tasks: Debian.yml
   when: ansible_os_family == 'Debian'
 
 - name: Remove Dashboard configuration file
-  file:
-    # noqa 503
-    path: "{{ dashboard_conf_path }}/opensearch_dashboards.yml"
+  ansible.builtin.file:
+    path: "{{ wazuh_dashboard_conf_path }}/opensearch_dashboards.yml"
     state: absent
   tags: install
 
-- import_tasks: security_actions.yml
+- name: Run Security Actions
+  ansible.builtin.import_tasks: security_actions.yml
 
 - name: Copy Configuration File
-  template:
+  ansible.builtin.template:
     src: "templates/opensearch_dashboards.yml.j2"
-    dest: "{{ dashboard_conf_path }}/opensearch_dashboards.yml"
+    dest: "{{ wazuh_dashboard_conf_path }}/opensearch_dashboards.yml"
     group: wazuh-dashboard
     owner: wazuh-dashboard
-    mode: 0640
-    force: yes
-  notify: restart wazuh-dashboard
+    mode: "0640"
+    force: true
+  notify: Restart wazuh-dashboard
   tags:
     - install
     - configure
 
 - name: Ensuring Wazuh dashboard directory owner
-  file:
-    # noqa 208
+  ansible.builtin.file:
     path: "/usr/share/wazuh-dashboard"
     state: directory
     owner: wazuh-dashboard
     group: wazuh-dashboard
-    recurse: yes
+    recurse: true
 
 - name: Wait for Wazuh-Indexer port
-  wait_for: host={{ indexer_network_host }} port={{ indexer_http_port }}
+  ansible.builtin.wait_for:
+    host: "{{ wazuh_indexer_network_host }}"
+    port: "{{ wazuh_indexer_http_port }}"
 
 - name: Select correct API protocol
-  set_fact:
-    indexer_api_protocol: "{% if dashboard_security is defined and dashboard_security %}https{% else %}http{% endif %}"
+  ansible.builtin.set_fact:
+    wazuh_indexer_api_protocol: "{% if wazuh_dashboard_security is defined and wazuh_dashboard_security %}https{% else %}http{% endif %}"
 
 - name: Attempting to delete legacy Wazuh index if exists
-  uri:
-    url: "{{ indexer_api_protocol }}://{{ indexer_network_host }}:{{ indexer_http_port }}/.wazuh"
+  ansible.builtin.uri:
+    url: "{{ wazuh_indexer_api_protocol }}://{{ wazuh_indexer_network_host }}:{{ wazuh_indexer_http_port }}/.wazuh"
     method: DELETE
     user: "admin"
-    password: "{{ indexer_admin_password }}"
-    validate_certs: no
+    password: "{{ wazuh_indexer_admin_password }}"
+    validate_certs: false
     status_code: 200, 404
 
 - name: Create Wazuh Plugin config directory
-  file:
+  ansible.builtin.file:
     path: /usr/share/wazuh-dashboard/data/wazuh/config/
     state: directory
-    recurse: yes
+    recurse: true
     owner: wazuh-dashboard
     group: wazuh-dashboard
-    mode: 0751
-  changed_when: False
+    mode: "0751"
+  changed_when: false
 
 - name: Configure Wazuh Dashboard Plugin
-  template:
+  ansible.builtin.template:
     src: wazuh.yml.j2
     dest: /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml
     owner: wazuh-dashboard
     group: wazuh-dashboard
-    mode: 0751
-  changed_when: False
+    mode: "0751"
+  changed_when: false
 
 - name: Configure opensearch.password in opensearch_dashboards.keystore
-  shell: >-
-    echo '{{ dashboard_password }}' | /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root add -f --stdin opensearch.password
+  ansible.builtin.shell: |
+    set -o pipefail
+    echo '{{ wazuh_dashboard_password }}' | /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root add -f --stdin opensearch.password
   args:
     executable: /bin/bash
-  become: yes
+  changed_when: false
+  become: true
 
 - name: Ensure Wazuh dashboard started and enabled
-  service:
+  ansible.builtin.service:
     name: wazuh-dashboard
     enabled: true
     state: started
 
-- import_tasks: RMRedHat.yml
+- name: Remove Red Hat repository
+  ansible.builtin.import_tasks: RMRedHat.yml
   when: ansible_os_family == 'RedHat'

--- a/roles/wazuh/wazuh-dashboard/tasks/security_actions.yml
+++ b/roles/wazuh/wazuh-dashboard/tasks/security_actions.yml
@@ -1,23 +1,23 @@
-- block:
-
-  - name: Ensure Dashboard certificates directory permissions.
-    file:
-      path: "/etc/wazuh-dashboard/certs/"
-      state: directory
-      owner: wazuh-dashboard
-      group: wazuh-dashboard
-      mode: 500
-
-  - name: Copy the certificates from local to the Wazuh dashboard instance
-    copy:
-      src: "{{ local_certs_path }}/wazuh-certificates/{{ item }}"
-      dest: /etc/wazuh-dashboard/certs/
-      owner: wazuh-dashboard
-      group: wazuh-dashboard
-      mode: 0400
-    with_items:
-      - "root-ca.pem"
-      - "{{ dashboard_node_name }}-key.pem"
-      - "{{ dashboard_node_name }}.pem"
+- name: Run Security Actions
   tags:
-  - security
+    - security
+  block:
+    - name: Ensure Dashboard certificates directory permissions.
+      ansible.builtin.file:
+        path: "/etc/wazuh-dashboard/certs/"
+        state: directory
+        owner: wazuh-dashboard
+        group: wazuh-dashboard
+        mode: "0500"
+
+    - name: Copy the certificates from local to the Wazuh dashboard instance
+      ansible.builtin.copy:
+        src: "{{ wazuh_local_certs_path }}/wazuh-certificates/{{ item }}"
+        dest: /etc/wazuh-dashboard/certs/
+        owner: wazuh-dashboard
+        group: wazuh-dashboard
+        mode: "0400"
+      with_items:
+        - "root-ca.pem"
+        - "{{ wazuh_dashboard_node_name }}-key.pem"
+        - "{{ wazuh_dashboard_node_name }}.pem"

--- a/roles/wazuh/wazuh-dashboard/templates/opensearch_dashboards.yml.j2
+++ b/roles/wazuh/wazuh-dashboard/templates/opensearch_dashboards.yml.j2
@@ -1,16 +1,16 @@
-server.host: {{ dashboard_server_host }}
-server.port: {{ dashboard_server_port }}
+server.host: {{ wazuh_dashboard_server_host }}
+server.port: {{ wazuh_dashboard_server_port }}
 opensearch.hosts:
-{% for item in indexer_cluster_nodes %}
-  - https://{{ item }}:{{ indexer_http_port }}
+{% for item in wazuh_indexer_cluster_nodes %}
+  - https://{{ item }}:{{ wazuh_indexer_http_port }}
 {% endfor %}
 opensearch.ssl.verificationMode: certificate
 opensearch.requestHeadersWhitelist: ["securitytenant","Authorization"]
 opensearch_security.multitenancy.enabled: false
 opensearch_security.readonly_mode.roles: ["kibana_read_only"]
 server.ssl.enabled: true
-server.ssl.key: "/etc/wazuh-dashboard/certs/{{ dashboard_node_name }}-key.pem"
-server.ssl.certificate: "/etc/wazuh-dashboard/certs/{{ dashboard_node_name }}.pem"
+server.ssl.key: "/etc/wazuh-dashboard/certs/{{ wazuh_dashboard_node_name }}-key.pem"
+server.ssl.certificate: "/etc/wazuh-dashboard/certs/{{ wazuh_dashboard_node_name }}.pem"
 opensearch.ssl.certificateAuthorities: ["/etc/wazuh-dashboard/certs/root-ca.pem"]
 uiSettings.overrides.defaultRoute: /app/wz-home
 # Session expiration settings

--- a/roles/wazuh/wazuh-dashboard/vars/debian.yml
+++ b/roles/wazuh/wazuh-dashboard/vars/debian.yml
@@ -1,2 +1,2 @@
 ---
-dashboard_version: 4.14.2
+wazuh_dashboard_version: 4.14.1

--- a/roles/wazuh/wazuh-indexer/defaults/main.yml
+++ b/roles/wazuh/wazuh-indexer/defaults/main.yml
@@ -12,12 +12,12 @@ indexer_node_data: true
 indexer_node_ingest: true
 indexer_start_timeout: 90
 
-indexer_cluster_nodes:
+wazuh_indexer_cluster_nodes:
   - 127.0.0.1
 indexer_discovery_nodes:
   - 127.0.0.1
 
-local_certs_path: "{{ playbook_dir }}/indexer/certificates"
+wazuh_local_certs_path: "{{ playbook_dir }}/indexer/certificates"
 
 # Minimum master nodes in cluster, 2 for 3 nodes Wazuh indexer cluster
 minimum_master_nodes: 2
@@ -38,10 +38,10 @@ indexer_custom_user_role: "admin"
 # Set JVM memory limits
 indexer_jvm_xms: null
 
-indexer_http_port: 9200
+wazuh_indexer_http_port: 9200
 
-indexer_admin_password: changeme
-dashboard_password: changeme
+wazuh_indexer_admin_password: changeme
+wazuh_dashboard_password: changeme
 
 # Deployment settings
 generate_certs: true

--- a/roles/wazuh/wazuh-indexer/tasks/local_actions.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/local_actions.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check if certificates already exists
   stat:
-    path: "{{ local_certs_path }}"
+    path: "{{ wazuh_local_certs_path }}"
   register: certificates_folder
   delegate_to: localhost
   become: no
@@ -13,31 +13,31 @@
 
   - name: Local action | Create local temporary directory for certificates generation
     file:
-      path: "{{ local_certs_path }}"
+      path: "{{ wazuh_local_certs_path }}"
       mode: 0755
       state: directory
 
   - name: Local action | Check that the generation tool exists
     stat:
-      path: "{{ local_certs_path }}/wazuh-certs-tool.sh"
+      path: "{{ wazuh_local_certs_path }}/wazuh-certs-tool.sh"
     register: tool_package
 
   - name: Local action | Download certificates generation tool
     get_url:
       url: "{{ certs_gen_tool_url }}"
-      dest: "{{ local_certs_path }}/wazuh-certs-tool.sh"
+      dest: "{{ wazuh_local_certs_path }}/wazuh-certs-tool.sh"
     when: not tool_package.stat.exists
 
   - name: Local action | Prepare the certificates generation template file
     template:
       src: "templates/config.yml.j2"
-      dest: "{{ local_certs_path }}/config.yml"
+      dest: "{{ wazuh_local_certs_path }}/config.yml"
       mode: 0644
     register: tlsconfig_template
 
   - name: Local action | Generate the node & admin certificates in local
     command: >-
-      bash {{ local_certs_path }}/wazuh-certs-tool.sh -A
+      bash {{ wazuh_local_certs_path }}/wazuh-certs-tool.sh -A
 
   run_once: true
   delegate_to: localhost

--- a/roles/wazuh/wazuh-indexer/tasks/main.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/main.yml
@@ -93,9 +93,9 @@
 
     - name: Wait for Wazuh indexer API
       uri:
-        url: "https://{{ inventory_hostname if not single_node else indexer_network_host }}:{{ indexer_http_port }}/_cat/health/"
+        url: "https://{{ inventory_hostname if not single_node else indexer_network_host }}:{{ wazuh_indexer_http_port }}/_cat/health/"
         user: "admin" # Default Indexer user is always "admin"
-        password: "{{ indexer_admin_password }}"
+        password: "{{ wazuh_indexer_admin_password }}"
         validate_certs: no
         status_code: 200,401
         return_content: yes
@@ -112,9 +112,9 @@
 
     - name: Wait for Wazuh indexer API (Private IP)
       uri:
-        url: "https://{{ hostvars[inventory_hostname]['private_ip'] if not single_node else indexer_network_host }}:{{ indexer_http_port }}/_cat/health/"
+        url: "https://{{ hostvars[inventory_hostname]['private_ip'] if not single_node else indexer_network_host }}:{{ wazuh_indexer_http_port }}/_cat/health/"
         user: "admin" # Default Indexer user is always "admin"
-        password: "{{ indexer_admin_password }}"
+        password: "{{ wazuh_indexer_admin_password }}"
         validate_certs: no
         status_code: 200,401
         return_content: yes

--- a/roles/wazuh/wazuh-indexer/tasks/security_actions.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/security_actions.yml
@@ -20,7 +20,7 @@
 
 - name: Copy the node & admin certificates to Wazuh indexer cluster
   copy:
-    src: "{{ local_certs_path }}/wazuh-certificates/{{ item }}"
+    src: "{{ wazuh_local_certs_path }}/wazuh-certificates/{{ item }}"
     dest: "{{ indexer_conf_path }}/certs/"
     owner: wazuh-indexer
     group: wazuh-indexer
@@ -48,8 +48,8 @@
   - name: Hashing the custom admin password
     shell: |
       export JAVA_HOME=/usr/share/wazuh-indexer/jdk
-      {{ indexer_sec_plugin_tools_path }}/hash.sh -p '{{ indexer_admin_password }}'
-    register: indexer_admin_password_hashed
+      {{ indexer_sec_plugin_tools_path }}/hash.sh -p '{{ wazuh_indexer_admin_password }}'
+    register: wazuh_indexer_admin_password_hashed
     no_log: '{{ indexer_nolog_sensible | bool }}'
 
   - name: Set the Admin user password
@@ -58,13 +58,13 @@
       regexp: '(?<=admin:\n  hash: )(.*)(?=)'
       replace: "{{ indexer_password_hash | quote }}"
     vars:
-      indexer_password_hash: "{{ indexer_admin_password_hashed.stdout_lines | last }}"
+      indexer_password_hash: "{{ wazuh_indexer_admin_password_hashed.stdout_lines | last }}"
 
   # this can also be achieved with password_hash, but it requires dependencies on the controller
   - name: Hash the kibanaserver role/user pasword
     shell: |
       export JAVA_HOME=/usr/share/wazuh-indexer/jdk
-      {{ indexer_sec_plugin_tools_path }}/hash.sh -p '{{ dashboard_password }}'
+      {{ indexer_sec_plugin_tools_path }}/hash.sh -p '{{ wazuh_dashboard_password }}'
     register: indexer_kibanaserver_password_hashed
     no_log: '{{ indexer_nolog_sensible | bool }}'
 
@@ -97,13 +97,13 @@
 
 - name: Create custom user
   uri:
-    url: "https://{{ target_address }}:{{ indexer_http_port }}/_plugins/_security/api/internalusers/{{ indexer_custom_user }}"
+    url: "https://{{ target_address }}:{{ wazuh_indexer_http_port }}/_plugins/_security/api/internalusers/{{ indexer_custom_user }}"
     method: PUT
     user: "admin" # Default Indexer user is always "admin"
-    password: "{{ indexer_admin_password }}"
+    password: "{{ wazuh_indexer_admin_password }}"
     body: |
       {
-        "password": "{{ indexer_admin_password }}",
+        "password": "{{ wazuh_indexer_admin_password }}",
         "backend_roles": ["{{ indexer_custom_user_role }}"]
       }
     body_format: json

--- a/roles/wazuh/wazuh-indexer/templates/internal_users.yml.j2
+++ b/roles/wazuh/wazuh-indexer/templates/internal_users.yml.j2
@@ -9,13 +9,13 @@ _meta:
 # Define your internal users here
 
 admin:
-  hash: "{{ indexer_admin_password }}"
+  hash: "{{ wazuh_indexer_admin_password }}"
   reserved: true
   backend_roles:
   - "admin"
   description: "admin user"
 
 kibanaserver:
-  hash: "{{ dashboard_password }}"
+  hash: "{{ wazuh_dashboard_password }}"
   reserved: true
   description: "kibanaserver user"

--- a/roles/wazuh/wazuh-indexer/templates/opensearch.yml.j2
+++ b/roles/wazuh/wazuh-indexer/templates/opensearch.yml.j2
@@ -4,7 +4,7 @@ node.name: {{ indexer_node_name }}
 discovery.type: single-node
 {% else %}
 cluster.initial_master_nodes:
-{% for item in indexer_cluster_nodes %}
+{% for item in wazuh_indexer_cluster_nodes %}
   - {{ item }}
 {% endfor %}
 


### PR DESCRIPTION
Clean up the wazuh dashboard role and fix ansible lint warnings to bring role into compliance with ansible standards. I have tested and it works with Almalinux 9.