### PR TITLE
Fixed 5.0.0 branch references after bump

### DIFF
--- a/.github/workflows/5_check_integration_tools.yaml
+++ b/.github/workflows/5_check_integration_tools.yaml
@@ -17,7 +17,7 @@ on:
       automation_reference:
         description: 'Branch of wazuh-automation to use'
         required: false
-        default: 'v5.0.0-beta3'
+        default: '5.0.0'
         type: string
       deployment_type:
         description: 'Deployment type to test'


### PR DESCRIPTION
close https://github.com/wazuh/wazuh-ansible/issues/2157

Fixed 5.0.0 branch references after bump