### PR TITLE
Compare RHEL version as integer when having custom packages

### DIFF
--- a/roles/wazuh/ansible-wazuh-agent/tasks/installation_from_custom_packages.yml
+++ b/roles/wazuh/ansible-wazuh-agent/tasks/installation_from_custom_packages.yml
@@ -15,8 +15,8 @@
     when:
       - ansible_os_family|lower == "redhat"
       - wazuh_custom_packages_installation_agent_enabled
-      - not (ansible_distribution|lower == "centos" and ansible_distribution_major_version >= "8")
-      - not (ansible_distribution|lower == "redhat" and ansible_distribution_major_version >= "8")
+      - not (ansible_distribution|lower == "centos" and ansible_distribution_major_version | int >= 8)
+      - not (ansible_distribution|lower == "redhat" and ansible_distribution_major_version | int >= 8)
 
   - name: Install Wazuh Agent from .rpm packages | dnf
     dnf:
@@ -25,5 +25,5 @@
     when:
       - ansible_os_family|lower == "redhat"
       - wazuh_custom_packages_installation_agent_enabled
-      - (ansible_distribution|lower == "centos" and ansible_distribution_major_version >= "8") or
-        (ansible_distribution|lower == "redhat" and ansible_distribution_major_version >= "8")
+      - (ansible_distribution|lower == "centos" and ansible_distribution_major_version | int >= 8) or
+        (ansible_distribution|lower == "redhat" and ansible_distribution_major_version | int >= 8)

--- a/roles/wazuh/ansible-wazuh-manager/tasks/installation_from_custom_packages.yml
+++ b/roles/wazuh/ansible-wazuh-manager/tasks/installation_from_custom_packages.yml
@@ -17,8 +17,8 @@
         lock_timeout: 200
       when:
         - wazuh_custom_packages_installation_manager_enabled
-        - not (ansible_distribution|lower == "centos" and ansible_distribution_major_version >= "8")
-        - not (ansible_distribution|lower == "redhat" and ansible_distribution_major_version >= "8")
+        - not (ansible_distribution|lower == "centos" and ansible_distribution_major_version | int >= 8)
+        - not (ansible_distribution|lower == "redhat" and ansible_distribution_major_version | int >= 8)
 
     - name: Install Wazuh Manager from .rpm packages | dnf
       dnf:
@@ -26,7 +26,7 @@
         state: present
       when:
         - wazuh_custom_packages_installation_manager_enabled
-        - (ansible_distribution|lower == "centos" and ansible_distribution_major_version >= "8") or
-          (ansible_distribution|lower == "redhat" and ansible_distribution_major_version >= "8")
+        - (ansible_distribution|lower == "centos" and ansible_distribution_major_version | int >= 8) or
+          (ansible_distribution|lower == "redhat" and ansible_distribution_major_version | int >= 8)
     when:
       - ansible_os_family|lower == "redhat"


### PR DESCRIPTION
This fixes yum module being used instead of dnf on RHEL and clones >= 10. Otherwise, as the comparison is made as a string, "10" is always < "8" (and not the expected 10 >= 8).

Despite this, without this fix the playbook still works when the RHEL 10 installation has the appropriate yum wrapper installed, but it's not the best approach to mandate that, and on minimal installs that may not always be the case so the playbook shouldn't depend on it.