### PR TITLE
Forbid run test in draft PRs

### DIFF
--- a/.github/workflows/aio.yml
+++ b/.github/workflows/aio.yml
@@ -38,7 +38,6 @@ on:
           - -vvv
           - -vvvv
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
   release:
 env:
   AGENT_COMPOSITE_NAMES: >
@@ -53,7 +52,6 @@ jobs:
   setup-runner:
     name: Setup runner
     runs-on: ubuntu-22.04
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Display workflow inputs
         run: echo "${{ toJson(inputs) }}"

--- a/.github/workflows/aio.yml
+++ b/.github/workflows/aio.yml
@@ -94,6 +94,16 @@ jobs:
           fi
           echo "COMMIT_LIST=$COMMIT_LIST" >> $GITHUB_OUTPUT
           echo "Revision list (indexer, manager, dashboard, agent, installation-assistant): $COMMIT_LIST"
+      - name: Checkout wazuh/wazuh-ansible repository
+        uses: actions/checkout@v4
+        with:
+          path: wazuh-ansible/
+      - name: Run ansible-lint
+        uses: ansible/ansible-lint@v25
+        with:
+          args: "-v wazuh-agent.yml wazuh-aio.yml wazuh-distributed.yml .github/playbooks/gather_agent_logs.yml .github/playbooks/gather_central_logs.yml"
+          working_directory: "wazuh-ansible"
+          requirements_file: "requirements.yml"
       - name: Configure AWS credentials (assume role)
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -396,7 +406,7 @@ jobs:
       fail-fast: false # all jobs will run even if one fails
       matrix:
         system: ${{ fromJson(needs.setup-runner.outputs.OS_LIST) }}
-    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+    if: ${{ always() && needs.setup-runner.result != 'skipped' }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -508,12 +518,12 @@ jobs:
           # Wait for all deletion tasks to complete
           wait
   final-cleanup:
-    name: Final validation and cleanup
+    name: Delete key pair for allocated instances
     needs:
       - setup-runner
       - stop-runner
     runs-on: ubuntu-22.04
-    if: ${{ always() }}
+    if: ${{ always() && needs.setup-runner.result != 'skipped' }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -540,13 +550,3 @@ jobs:
 
           aws ec2 delete-key-pair --key-name "$KEY_NAME" --region us-east-1
           echo "Deleted key pair: $KEY_NAME"
-      - name: Checkout wazuh/wazuh-ansible repository
-        uses: actions/checkout@v4
-        with:
-          path: wazuh-ansible/
-      - name: Run ansible-lint
-        uses: ansible/ansible-lint@v25
-        with:
-          args: "-v wazuh-agent.yml wazuh-aio.yml wazuh-distributed.yml .github/playbooks/gather_agent_logs.yml .github/playbooks/gather_central_logs.yml"
-          working_directory: "wazuh-ansible"
-          requirements_file: "requirements.yml"

--- a/.github/workflows/aio.yml
+++ b/.github/workflows/aio.yml
@@ -38,6 +38,7 @@ on:
           - -vvv
           - -vvvv
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   release:
 env:
   AGENT_COMPOSITE_NAMES: >
@@ -52,6 +53,7 @@ jobs:
   setup-runner:
     name: Setup runner
     runs-on: ubuntu-22.04
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Display workflow inputs
         run: echo "${{ toJson(inputs) }}"

--- a/.github/workflows/aio.yml
+++ b/.github/workflows/aio.yml
@@ -38,6 +38,7 @@ on:
           - -vvv
           - -vvvv
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   release:
 env:
   AGENT_COMPOSITE_NAMES: >
@@ -51,6 +52,7 @@ permissions:
 jobs:
   setup-runner:
     name: Setup runner
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-22.04
     steps:
       - name: Display workflow inputs

--- a/.github/workflows/distributed.yml
+++ b/.github/workflows/distributed.yml
@@ -38,6 +38,7 @@ on:
           - -vvv
           - -vvvv
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   release:
 env:
   AGENT_COMPOSITE_NAMES: >

--- a/.github/workflows/distributed.yml
+++ b/.github/workflows/distributed.yml
@@ -96,6 +96,16 @@ jobs:
           fi
           echo "COMMIT_LIST=$COMMIT_LIST" >> $GITHUB_OUTPUT
           echo "Revision list (indexer, manager, dashboard, agent, installation-assistant): $COMMIT_LIST"
+      - name: Checkout wazuh/wazuh-ansible repository
+        uses: actions/checkout@v4
+        with:
+          path: wazuh-ansible/
+      - name: Run ansible-lint
+        uses: ansible/ansible-lint@v25
+        with:
+          args: "-v wazuh-agent.yml wazuh-aio.yml wazuh-distributed.yml .github/playbooks/gather_agent_logs.yml .github/playbooks/gather_central_logs.yml"
+          working_directory: "wazuh-ansible"
+          requirements_file: "requirements.yml"
       - name: Configure AWS credentials (assume role)
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -437,7 +447,7 @@ jobs:
       fail-fast: false # all jobs will run even if one fails
       matrix:
         system: ${{ fromJson(needs.setup-runner.outputs.OS_LIST) }}
-    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+    if: ${{ always() && needs.setup-runner.result != 'skipped' }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -563,12 +573,12 @@ jobs:
           # Wait for all deletion tasks to complete
           wait
   final-cleanup:
-    name: Final validation and cleanup
+    name: Delete key pair for allocated instances
     needs:
       - setup-runner
       - stop-runner
     runs-on: ubuntu-22.04
-    if: ${{ always() }}
+    if: ${{ always() && needs.setup-runner.result != 'skipped' }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -595,13 +605,3 @@ jobs:
 
           aws ec2 delete-key-pair --key-name "$KEY_NAME" --region us-east-1
           echo "Deleted key pair: $KEY_NAME"
-      - name: Checkout wazuh/wazuh-ansible repository
-        uses: actions/checkout@v4
-        with:
-          path: wazuh-ansible/
-      - name: Run ansible-lint
-        uses: ansible/ansible-lint@v25
-        with:
-          args: "-v wazuh-agent.yml wazuh-aio.yml wazuh-distributed.yml .github/playbooks/gather_agent_logs.yml .github/playbooks/gather_central_logs.yml"
-          working_directory: "wazuh-ansible"
-          requirements_file: "requirements.yml"

--- a/.github/workflows/distributed.yml
+++ b/.github/workflows/distributed.yml
@@ -53,6 +53,7 @@ permissions:
 jobs:
   setup-runner:
     name: Setup runner
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-22.04
     steps:
       - name: Display workflow inputs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Forbid run test in draft PRs ([#2093](https://github.com/wazuh/wazuh-ansible/pull/2093))
 - Fixed Wazuh manager certificates handling ([#2055](https://github.com/wazuh/wazuh-ansible/pull/2055))
 - URLs file path update ([#2039](https://github.com/wazuh/wazuh-ansible/pull/2039))
 - Adapted the Ansible deployment according to the config.yml changes. ([#2000](https://github.com/wazuh/wazuh-ansible/pull/2000))


### PR DESCRIPTION
## Description

The goal of this PR is to prevent workflows from running on draft pull requests.

To achieve this, the necessary types have been added to the pull_request trigger, notably the ready_for_review type.

A condition has also been added to check whether the PR is in draft status, since the synchronized type in the pull_request trigger triggers whenever a commit is made to a PR, even if it is in draft status.

### Other changes

In addition, I've changed when the Ansible lint check runs, adding it to the first step so that if it fails, we'll know as soon as possible rather than after completing the entire installation and testing process.

## Testing 🧪 

<details>
<summary>Draft PRs</summary>

<img width="915" height="765" alt="image" src="https://github.com/user-attachments/assets/ef949320-e957-40b2-a458-fc5a651bfc63" />

</details>

<details>
<summary>Open PRs</summary>

<img width="867" height="880" alt="image" src="https://github.com/user-attachments/assets/c6ea0f36-ad78-4023-a3c5-fce57f8170cc" />

</details>