### PR TITLE
Delete PR option into test workflow

### DIFF
--- a/.github/workflows/al_aio.yml
+++ b/.github/workflows/al_aio.yml
@@ -1,6 +1,6 @@
 ---
 name: AIO-AL-Single-Instance
-on: [pull_request, workflow_dispatch, release]
+on: [workflow_dispatch, release]
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner

--- a/.github/workflows/al_wazuh.yml
+++ b/.github/workflows/al_wazuh.yml
@@ -1,6 +1,6 @@
 ---
 name: Wazuh-AL-Single-Instance
-on: [pull_request, workflow_dispatch, release]
+on: [workflow_dispatch, release]
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner

--- a/.github/workflows/centos_aio.yml
+++ b/.github/workflows/centos_aio.yml
@@ -1,6 +1,6 @@
 ---
 name: AIO-CentOS-Single-Instance
-on: [pull_request, workflow_dispatch, release]
+on: [workflow_dispatch, release]
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner

--- a/.github/workflows/centos_wazuh.yml
+++ b/.github/workflows/centos_wazuh.yml
@@ -1,6 +1,6 @@
 ---
 name: Wazuh-CentOS-Single-Instance
-on: [pull_request, workflow_dispatch, release]
+on: [workflow_dispatch, release]
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner

--- a/.github/workflows/ubuntu_aio.yml
+++ b/.github/workflows/ubuntu_aio.yml
@@ -1,6 +1,6 @@
 ---
 name: AIO-Ubuntu-Single-Instance
-on: [pull_request, workflow_dispatch, release]
+on: [workflow_dispatch, release]
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner

--- a/.github/workflows/ubuntu_wazuh.yml
+++ b/.github/workflows/ubuntu_wazuh.yml
@@ -1,6 +1,6 @@
 ---
 name: Wazuh-Ubuntu-Single-Instance
-on: [pull_request, workflow_dispatch, release]
+on: [workflow_dispatch, release]
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- None
+- Delete PR option into test workflow ([#2108](https://github.com/wazuh/wazuh-ansible/pull/2108))
 
 ### Fixed
 


### PR DESCRIPTION
This pull request removes the Pull Request execution option for repository test workflows, as the packages are not available for installation until a pre-release stage is reached.