### PR TITLE
Forbid run test in draft PRs - Distributed test workflow

### DIFF
--- a/.github/workflows/aio.yml
+++ b/.github/workflows/aio.yml
@@ -38,7 +38,6 @@ on:
           - -vvv
           - -vvvv
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
   release:
 env:
   AGENT_COMPOSITE_NAMES: >
@@ -53,7 +52,6 @@ jobs:
   setup-runner:
     name: Setup runner
     runs-on: ubuntu-22.04
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Display workflow inputs
         run: echo "${{ toJson(inputs) }}"

--- a/.github/workflows/aio.yml
+++ b/.github/workflows/aio.yml
@@ -38,6 +38,7 @@ on:
           - -vvv
           - -vvvv
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   release:
 env:
   AGENT_COMPOSITE_NAMES: >
@@ -52,6 +53,7 @@ jobs:
   setup-runner:
     name: Setup runner
     runs-on: ubuntu-22.04
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Display workflow inputs
         run: echo "${{ toJson(inputs) }}"

--- a/.github/workflows/distributed.yml
+++ b/.github/workflows/distributed.yml
@@ -38,6 +38,7 @@ on:
           - -vvv
           - -vvvv
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   release:
 env:
   AGENT_COMPOSITE_NAMES: >

--- a/.github/workflows/distributed.yml
+++ b/.github/workflows/distributed.yml
@@ -53,6 +53,7 @@ permissions:
 jobs:
   setup-runner:
     name: Setup runner
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-22.04
     steps:
       - name: Display workflow inputs


### PR DESCRIPTION
## Description

The goal of this PR is to prevent workflows from running on draft pull requests.

To achieve this, the necessary types have been added to the pull_request trigger, notably the `ready_for_review` type.

A condition has also been added to check whether the PR is in draft status, since the `synchronized` type in the pull_request trigger triggers whenever a commit is made to a PR, even if it is in draft status.


