### PR TITLE
fix: resolve ansible lint warnings for indexer role

### DIFF
--- a/.github/playbooks/aio-wazuh.yml
+++ b/.github/playbooks/aio-wazuh.yml
@@ -11,11 +11,11 @@
     # 2. Generate certificates
     - role: ../../roles/wazuh/wazuh-indexer
       vars:
-        generate_certs: true
-        perform_installation: false
+        wazuh_generate_certs: true
+        wazuh_perform_installation: false
         instances:
           node1:
-            name: wazuh-es01       # Important: must be equal to indexer_node_name.
+            name: wazuh-es01       # Important: must be equal to wazuh_indexer_node_name.
             ip: "127.0.0.1"   # When unzipping, the node will search for its node name folder to get the cert.
             role: indexer
           node3:
@@ -39,8 +39,8 @@
     # 1. Wazuh indexer
     - role: ../../roles/wazuh/wazuh-indexer
       vars:
-        indexer_node_name: "wazuh-es01"
-        single_node: true
+        wazuh_indexer_node_name: "wazuh-es01"
+        wazuh_single_node: true
     # 2. Managers
     - role: ../../roles/wazuh/ansible-wazuh-manager
     - role: ../../roles/wazuh/ansible-filebeat-oss
@@ -55,7 +55,7 @@
   vars:
     instances:
       node1:
-        name: wazuh-es01       # Important: must be equal to indexer_node_name.
+        name: wazuh-es01       # Important: must be equal to wazuh_indexer_node_name.
         ip: "127.0.0.1"  # When unzipping, the node will search for its node name folder to get the cert.
         role: indexer
       node3:

--- a/.github/playbooks/single-wazuh.yml
+++ b/.github/playbooks/single-wazuh.yml
@@ -7,11 +7,11 @@
       delegate_to: localhost
       run_once: true
     - role: ../../roles/wazuh/wazuh-indexer
-      perform_installation: false
+      wazuh_perform_installation: false
   vars:
     instances:
       node1:
-        name: node-1       # Important: must be equal to indexer_node_name.
+        name: node-1       # Important: must be equal to wazuh_indexer_node_name.
         ip: 127.0.0.1
         role: indexer
   tags:

--- a/README.md
+++ b/README.md
@@ -72,22 +72,22 @@ The hereunder example playbook uses the `wazuh-ansible` role to provision a prod
     - hosts: wi1
       roles:
         - role: ../roles/wazuh/wazuh-indexer
-          indexer_network_host: "{{ private_ip }}"
-          indexer_cluster_nodes:
+          wazuh_indexer_network_host: "{{ private_ip }}"
+          wazuh_indexer_cluster_nodes:
             - "{{ hostvars.wi1.private_ip }}"
             - "{{ hostvars.wi2.private_ip }}"
             - "{{ hostvars.wi3.private_ip }}"
-          indexer_discovery_nodes:
+          wazuh_indexer_discovery_nodes:
             - "{{ hostvars.wi1.private_ip }}"
             - "{{ hostvars.wi2.private_ip }}"
             - "{{ hostvars.wi3.private_ip }}"
-          perform_installation: false
+          wazuh_perform_installation: false
       become: no
       vars:
-        indexer_node_master: true
+        wazuh_indexer_node_master: true
         instances:
           node1:
-            name: node-1       # Important: must be equal to indexer_node_name.
+            name: node-1       # Important: must be equal to wazuh_indexer_node_name.
             ip: "{{ hostvars.wi1.private_ip }}"   # When unzipping, the node will search for its node name folder to get the cert.
             role: indexer
           node2:
@@ -120,22 +120,22 @@ The hereunder example playbook uses the `wazuh-ansible` role to provision a prod
       strategy: free
       roles:
         - role: ../roles/wazuh/wazuh-indexer
-          indexer_network_host: "{{ private_ip }}"
+          wazuh_indexer_network_host: "{{ private_ip }}"
       become: yes
       become_user: root
       vars:
-        indexer_cluster_nodes:
+        wazuh_indexer_cluster_nodes:
           - "{{ hostvars.wi1.private_ip }}"
           - "{{ hostvars.wi2.private_ip }}"
           - "{{ hostvars.wi3.private_ip }}"
-        indexer_discovery_nodes:
+        wazuh_indexer_discovery_nodes:
           - "{{ hostvars.wi1.private_ip }}"
           - "{{ hostvars.wi2.private_ip }}"
           - "{{ hostvars.wi3.private_ip }}"
-        indexer_node_master: true
+        wazuh_indexer_node_master: true
         instances:
           node1:
-            name: node-1       # Important: must be equal to indexer_node_name.
+            name: node-1       # Important: must be equal to wazuh_indexer_node_name.
             ip: "{{ hostvars.wi1.private_ip }}"   # When unzipping, the node will search for its node name folder to get the cert.
             role: indexer
           node2:
@@ -230,7 +230,7 @@ The hereunder example playbook uses the `wazuh-ansible` role to provision a prod
       become: yes
       become_user: root
       vars:
-        indexer_network_host: "{{ hostvars.wi1.private_ip }}"
+        wazuh_indexer_network_host: "{{ hostvars.wi1.private_ip }}"
         dashboard_node_name: node-6
         wazuh_api_credentials:
           - id: default
@@ -249,9 +249,9 @@ The hereunder example playbook uses the `wazuh-ansible` role to provision a prod
 - The ssh credentials used by Ansible during the provision can be specified in this file too. Another option is including them directly on the playbook.
 
 ```ini
-wi1 ansible_host=<wi1_ec2_public_ip> private_ip=<wi1_ec2_private_ip> indexer_node_name=node-1
-wi2 ansible_host=<wi2_ec2_public_ip> private_ip=<wi2_ec2_private_ip> indexer_node_name=node-2
-wi3 ansible_host=<wi3_ec2_public_ip> private_ip=<wi3_ec2_private_ip> indexer_node_name=node-3
+wi1 ansible_host=<wi1_ec2_public_ip> private_ip=<wi1_ec2_private_ip> wazuh_indexer_node_name=node-1
+wi2 ansible_host=<wi2_ec2_public_ip> private_ip=<wi2_ec2_private_ip> wazuh_indexer_node_name=node-2
+wi3 ansible_host=<wi3_ec2_public_ip> private_ip=<wi3_ec2_private_ip> wazuh_indexer_node_name=node-3
 dashboard  ansible_host=<dashboard_node_public_ip> private_ip=<dashboard_ec2_private_ip>
 manager ansible_host=<manager_node_public_ip> private_ip=<manager_ec2_private_ip>
 worker  ansible_host=<worker_node_public_ip> private_ip=<worker_ec2_private_ip>
@@ -287,14 +287,14 @@ The hereunder example playbook uses the `wazuh-ansible` role to provision a sing
   - hosts: aio
     roles:
       - role: ../roles/wazuh/wazuh-indexer
-        perform_installation: false
+        wazuh_perform_installation: false
     become: no
     #become_user: root
     vars:
-      indexer_node_master: true
+      wazuh_indexer_node_master: true
       instances:
         node1:
-          name: node-1       # Important: must be equal to indexer_node_name.
+          name: node-1       # Important: must be equal to wazuh_indexer_node_name.
           ip: 127.0.0.1
           role: indexer
     tags:
@@ -309,16 +309,16 @@ The hereunder example playbook uses the `wazuh-ansible` role to provision a sing
       - role: ../roles/wazuh/ansible-filebeat-oss
       - role: ../roles/wazuh/wazuh-dashboard
     vars:
-      single_node: true
-      minimum_master_nodes: 1
-      indexer_node_master: true
-      indexer_network_host: 127.0.0.1
+      wazuh_single_node: true
+      wazuh_minimum_master_nodes: 1
+      wazuh_indexer_node_master: true
+      wazuh_indexer_network_host: 127.0.0.1
       filebeat_node_name: node-1
       filebeat_output_indexer_hosts:
       - 127.0.0.1
       instances:
         node1:
-          name: node-1       # Important: must be equal to indexer_node_name.
+          name: node-1       # Important: must be equal to wazuh_indexer_node_name.
           ip: 127.0.0.1
           role: indexer
       ansible_shell_allow_world_readable_temp: true

--- a/playbooks/wazuh-production-ready.yml
+++ b/playbooks/wazuh-production-ready.yml
@@ -3,22 +3,22 @@
     - hosts: wi1
       roles:
         - role: ../roles/wazuh/wazuh-indexer
-          indexer_network_host: "{{ private_ip }}"
-          indexer_cluster_nodes:
+          wazuh_indexer_network_host: "{{ private_ip }}"
+          wazuh_indexer_cluster_nodes:
             - "{{ hostvars.wi1.private_ip }}"
             - "{{ hostvars.wi2.private_ip }}"
             - "{{ hostvars.wi3.private_ip }}"
-          indexer_discovery_nodes:
+          wazuh_indexer_discovery_nodes:
             - "{{ hostvars.wi1.private_ip }}"
             - "{{ hostvars.wi2.private_ip }}"
             - "{{ hostvars.wi3.private_ip }}"
-          perform_installation: false
+          wazuh_perform_installation: false
       become: no
       vars:
-        indexer_node_master: true
+        wazuh_indexer_node_master: true
         instances:
           node1:
-            name: node-1       # Important: must be equal to indexer_node_name.
+            name: node-1       # Important: must be equal to wazuh_indexer_node_name.
             ip: "{{ hostvars.wi1.private_ip }}"   # When unzipping, the node will search for its node name folder to get the cert.
             role: indexer
           node2:
@@ -51,22 +51,22 @@
       strategy: free
       roles:
         - role: ../roles/wazuh/wazuh-indexer
-          indexer_network_host: "{{ private_ip }}"
+          wazuh_indexer_network_host: "{{ private_ip }}"
       become: yes
       become_user: root
       vars:
-        indexer_cluster_nodes:
+        wazuh_indexer_cluster_nodes:
           - "{{ hostvars.wi1.private_ip }}"
           - "{{ hostvars.wi2.private_ip }}"
           - "{{ hostvars.wi3.private_ip }}"
-        indexer_discovery_nodes:
+        wazuh_indexer_discovery_nodes:
           - "{{ hostvars.wi1.private_ip }}"
           - "{{ hostvars.wi2.private_ip }}"
           - "{{ hostvars.wi3.private_ip }}"
-        indexer_node_master: true
+        wazuh_indexer_node_master: true
         instances:
           node1:
-            name: node-1       # Important: must be equal to indexer_node_name.
+            name: node-1       # Important: must be equal to wazuh_indexer_node_name.
             ip: "{{ hostvars.wi1.private_ip }}"   # When unzipping, the node will search for its node name folder to get the cert.
             role: indexer
           node2:
@@ -161,8 +161,8 @@
       become: yes
       become_user: root
       vars:
-        indexer_network_host: "{{ hostvars.wi1.private_ip }}"
-        indexer_cluster_nodes:
+        wazuh_indexer_network_host: "{{ hostvars.wi1.private_ip }}"
+        wazuh_indexer_cluster_nodes:
           - "{{ hostvars.wi1.private_ip }}"
           - "{{ hostvars.wi2.private_ip }}"
           - "{{ hostvars.wi3.private_ip }}"

--- a/playbooks/wazuh-single.yml
+++ b/playbooks/wazuh-single.yml
@@ -3,14 +3,14 @@
   - hosts: aio
     roles:
       - role: ../roles/wazuh/wazuh-indexer
-        perform_installation: false
+        wazuh_perform_installation: false
     become: no
     #become_user: root
     vars:
-      indexer_node_master: true
+      wazuh_indexer_node_master: true
       instances:
         node1:
-          name: node-1       # Important: must be equal to indexer_node_name.
+          name: node-1       # Important: must be equal to wazuh_indexer_node_name.
           ip: 127.0.0.1
           role: indexer
     tags:
@@ -25,16 +25,16 @@
       - role: ../roles/wazuh/ansible-filebeat-oss
       - role: ../roles/wazuh/wazuh-dashboard
     vars:
-      single_node: true
-      minimum_master_nodes: 1
-      indexer_node_master: true
-      indexer_network_host: 127.0.0.1
+      wazuh_single_node: true
+      wazuh_minimum_master_nodes: 1
+      wazuh_indexer_node_master: true
+      wazuh_indexer_network_host: 127.0.0.1
       filebeat_node_name: node-1
       filebeat_output_indexer_hosts:
       - 127.0.0.1
       instances:
         node1:
-          name: node-1       # Important: must be equal to indexer_node_name.
+          name: node-1       # Important: must be equal to wazuh_indexer_node_name.
           ip: 127.0.0.1
           role: indexer
       ansible_shell_allow_world_readable_temp: true

--- a/roles/opendistro/opendistro-kibana/defaults/main.yml
+++ b/roles/opendistro/opendistro-kibana/defaults/main.yml
@@ -43,7 +43,7 @@ kibana_telemetry_enabled: "false"
 opendistro_admin_password: changeme
 opendistro_kibana_user: kibanaserver
 opendistro_kibana_password: changeme
-local_certs_path: "{{ playbook_dir }}/opendistro/certificates"
+wazuh_local_certs_path: "{{ playbook_dir }}/opendistro/certificates"
 
 # Nodejs
 nodejs:

--- a/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
+++ b/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
@@ -19,4 +19,4 @@ filebeat_security: true
 filebeat_ssl_dir: /etc/pki/filebeat
 
 # Local path to store the generated certificates (Opensearch security plugin)
-local_certs_path: "{{ playbook_dir }}/indexer/certificates"
+wazuh_local_certs_path: "{{ playbook_dir }}/indexer/certificates"

--- a/roles/wazuh/ansible-filebeat-oss/tasks/security_actions.yml
+++ b/roles/wazuh/ansible-filebeat-oss/tasks/security_actions.yml
@@ -10,7 +10,7 @@
 
   - name: Copy the certificates from local to the Manager instance
     copy:
-      src: "{{ local_certs_path }}/wazuh-certificates/{{ item }}"
+      src: "{{ wazuh_local_certs_path }}/wazuh-certificates/{{ item }}"
       dest: "{{ filebeat_ssl_dir }}"
       owner: root
       group: root

--- a/roles/wazuh/wazuh-dashboard/defaults/main.yml
+++ b/roles/wazuh/wazuh-dashboard/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 # Dashboard configuration
-indexer_http_port: 9200
+wazuh_indexer_http_port: 9200
 indexer_api_protocol: https
 dashboard_conf_path: /etc/wazuh-dashboard/
 dashboard_node_name: node-1
@@ -9,7 +9,7 @@ dashboard_server_host: "0.0.0.0"
 dashboard_server_port: "443"
 dashboard_server_name: "dashboard"
 wazuh_version: 4.14.2
-indexer_cluster_nodes:
+wazuh_indexer_cluster_nodes:
   - 127.0.0.1
 
 # The Wazuh dashboard package repository
@@ -25,7 +25,7 @@ wazuh_api_credentials:
 
 # Dashboard Security
 dashboard_security: true
-indexer_admin_password: changeme
+wazuh_indexer_admin_password: changeme
 dashboard_user: kibanaserver
-dashboard_password: changeme
-local_certs_path: "{{ playbook_dir }}/indexer/certificates"
+wazuh_dashboard_password: changeme
+wazuh_local_certs_path: "{{ playbook_dir }}/indexer/certificates"

--- a/roles/wazuh/wazuh-dashboard/tasks/main.yml
+++ b/roles/wazuh/wazuh-dashboard/tasks/main.yml
@@ -48,7 +48,7 @@
     recurse: yes
 
 - name: Wait for Wazuh-Indexer port
-  wait_for: host={{ indexer_network_host }} port={{ indexer_http_port }}
+  wait_for: host={{ wazuh_indexer_network_host }} port={{ wazuh_indexer_http_port }}
 
 - name: Select correct API protocol
   set_fact:
@@ -56,10 +56,10 @@
 
 - name: Attempting to delete legacy Wazuh index if exists
   uri:
-    url: "{{ indexer_api_protocol }}://{{ indexer_network_host }}:{{ indexer_http_port }}/.wazuh"
+    url: "{{ indexer_api_protocol }}://{{ wazuh_indexer_network_host }}:{{ wazuh_indexer_http_port }}/.wazuh"
     method: DELETE
     user: "admin"
-    password: "{{ indexer_admin_password }}"
+    password: "{{ wazuh_indexer_admin_password }}"
     validate_certs: no
     status_code: 200, 404
 
@@ -84,7 +84,7 @@
 
 - name: Configure opensearch.password in opensearch_dashboards.keystore
   shell: >-
-    echo '{{ dashboard_password }}' | /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root add -f --stdin opensearch.password
+    echo '{{ wazuh_dashboard_password }}' | /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root add -f --stdin opensearch.password
   args:
     executable: /bin/bash
   become: yes

--- a/roles/wazuh/wazuh-dashboard/tasks/security_actions.yml
+++ b/roles/wazuh/wazuh-dashboard/tasks/security_actions.yml
@@ -10,7 +10,7 @@
 
   - name: Copy the certificates from local to the Wazuh dashboard instance
     copy:
-      src: "{{ local_certs_path }}/wazuh-certificates/{{ item }}"
+      src: "{{ wazuh_local_certs_path }}/wazuh-certificates/{{ item }}"
       dest: /etc/wazuh-dashboard/certs/
       owner: wazuh-dashboard
       group: wazuh-dashboard

--- a/roles/wazuh/wazuh-dashboard/templates/opensearch_dashboards.yml.j2
+++ b/roles/wazuh/wazuh-dashboard/templates/opensearch_dashboards.yml.j2
@@ -1,8 +1,8 @@
 server.host: {{ dashboard_server_host }}
 server.port: {{ dashboard_server_port }}
 opensearch.hosts:
-{% for item in indexer_cluster_nodes %}
-  - https://{{ item }}:{{ indexer_http_port }}
+{% for item in wazuh_indexer_cluster_nodes %}
+  - https://{{ item }}:{{ wazuh_indexer_http_port }}
 {% endfor %}
 opensearch.ssl.verificationMode: certificate
 opensearch.requestHeadersWhitelist: ["securitytenant","Authorization"]

--- a/roles/wazuh/wazuh-indexer/defaults/main.yml
+++ b/roles/wazuh/wazuh-indexer/defaults/main.yml
@@ -1,50 +1,50 @@
 ---
 # Cluster Settings
-indexer_version: 4.14.2
+wazuh_indexer_version: 4.14.2
 
-single_node: false
-indexer_node_name: node-1
-indexer_cluster_name: wazuh
-indexer_network_host: '0.0.0.0'
+wazuh_single_node: false
+wazuh_indexer_node_name: node-1
+wazuh_indexer_cluster_name: wazuh
+wazuh_indexer_network_host: '0.0.0.0'
 
-indexer_node_master: true
-indexer_node_data: true
-indexer_node_ingest: true
-indexer_start_timeout: 90
+wazuh_indexer_node_master: true
+wazuh_indexer_node_data: true
+wazuh_indexer_node_ingest: true
+wazuh_indexer_start_timeout: 90
 
-indexer_cluster_nodes:
+wazuh_indexer_cluster_nodes:
   - 127.0.0.1
-indexer_discovery_nodes:
+wazuh_indexer_discovery_nodes:
   - 127.0.0.1
 
-local_certs_path: "{{ playbook_dir }}/indexer/certificates"
+wazuh_local_certs_path: "{{ playbook_dir }}/indexer/certificates"
 
 # Minimum master nodes in cluster, 2 for 3 nodes Wazuh indexer cluster
-minimum_master_nodes: 2
+wazuh_minimum_master_nodes: 2
 
 # Configure hostnames for Wazuh indexer nodes
 # Example es1.example.com, es2.example.com
-domain_name: wazuh.com
+wazuh_domain_name: wazuh.com
 
-indexer_sec_plugin_conf_path: /etc/wazuh-indexer/opensearch-security
-indexer_sec_plugin_tools_path: /usr/share/wazuh-indexer/plugins/opensearch-security/tools
-indexer_conf_path: /etc/wazuh-indexer
-indexer_index_path: /var/lib/wazuh-indexer/
+wazuh_indexer_sec_plugin_conf_path: /etc/wazuh-indexer/opensearch-security
+wazuh_indexer_sec_plugin_tools_path: /usr/share/wazuh-indexer/plugins/opensearch-security/tools
+wazuh_indexer_conf_path: /etc/wazuh-indexer
+wazuh_indexer_index_path: /var/lib/wazuh-indexer/
 
 # Security password
-indexer_custom_user: ""
-indexer_custom_user_role: "admin"
+wazuh_indexer_custom_user: ""
+wazuh_indexer_custom_user_role: "admin"
 
 # Set JVM memory limits
-indexer_jvm_xms: null
+wazuh_indexer_jvm_xms: null
 
-indexer_http_port: 9200
+wazuh_indexer_http_port: 9200
 
-indexer_admin_password: changeme
-dashboard_password: changeme
+wazuh_indexer_admin_password: changeme
+wazuh_dashboard_password: changeme
 
 # Deployment settings
-generate_certs: true
-perform_installation: true
+wazuh_generate_certs: true
+wazuh_perform_installation: true
 
-indexer_nolog_sensible: true
+wazuh_indexer_nolog_sensible: true

--- a/roles/wazuh/wazuh-indexer/handlers/main.yml
+++ b/roles/wazuh/wazuh-indexer/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: restart wazuh-indexer
-  service:
+- name: Restart wazuh-indexer
+  ansible.builtin.service:
     name: wazuh-indexer
     state: restarted

--- a/roles/wazuh/wazuh-indexer/meta/main.yml
+++ b/roles/wazuh/wazuh-indexer/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Installing and maintaining Wazuh indexer.
   company: wazuh.com
   license: license (GPLv3)
-  min_ansible_version: 2.0
+  min_ansible_version: "2.0"
   platforms:
     - name: EL
       versions:

--- a/roles/wazuh/wazuh-indexer/tasks/Debian.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/Debian.yml
@@ -1,12 +1,11 @@
-
 ---
 
 - name: Update cache
-  apt:
-    update_cache: yes
+  ansible.builtin.apt:
+    update_cache: true
 
 - name: Install Wazuh indexer dependencies
-  apt:
+  ansible.builtin.apt:
     name:
       - unzip
       - wget
@@ -19,30 +18,33 @@
 - name: Add Wazuh indexer repository
   block:
     - name: Add apt repository signing key
-      get_url:
+      ansible.builtin.get_url:
         url: "{{ wazuh_repo.gpg }}"
         dest: "{{ wazuh_repo.path }}"
+        owner: root
+        group: root
+        mode: "0660"
 
     - name: Import Wazuh repository GPG key
-      command: "gpg --no-default-keyring --keyring gnupg-ring:{{ wazuh_repo.keyring_path }} --import {{ wazuh_repo.path }}"
+      ansible.builtin.command: "gpg --no-default-keyring --keyring gnupg-ring:{{ wazuh_repo.keyring_path }} --import {{ wazuh_repo.path }}"
       args:
         creates: "{{ wazuh_repo.keyring_path }}"
 
     - name: Set permissions for Wazuh repository GPG key
-      file:
+      ansible.builtin.file:
         path: "{{ wazuh_repo.keyring_path }}"
         mode: '0644'
 
     - name: Add Wazuh indexer repository
-      apt_repository:
+      ansible.builtin.apt_repository:
         repo: "{{ wazuh_repo.apt }}"
         state: present
         filename: 'wazuh-indexer'
-        update_cache: yes
+        update_cache: true
 
 - name: Install Wazuh indexer
-  apt:
-    name: wazuh-indexer={{ indexer_version }}-1
+  ansible.builtin.apt:
+    name: wazuh-indexer={{ wazuh_indexer_version }}-1
     state: present
   register: install
   tags: install

--- a/roles/wazuh/wazuh-indexer/tasks/RMRedHat.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/RMRedHat.yml
@@ -1,6 +1,6 @@
 ---
 - name: RedHat/CentOS/Fedora | Remove Wazuh indexer repository (and clean up left-over metadata)
-  yum_repository:
+  ansible.builtin.yum_repository:
     name: wazuh_repo
     state: absent
   changed_when: false

--- a/roles/wazuh/wazuh-indexer/tasks/RedHat.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/RedHat.yml
@@ -1,59 +1,60 @@
 ---
-- block:
-
-  - name: RedHat/CentOS/Fedora | Add Wazuh indexer repo
-    yum_repository:
-      name: wazuh_repo
-      description: Wazuh yum repository
-      baseurl: "{{ wazuh_repo.yum }}"
-      gpgkey: "{{ wazuh_repo.gpg }}"
-      gpgcheck: true
-    changed_when: false
-
-
-
-  - name: Amazon Linux | Configure system settings
-    block:
-      - name: Install Amazon extras in Amazon Linux 2
-        yum:
-          name: amazon-linux-extras
-          state: present
-          lock_timeout: 200
-        when:
-          - ansible_distribution == 'Amazon'
-          - ansible_distribution_major_version == '2'
-
-      - name: Configure vm.max_map_count
-        lineinfile:
-          line: "vm.max_map_count=262144"
-          dest: "/etc/sysctl.conf"
-          insertafter: EOF
-          create: true
-        become: yes
-
-      - name: Update vm.max_map_count
-        shell: sysctl -p
-        become: yes
-
-    when:
-      - ansible_distribution == 'Amazon'
-
-  - name: RedHat/CentOS/Fedora | Install Indexer dependencies
-    yum:
-      name: "{{ packages }}"
-      state: present
-      lock_timeout: 200
-    vars:
-      packages:
-      - wget
-      - unzip
-
-  - name: Install Wazuh indexer
-    package:
-      name: wazuh-indexer-{{ indexer_version }}
-      state: present
-    register: install
-    tags: install
-
+- name: Install Wazuh Indexer
   tags:
-  - install
+    - install
+
+  block:
+    - name: RedHat/CentOS/Fedora | Add Wazuh indexer repo
+      ansible.builtin.yum_repository:
+        name: wazuh_repo
+        description: Wazuh yum repository
+        baseurl: "{{ wazuh_repo.yum }}"
+        gpgkey: "{{ wazuh_repo.gpg }}"
+        gpgcheck: true
+      changed_when: false
+
+    - name: Amazon Linux | Configure system settings
+      when:
+        - ansible_distribution == 'Amazon'
+      block:
+        - name: Install Amazon extras in Amazon Linux 2
+          ansible.builtin.dnf:
+            name: amazon-linux-extras
+            state: present
+            lock_timeout: 200
+          when:
+            - ansible_distribution == 'Amazon'
+            - ansible_distribution_major_version == '2'
+
+        - name: Configure vm.max_map_count
+          ansible.builtin.lineinfile:
+            line: "vm.max_map_count=262144"
+            dest: "/etc/sysctl.conf"
+            insertafter: EOF
+            create: true
+            owner: root
+            group: root
+            mode: "0644"
+          become: true
+
+        - name: Update vm.max_map_count
+          ansible.builtin.command: sysctl -p
+          changed_when: false
+          become: true
+
+    - name: RedHat/CentOS/Fedora | Install Indexer dependencies
+      ansible.builtin.dnf:
+        name: "{{ packages }}"
+        state: present
+        lock_timeout: 200
+      vars:
+        packages:
+          - wget
+          - unzip
+
+    - name: Install Wazuh indexer
+      ansible.builtin.package:
+        name: wazuh-indexer-{{ wazuh_indexer_version }}
+        state: present
+      register: install
+      tags: install

--- a/roles/wazuh/wazuh-indexer/tasks/local_actions.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/local_actions.yml
@@ -1,48 +1,49 @@
 ---
 - name: Check if certificates already exists
-  stat:
-    path: "{{ local_certs_path }}"
+  ansible.builtin.stat:
+    path: "{{ wazuh_local_certs_path }}"
   register: certificates_folder
   delegate_to: localhost
-  become: no
+  become: false
   tags:
     - generate-certs
 
-
-- block:
-
-  - name: Local action | Create local temporary directory for certificates generation
-    file:
-      path: "{{ local_certs_path }}"
-      mode: 0755
-      state: directory
-
-  - name: Local action | Check that the generation tool exists
-    stat:
-      path: "{{ local_certs_path }}/wazuh-certs-tool.sh"
-    register: tool_package
-
-  - name: Local action | Download certificates generation tool
-    get_url:
-      url: "{{ certs_gen_tool_url }}"
-      dest: "{{ local_certs_path }}/wazuh-certs-tool.sh"
-    when: not tool_package.stat.exists
-
-  - name: Local action | Prepare the certificates generation template file
-    template:
-      src: "templates/config.yml.j2"
-      dest: "{{ local_certs_path }}/config.yml"
-      mode: 0644
-    register: tlsconfig_template
-
-  - name: Local action | Generate the node & admin certificates in local
-    command: >-
-      bash {{ local_certs_path }}/wazuh-certs-tool.sh -A
-
+- name: Generate certificates
   run_once: true
   delegate_to: localhost
-  become: no
+  become: false
   tags:
     - generate-certs
   when:
     - not certificates_folder.stat.exists
+
+  block:
+    - name: Local action | Create local temporary directory for certificates generation
+      ansible.builtin.file:
+        path: "{{ wazuh_local_certs_path }}"
+        mode: "0755"
+        state: directory
+
+    - name: Local action | Check that the generation tool exists
+      ansible.builtin.stat:
+        path: "{{ wazuh_local_certs_path }}/wazuh-certs-tool.sh"
+      register: tool_package
+
+    - name: Local action | Download certificates generation tool
+      ansible.builtin.get_url:
+        url: "{{ certs_gen_tool_url }}"
+        dest: "{{ wazuh_local_certs_path }}/wazuh-certs-tool.sh"
+        mode: "0770"
+      when: not tool_package.stat.exists
+
+    - name: Local action | Prepare the certificates generation template file
+      ansible.builtin.template:
+        src: "templates/config.yml.j2"
+        dest: "{{ wazuh_local_certs_path }}/config.yml"
+        mode: "0644"
+      register: tlsconfig_template
+
+    - name: Local action | Generate the node & admin certificates in local
+      ansible.builtin.command: >-
+        bash {{ wazuh_local_certs_path }}/wazuh-certs-tool.sh -A
+      changed_when: false

--- a/roles/wazuh/wazuh-indexer/tasks/main.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/main.yml
@@ -1,29 +1,37 @@
 ---
-- include_vars: ../../vars/repo_vars.yml
+- name: Include Repository Variables
+  ansible.builtin.include_vars: ../../vars/repo_vars.yml
 
-- include_vars: ../../vars/repo.yml
+- name: Include Production Repository Variables
+  ansible.builtin.include_vars: ../../vars/repo.yml
   when: packages_repository == 'production'
 
-- include_vars: ../../vars/repo_pre-release.yml
+- name: Include Pre-Release Repository Variables
+  ansible.builtin.include_vars: ../../vars/repo_pre-release.yml
   when: packages_repository == 'pre-release'
 
-- include_vars: ../../vars/repo_staging.yml
+- name: Include Staging Repository Variables
+  ansible.builtin.include_vars: ../../vars/repo_staging.yml
   when: packages_repository == 'staging'
 
-- import_tasks: local_actions.yml
+- name: Run Local Actions
+  ansible.builtin.import_tasks: local_actions.yml
   when:
-    - generate_certs
+    - wazuh_generate_certs
 
-- block:
-    - import_tasks: RedHat.yml
+- name: Configure Wazuh Indexer
+  when: wazuh_perform_installation
+  block:
+    - name: RedHat/Centos | Install Wazuh Indexer
+      ansible.builtin.import_tasks: RedHat.yml
       when: ansible_os_family == 'RedHat'
 
-    - import_tasks: Debian.yml
+    - name: Debian/Ubuntu | Install Wazuh Indexer
+      ansible.builtin.import_tasks: Debian.yml
       when: ansible_os_family == 'Debian'
 
     - name: Remove performance analyzer plugin from Wazuh indexer
-      become: true
-      command: ./opensearch-plugin remove opensearch-performance-analyzer
+      ansible.builtin.command: ./opensearch-plugin remove opensearch-performance-analyzer
       ignore_errors: true
       args:
         chdir: /usr/share/wazuh-indexer/bin/
@@ -32,78 +40,79 @@
         - remove_opensearch_performance_analyzer.rc != 0
         - '"not found" not in remove_opensearch_performance_analyzer.stderr'
       changed_when: "remove_opensearch_performance_analyzer.rc == 0"
+      become: true
 
     - name: Remove Opensearch configuration file
-      file:
-        path: "{{ indexer_conf_path }}/opensearch.yml"
+      ansible.builtin.file:
+        path: "{{ wazuh_indexer_conf_path }}/opensearch.yml"
         state: absent
       tags: install
 
     - name: Copy Opensearch Configuration File
-      template:
+      ansible.builtin.template:
         src: "templates/opensearch.yml.j2"
-        dest: "{{ indexer_conf_path }}/opensearch.yml"
+        dest: "{{ wazuh_indexer_conf_path }}/opensearch.yml"
         owner: root
         group: wazuh-indexer
-        mode: 0640
-        force: yes
+        mode: "0640"
+        force: true
       tags: install
 
-    - include_tasks: security_actions.yml
+    - name: Run Security Actions
+      ansible.builtin.include_tasks: security_actions.yml
       tags:
         - security
 
-
     - name: Configure Wazuh indexer JVM memmory.
-      template:
+      ansible.builtin.template:
         src: "templates/jvm.options.j2"
-        dest: "{{ indexer_conf_path }}/jvm.options"
+        dest: "{{ wazuh_indexer_conf_path }}/jvm.options"
         owner: root
         group: wazuh-indexer
-        mode: 0644
-        force: yes
-      notify: restart wazuh-indexer
+        mode: "0644"
+        force: true
+      notify: Restart wazuh-indexer
       tags: install
 
     - name: Ensure extra time for Wazuh indexer to start on reboots
-      lineinfile:
+      ansible.builtin.lineinfile:
         path: /usr/lib/systemd/system/wazuh-indexer.service
         regexp: '^TimeoutStartSec='
-        line: "TimeoutStartSec={{ indexer_start_timeout }}"
-      become: yes
+        line: "TimeoutStartSec={{ wazuh_indexer_start_timeout }}"
+      become: true
       tags: configure
 
     - name: Index files to remove
-      find:
-        paths: "{{ indexer_index_path }}"
+      ansible.builtin.find:
+        paths: "{{ wazuh_indexer_index_path }}"
         patterns: "*"
       register: files_to_delete
 
     - name: Remove Index Files
-      file:
+      ansible.builtin.file:
         path: "{{ item.path }}"
         state: absent
       with_items: "{{ files_to_delete.files }}"
 
     - name: Ensure Wazuh indexer started and enabled
-      service:
+      ansible.builtin.service:
         name: wazuh-indexer
         enabled: true
         state: started
 
     - name: Wait for Wazuh indexer API
-      uri:
-        url: "https://{{ inventory_hostname if not single_node else indexer_network_host }}:{{ indexer_http_port }}/_cat/health/"
+      ansible.builtin.uri:
+        url: "https://{{ inventory_hostname if not wazuh_single_node else wazuh_indexer_network_host }}:{{ wazuh_indexer_http_port }}/_cat/health/"
         user: "admin" # Default Indexer user is always "admin"
-        password: "{{ indexer_admin_password }}"
-        validate_certs: no
+        password: "{{ wazuh_indexer_admin_password }}"
+        validate_certs: false
         status_code: 200,401
-        return_content: yes
+        return_content: true
         timeout: 4
       register: _result
       until:
         - _result is defined
-        - '"green" in _result.content or ( "yellow" in _result.content and single_node )'
+        - '"green" in _result.content or ( "yellow" in _result.content and wazuh_single_node )'
       retries: 24
       delay: 5
       tags: debug
@@ -111,30 +120,32 @@
         - hostvars[inventory_hostname]['private_ip'] is not defined or not hostvars[inventory_hostname]['private_ip']
 
     - name: Wait for Wazuh indexer API (Private IP)
-      uri:
-        url: "https://{{ hostvars[inventory_hostname]['private_ip'] if not single_node else indexer_network_host }}:{{ indexer_http_port }}/_cat/health/"
+      ansible.builtin.uri:
+        url: |
+          https://{{ hostvars[inventory_hostname]['private_ip']
+          if not wazuh_single_node else wazuh_indexer_network_host }}:{{ wazuh_indexer_http_port }}/_cat/health/
         user: "admin" # Default Indexer user is always "admin"
-        password: "{{ indexer_admin_password }}"
-        validate_certs: no
+        password: "{{ wazuh_indexer_admin_password }}"
+        validate_certs: false
         status_code: 200,401
-        return_content: yes
+        return_content: true
         timeout: 4
       register: _result
       until:
         - _result is defined
-        - '"green" in _result.content or ( "yellow" in _result.content and single_node )'
+        - '"green" in _result.content or ( "yellow" in _result.content and wazuh_single_node )'
       retries: 24
       delay: 5
       tags: debug
       when:
         - hostvars[inventory_hostname]['private_ip'] is defined and hostvars[inventory_hostname]['private_ip']
 
-    - import_tasks: "RMRedHat.yml"
+    - name: Removing Red Hat Repository
+      ansible.builtin.import_tasks: "RMRedHat.yml"
       when: ansible_os_family == "RedHat"
 
     - name: Reload systemd configuration
-      systemd:
+      ansible.builtin.systemd:
         daemon_reload: true
-      become: yes
-      notify: restart wazuh-indexer
-  when: perform_installation
+      become: true
+      notify: Restart wazuh-indexer

--- a/roles/wazuh/wazuh-indexer/tasks/security_actions.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/security_actions.yml
@@ -1,118 +1,122 @@
 - name: Configure IP (Private address)
-  set_fact:
-    target_address: "{{ hostvars[inventory_hostname]['private_ip'] if not single_node else indexer_network_host }}"
+  ansible.builtin.set_fact:
+    target_address: "{{ hostvars[inventory_hostname]['private_ip'] if not wazuh_single_node else wazuh_indexer_network_host }}"
   when:
     - hostvars[inventory_hostname]['private_ip'] is defined
 
 - name: Configure IP (Public address)
-  set_fact:
-    target_address: "{{ inventory_hostname if not single_node else indexer_network_host }}"
+  ansible.builtin.set_fact:
+    target_address: "{{ inventory_hostname if not wazuh_single_node else wazuh_indexer_network_host }}"
   when:
     - hostvars[inventory_hostname]['private_ip'] is not defined
 
 - name: Ensure Indexer certificates directory permissions.
-  file:
-    path: "{{ indexer_conf_path }}/certs/"
+  ansible.builtin.file:
+    path: "{{ wazuh_indexer_conf_path }}/certs/"
     state: directory
     owner: wazuh-indexer
     group: wazuh-indexer
-    mode: 500
+    mode: "0500"
 
 - name: Copy the node & admin certificates to Wazuh indexer cluster
-  copy:
-    src: "{{ local_certs_path }}/wazuh-certificates/{{ item }}"
-    dest: "{{ indexer_conf_path }}/certs/"
+  ansible.builtin.copy:
+    src: "{{ wazuh_local_certs_path }}/wazuh-certificates/{{ item }}"
+    dest: "{{ wazuh_indexer_conf_path }}/certs/"
     owner: wazuh-indexer
     group: wazuh-indexer
-    mode: 0400
+    mode: "0400"
   with_items:
     - root-ca.pem
-    - "{{ indexer_node_name }}-key.pem"
-    - "{{ indexer_node_name }}.pem"
+    - "{{ wazuh_indexer_node_name }}-key.pem"
+    - "{{ wazuh_indexer_node_name }}.pem"
     - admin-key.pem
     - admin.pem
 
 - name: Restart Wazuh indexer with security configuration
-  systemd:
+  ansible.builtin.systemd:
     name: wazuh-indexer
     state: restarted
 
 - name: Copy the Opensearch security internal users template
-  template:
+  ansible.builtin.template:
     src: "templates/internal_users.yml.j2"
-    dest: "{{ indexer_sec_plugin_conf_path }}/internal_users.yml"
-    mode: 0644
+    dest: "{{ wazuh_indexer_sec_plugin_conf_path }}/internal_users.yml"
+    mode: "0644"
   run_once: true
 
-- block:
-  - name: Hashing the custom admin password
-    shell: |
-      export JAVA_HOME=/usr/share/wazuh-indexer/jdk
-      {{ indexer_sec_plugin_tools_path }}/hash.sh -p '{{ indexer_admin_password }}'
-    register: indexer_admin_password_hashed
-    no_log: '{{ indexer_nolog_sensible | bool }}'
-
-  - name: Set the Admin user password
-    replace:
-      path: "{{ indexer_sec_plugin_conf_path }}/internal_users.yml"
-      regexp: '(?<=admin:\n  hash: )(.*)(?=)'
-      replace: "{{ indexer_password_hash | quote }}"
-    vars:
-      indexer_password_hash: "{{ indexer_admin_password_hashed.stdout_lines | last }}"
-
-  # this can also be achieved with password_hash, but it requires dependencies on the controller
-  - name: Hash the kibanaserver role/user pasword
-    shell: |
-      export JAVA_HOME=/usr/share/wazuh-indexer/jdk
-      {{ indexer_sec_plugin_tools_path }}/hash.sh -p '{{ dashboard_password }}'
-    register: indexer_kibanaserver_password_hashed
-    no_log: '{{ indexer_nolog_sensible | bool }}'
-
-  - name: Set the kibanaserver user password
-    replace:
-      path: "{{ indexer_sec_plugin_conf_path }}/internal_users.yml"
-      regexp: '(?<=kibanaserver:\n  hash: )(.*)(?=)'
-      replace: "{{ indexer_password_hash | quote }}"
-    vars:
-      indexer_password_hash: "{{ indexer_kibanaserver_password_hashed.stdout_lines | last }}"
-
-  - name: Initialize the Opensearch security index in Wazuh indexer
-    command: >
-      sudo -u wazuh-indexer OPENSEARCH_PATH_CONF={{ indexer_conf_path }}
-      JAVA_HOME=/usr/share/wazuh-indexer/jdk
-      {{ indexer_sec_plugin_tools_path }}/securityadmin.sh
-      -cd {{ indexer_sec_plugin_conf_path }}/
-      -icl -p 9200 -cd {{ indexer_sec_plugin_conf_path }}/
-      -nhnv
-      -cacert {{ indexer_conf_path }}/certs/root-ca.pem
-      -cert {{ indexer_conf_path }}/certs/admin.pem
-      -key {{ indexer_conf_path }}/certs/admin-key.pem
-      -h {{ target_address }}
-    retries: 2
-    delay: 5
-    register: result
-    until: result.rc == 0
-
+- name: Setting Up Admin User
   when: inventory_hostname == ansible_play_hosts[0]
 
+  block:
+    - name: Hashing the custom admin password
+      ansible.builtin.shell: |
+        export JAVA_HOME=/usr/share/wazuh-indexer/jdk
+        {{ wazuh_indexer_sec_plugin_tools_path }}/hash.sh -p '{{ wazuh_indexer_admin_password }}'
+      register: wazuh_indexer_admin_password_hashed
+      no_log: '{{ wazuh_indexer_nolog_sensible | bool }}'
+      changed_when: false
+
+    - name: Set the Admin user password
+      ansible.builtin.replace:
+        path: "{{ wazuh_indexer_sec_plugin_conf_path }}/internal_users.yml"
+        regexp: '(?<=admin:\n  hash: )(.*)(?=)'
+        replace: "{{ indexer_password_hash | quote }}"
+      vars:
+        indexer_password_hash: "{{ wazuh_indexer_admin_password_hashed.stdout_lines | last }}"
+
+    # this can also be achieved with password_hash, but it requires dependencies on the controller
+    - name: Hash the kibanaserver role/user pasword
+      ansible.builtin.shell: |
+        export JAVA_HOME=/usr/share/wazuh-indexer/jdk
+        {{ wazuh_indexer_sec_plugin_tools_path }}/hash.sh -p '{{ wazuh_dashboard_password }}'
+      register: indexer_kibanaserver_password_hashed
+      no_log: '{{ wazuh_indexer_nolog_sensible | bool }}'
+      changed_when: false
+
+    - name: Set the kibanaserver user password
+      ansible.builtin.replace:
+        path: "{{ wazuh_indexer_sec_plugin_conf_path }}/internal_users.yml"
+        regexp: '(?<=kibanaserver:\n  hash: )(.*)(?=)'
+        replace: "{{ indexer_password_hash | quote }}"
+      vars:
+        indexer_password_hash: "{{ indexer_kibanaserver_password_hashed.stdout_lines | last }}"
+
+    - name: Initialize the Opensearch security index in Wazuh indexer
+      ansible.builtin.command: >
+        sudo -u wazuh-indexer OPENSEARCH_PATH_CONF={{ wazuh_indexer_conf_path }}
+        JAVA_HOME=/usr/share/wazuh-indexer/jdk
+        {{ wazuh_indexer_sec_plugin_tools_path }}/securityadmin.sh
+        -cd {{ wazuh_indexer_sec_plugin_conf_path }}/
+        -icl -p 9200 -cd {{ wazuh_indexer_sec_plugin_conf_path }}/
+        -nhnv
+        -cacert {{ wazuh_indexer_conf_path }}/certs/root-ca.pem
+        -cert {{ wazuh_indexer_conf_path }}/certs/admin.pem
+        -key {{ wazuh_indexer_conf_path }}/certs/admin-key.pem
+        -h {{ target_address }}
+      retries: 2
+      delay: 5
+      register: result
+      until: result.rc == 0
+      changed_when: false
+
 - name: Create custom user
-  uri:
-    url: "https://{{ target_address }}:{{ indexer_http_port }}/_plugins/_security/api/internalusers/{{ indexer_custom_user }}"
+  ansible.builtin.uri:
+    url: "https://{{ target_address }}:{{ wazuh_indexer_http_port }}/_plugins/_security/api/internalusers/{{ wazuh_indexer_custom_user }}"
     method: PUT
     user: "admin" # Default Indexer user is always "admin"
-    password: "{{ indexer_admin_password }}"
+    password: "{{ wazuh_indexer_admin_password }}"
     body: |
       {
-        "password": "{{ indexer_admin_password }}",
-        "backend_roles": ["{{ indexer_custom_user_role }}"]
+        "password": "{{ wazuh_indexer_admin_password }}",
+        "backend_roles": ["{{ wazuh_indexer_custom_user_role }}"]
       }
     body_format: json
-    validate_certs: no
+    validate_certs: false
     status_code: 200,201,401
-    return_content: yes
+    return_content: true
     timeout: 4
   register: result
   until: result.status in [200,201,401]
   when:
-    - indexer_custom_user is defined and indexer_custom_user
+    - wazuh_indexer_custom_user is defined and wazuh_indexer_custom_user != ""
     - inventory_hostname == ansible_play_hosts[0]

--- a/roles/wazuh/wazuh-indexer/templates/config.yml.j2
+++ b/roles/wazuh/wazuh-indexer/templates/config.yml.j2
@@ -1,7 +1,7 @@
 nodes:
   # Indexer server nodes
   indexer:
-{% for (key,value) in instances.items() %}
+{% for (key,value) in wazuh_instances.items() %}
 {% if (value.role is defined and value.role == 'indexer') %}
     - name: {{ value.name }}
       ip: {{ value.ip }}
@@ -11,7 +11,7 @@ nodes:
   # Wazuh server nodes
   # Use node_type only with more than one Wazuh manager
   server:
-{% for (key,value) in instances.items() %}
+{% for (key,value) in wazuh_instances.items() %}
 {% if (value.role is defined and value.role == 'wazuh') %}
     - name: {{ value.name }}
       ip: {{ value.ip }}
@@ -25,7 +25,7 @@ nodes:
 
   # Dashboard node
   dashboard:
-{% for (key,value) in instances.items() %}
+{% for (key,value) in wazuh_instances.items() %}
 {% if (value.role is defined and value.role == 'dashboard') %}
     - name: {{ value.name }}
       ip: {{ value.ip }}

--- a/roles/wazuh/wazuh-indexer/templates/internal_users.yml.j2
+++ b/roles/wazuh/wazuh-indexer/templates/internal_users.yml.j2
@@ -9,13 +9,13 @@ _meta:
 # Define your internal users here
 
 admin:
-  hash: "{{ indexer_admin_password }}"
+  hash: "{{ wazuh_indexer_admin_password }}"
   reserved: true
   backend_roles:
   - "admin"
   description: "admin user"
 
 kibanaserver:
-  hash: "{{ dashboard_password }}"
+  hash: "{{ wazuh_dashboard_password }}"
   reserved: true
   description: "kibanaserver user"

--- a/roles/wazuh/wazuh-indexer/templates/jvm.options.j2
+++ b/roles/wazuh/wazuh-indexer/templates/jvm.options.j2
@@ -17,11 +17,11 @@
 # Xms represents the initial size of total heap space
 # Xmx represents the maximum size of total heap space
 
-{% if indexer_jvm_xms is not none %}
-{% if indexer_jvm_xms < 32000 %}
--Xms{{ indexer_jvm_xms }}m
+{% if wazuh_indexer_jvm_xms is not none %}
+{% if wazuh_indexer_jvm_xms < 32000 %}
+-Xms{{ wazuh_indexer_jvm_xms }}m
 
--Xmx{{ indexer_jvm_xms }}m
+-Xmx{{ wazuh_indexer_jvm_xms }}m
 {% else %}
 -Xms32000m
 

--- a/roles/wazuh/wazuh-indexer/templates/opensearch.yml.j2
+++ b/roles/wazuh/wazuh-indexer/templates/opensearch.yml.j2
@@ -1,20 +1,20 @@
-network.host: {{ indexer_network_host }}
-node.name: {{ indexer_node_name }}
-{% if single_node == true %}
+network.host: {{ wazuh_indexer_network_host }}
+node.name: {{ wazuh_indexer_node_name }}
+{% if wazuh_single_node == true %}
 discovery.type: single-node
 {% else %}
 cluster.initial_master_nodes:
-{% for item in indexer_cluster_nodes %}
+{% for item in wazuh_indexer_cluster_nodes %}
   - {{ item }}
 {% endfor %}
 
 discovery.seed_hosts:
-{% for item in indexer_discovery_nodes %}
+{% for item in wazuh_indexer_discovery_nodes %}
   - {{ item }}
 {% endfor %}
 {% endif %}
 
-cluster.name: {{ indexer_cluster_name }}
+cluster.name: {{ wazuh_indexer_cluster_name }}
 
 node.max_local_storage_nodes: "3"
 path.data: /var/lib/wazuh-indexer
@@ -28,11 +28,11 @@ path.logs: /var/log/wazuh-indexer
 #                                                                             #
 ###############################################################################
 
-plugins.security.ssl.http.pemcert_filepath: /etc/wazuh-indexer/certs/{{ indexer_node_name }}.pem
-plugins.security.ssl.http.pemkey_filepath: /etc/wazuh-indexer/certs/{{ indexer_node_name }}-key.pem
+plugins.security.ssl.http.pemcert_filepath: /etc/wazuh-indexer/certs/{{ wazuh_indexer_node_name }}.pem
+plugins.security.ssl.http.pemkey_filepath: /etc/wazuh-indexer/certs/{{ wazuh_indexer_node_name }}-key.pem
 plugins.security.ssl.http.pemtrustedcas_filepath: /etc/wazuh-indexer/certs/root-ca.pem
-plugins.security.ssl.transport.pemcert_filepath: /etc/wazuh-indexer/certs/{{ indexer_node_name }}.pem
-plugins.security.ssl.transport.pemkey_filepath: /etc/wazuh-indexer/certs/{{ indexer_node_name }}-key.pem
+plugins.security.ssl.transport.pemcert_filepath: /etc/wazuh-indexer/certs/{{ wazuh_indexer_node_name }}.pem
+plugins.security.ssl.transport.pemkey_filepath: /etc/wazuh-indexer/certs/{{ wazuh_indexer_node_name }}-key.pem
 plugins.security.ssl.transport.pemtrustedcas_filepath: /etc/wazuh-indexer/certs/root-ca.pem
 plugins.security.ssl.http.enabled: true
 plugins.security.ssl.transport.enforce_hostname_verification: false
@@ -50,7 +50,7 @@ plugins.security.authcz.admin_dn:
 plugins.security.check_snapshot_restore_write_privileges: true
 plugins.security.enable_snapshot_restore_privilege: true
 plugins.security.nodes_dn:
-{% for (key,value) in instances.items() %}
+{% for (key,value) in wazuh_instances.items() %}
 - "CN={{ value.name }},OU=Wazuh,O=Wazuh,L=California,C=US"
 {% endfor %}
 plugins.security.restapi.roles_enabled:

--- a/roles/wazuh/wazuh-indexer/templates/tlsconfig.yml.j2
+++ b/roles/wazuh/wazuh-indexer/templates/tlsconfig.yml.j2
@@ -1,6 +1,6 @@
 ca:
-   root:
-      dn: CN=root.ca.{{ domain_name }},OU=CA,O={{ domain_name }}\, Inc.,DC={{ domain_name }}
+    root:
+      dn: CN=root.ca.{{ wazuh_domain_name }},OU=CA,O={{ wazuh_domain_name }}\, Inc.,DC={{ wazuh_domain_name }}
       keysize: 2048
       validityDays: 730
       pkPassword: none
@@ -24,11 +24,11 @@ defaults:
 # Specify the nodes of your ES cluster here
 #
 nodes:
-{% for (key,value) in instances.items() %}
+{% for (key,value) in wazuh_instances.items() %}
 {% if (value.ip is defined and value.ip | length > 0) %}
   - name: {{ value.name }}
-    dn: CN={{ value.name }}.{{ domain_name }},OU=Ops,O={{ domain_name }}\, Inc.,DC={{ domain_name }}
-    dns: {{ value.name }}.{{ domain_name }}
+    dn: CN={{ value.name }}.{{ wazuh_domain_name }},OU=Ops,O={{ wazuh_domain_name }}\, Inc.,DC={{ wazuh_domain_name }}
+    dns: {{ value.name }}.{{ wazuh_domain_name }}
     ip: {{ value.ip }}
 {% endif %}
 {% endfor %}
@@ -43,5 +43,5 @@ nodes:
 #
 clients:
   - name: admin
-    dn: CN=admin.{{ domain_name }},OU=Ops,O={{ domain_name }}\, Inc.,DC={{ domain_name }}
+    dn: CN=admin.{{ wazuh_domain_name }},OU=Ops,O={{ wazuh_domain_name }}\, Inc.,DC={{ wazuh_domain_name }}
     admin: true


### PR DESCRIPTION
Clean up the wazuh indexer role and fix ansible lint warnings to bring role into compliance with ansible standards. I have tested and it works with Almalinux 9.