### PR TITLE
fix: updated role with syntax so deployment using ansible won't fail

### DIFF
--- a/roles/wazuh/wazuh-indexer/tasks/security_actions.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/security_actions.yml
@@ -114,5 +114,5 @@
   register: result
   until: result.status in [200,201,401]
   when:
-    - indexer_custom_user is defined and indexer_custom_user
+    - indexer_custom_user is defined and indexer_custom_user != ""
     - inventory_hostname == ansible_play_hosts[0]


### PR DESCRIPTION
This will update the comparison for a custom user setting. This will fix an issue where a deployment would fail if custom settings are used for the API password but not the user by setting the `indexer_admin_password` variable.