### PR TITLE
Fix `needrestart` task for debian in the dashboard role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix needrestart task for debian in the dashboard role ([#2087](https://github.com/wazuh/wazuh-ansible/pull/2087))
 - Wazuh indexer idempotency fix ([#2058](https://github.com/wazuh/wazuh-ansible/pull/2058))
 
 ### Deleted

--- a/roles/wazuh-dashboard/tasks/dependencies.yml
+++ b/roles/wazuh-dashboard/tasks/dependencies.yml
@@ -72,6 +72,9 @@
       when: needrestart_check.rc == 0
       block:
         - name: Debian-based | Get services that need restart
+          # noqa: risky-shell-pipe - pipefail is intentionally omitted: grep returns rc=1 when no
+          # NEEDRESTART-SVC lines are found (no services need restart), which is not an error.
+          # The trailing '|| true' ensures the pipeline always exits with rc=0.
           ansible.builtin.shell: |
             DEBIAN_FRONTEND=noninteractive needrestart -b 2>/dev/null | grep '^NEEDRESTART-SVC:' | awk '{print $2}' || true
           args:

--- a/roles/wazuh-dashboard/tasks/dependencies.yml
+++ b/roles/wazuh-dashboard/tasks/dependencies.yml
@@ -69,26 +69,23 @@
       changed_when: false
 
     - name: Debian-based | Restart required services after dependencies installation
-      when: needrestart_check is defined
+      when: needrestart_check.rc == 0
       block:
         - name: Debian-based | Get services that need restart
           ansible.builtin.shell: |
-            set -o pipefail
-            DEBIAN_FRONTEND=noninteractive needrestart -b 2>/dev/null | grep '^NEEDRESTART-SVC:' | awk '{print $2}'
+            DEBIAN_FRONTEND=noninteractive needrestart -b 2>/dev/null | grep '^NEEDRESTART-SVC:' | awk '{print $2}' || true
           args:
             executable: /bin/bash
           register: services_to_restart
           changed_when: false
-          when: needrestart_check.rc == 0
 
         - name: Debian-based | Restart required services (except SSH)
           ansible.builtin.systemd:
             name: "{{ item }}"
             state: restarted
-          loop: "{{ services_to_restart.stdout_lines | default([]) }}"
+          loop: "{{ services_to_restart.stdout_lines }}"
           when:
-            - needrestart_check.rc == 0
-            - services_to_restart.stdout_lines is defined
+            - services_to_restart.stdout_lines | length > 0
             - item not in ['ssh.service', 'sshd.service']
           failed_when: false
 
@@ -96,10 +93,9 @@
           ansible.builtin.systemd:
             name: "{{ item }}"
             state: restarted
-          loop: "{{ services_to_restart.stdout_lines | default([]) }}"
+          loop: "{{ services_to_restart.stdout_lines }}"
           when:
-            - needrestart_check.rc == 0
-            - services_to_restart.stdout_lines is defined
+            - services_to_restart.stdout_lines | length > 0
             - item in ['ssh.service', 'sshd.service']
           async: 1
           poll: 0
@@ -109,10 +105,7 @@
           ansible.builtin.wait_for_connection:
             delay: 30
             timeout: 300
-          when:
-            - needrestart_check.rc == 0
-            - services_to_restart.stdout_lines is defined
-            - "'ssh.service' in services_to_restart.stdout_lines or 'sshd.service' in services_to_restart.stdout_lines"
+          when: "'ssh.service' in services_to_restart.stdout_lines or 'sshd.service' in services_to_restart.stdout_lines"
 
     - name: Debian-based (AMD64) | Download wazuh-dashboard package
       ansible.builtin.get_url:


### PR DESCRIPTION
## Description

Fixes a deployment failure on Debian-based systems (e.g., Ubuntu 24.04) where the `needrestart` task in the `wazuh-dashboard` role would cause a non-zero return code even when no services required a restart.

### Root cause

Two bugs in `roles/wazuh-dashboard/tasks/dependencies.yml`:

1. **Wrong guard condition on the restart block**: The condition `when: needrestart_check is defined` was always `true` because Ansible's `register` directive always creates the variable regardless of whether the command succeeded. This caused the block to execute even when `needrestart` was not installed on the system.

2. **`set -o pipefail` combined with `grep` returning rc=1**: When no services require a restart, `needrestart -b` produces no `NEEDRESTART-SVC:` lines, so `grep` exits with rc=1 (expected behavior — no matches found). With `pipefail` enabled, this rc=1 was propagated as a failure for the entire pipeline, even though it is not an error condition.

### Changes

- **`wazuh-dashboard/tasks/dependencies.yml`**:
  - Fixed outer block condition from `when: needrestart_check is defined` to `when: needrestart_check.rc == 0`.
  - Replaced `set -o pipefail` with `|| true` at the end of the pipeline so that `grep` finding no matches does not cause a task failure.
  - Removed redundant `when: needrestart_check.rc == 0` from the inner shell task, as it is already guaranteed by the parent block condition.
  - Removed redundant `needrestart_check.rc == 0` and `services_to_restart.stdout_lines is defined` conditions from the service restart loops, since both are guaranteed within the block scope.
  - Removed `| default([])` filter from loop variables, as `register` always populates `stdout_lines` within the block.
  - Added `services_to_restart.stdout_lines | length > 0` guard to the restart loops to skip iteration entirely when no services need restarting.
  - Simplified `wait_for_connection` condition to a single expression, removing conditions already guaranteed by the block scope.

### Testing

Verified on Ubuntu 24.04 AIO deployment where `needrestart` is installed but no services require a restart after dependency installation. The playbook now completes successfully instead of failing with `non-zero return code`. In addition, an AL2023 was tested to ensure that everything was still working properly

- Ubuntu 24: https://github.com/wazuh/wazuh-ansible/issues/2045#issuecomment-4407019935
- AL2023: https://github.com/wazuh/wazuh-ansible/issues/2045#issuecomment-4419965806