### PR TITLE
Remove software-properties-common from Debian.yml

### DIFF
--- a/roles/wazuh/wazuh-indexer/tasks/Debian.yml
+++ b/roles/wazuh/wazuh-indexer/tasks/Debian.yml
@@ -12,7 +12,6 @@
       - wget
       - curl
       - apt-transport-https
-      - software-properties-common
       - gnupg
     state: present
 


### PR DESCRIPTION
## What does this PR do?

Removes the `software-properties-common` package from the wazuh-indexer Ansible role's Debian dependency list, allowing the role to run successfully on Debian 13.

## Why was this PR needed?

The `software-properties-common` package is no longer available in Debian 13 (Trixie) stable repositories due to an unresolved upstream Debian bug. This causes the wazuh-indexer Ansible role to fail at the "Install Wazuh indexer dependencies" task with: "no available installation candidate for software-properties-common

## What are the relevant issue numbers?

Closes #1931

## Testing

- Reproduced the original failure on a Debian 13.3 VM running wazuh-ansible v4.14.2
- Verified the indexer role completes successfully on Debian 13 after the change
- No functional change expected on Debian 11/12 since the package was unused