### PR TITLE
Fixed Wazuh manager distributed key configuration for Ansible deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 
 ### Fixed
 
+- Wazuh-manager master and worker nodes keys do not match. ([#2206](https://github.com/wazuh/wazuh-ansible/issues/2206))
 - Fix bumper workflow failure when bump produces no changes ([#2195](https://github.com/wazuh/wazuh-ansible/pull/2195))
 - Bumper script issue when the tag is set to false ([#2159](https://github.com/wazuh/wazuh-ansible/issues/2159))
 - Ansible deployment fails on needrestart task when no services require restart ([#2045](https://github.com/wazuh/wazuh-ansible/issues/2045))

--- a/roles/wazuh-manager/tasks/main.yml
+++ b/roles/wazuh-manager/tasks/main.yml
@@ -175,6 +175,31 @@
       register: keystore_password_result
       changed_when: keystore_password_result.rc == 0
 
+    - name: Manager-config | Configure cluster authentication key
+      when: not single_node
+      run_once: true
+      delegate_to: localhost
+      become: false
+      block:
+        - name: Cluster-key | Generate shared cluster authentication key
+          ansible.builtin.shell:
+            cmd: |
+              set -o pipefail
+              openssl rand -hex 16 > "{{ local_configs_path }}/wazuh-cluster-key"
+              chmod 600 "{{ local_configs_path }}/wazuh-cluster-key"
+            executable: /bin/bash
+          args:
+            creates: "{{ local_configs_path }}/wazuh-cluster-key"
+
+        - name: Cluster-key | Read shared cluster authentication key
+          ansible.builtin.slurp:
+            path: "{{ local_configs_path }}/wazuh-cluster-key"
+          register: wazuh_cluster_key_raw
+
+        - name: Cluster-key | Set cluster authentication key fact
+          ansible.builtin.set_fact:
+            wazuh_cluster_key: "{{ wazuh_cluster_key_raw.content | b64decode | trim }}"
+
     - name: Manager-config | Edit the wazuh-manager.conf file
       block:
         - name: Manager-config | Replace indexer hosts in wazuh-manager.conf
@@ -199,6 +224,13 @@
             path: /var/wazuh-manager/etc/wazuh-manager.conf
             regexp: '(<node_type>)[^<]+(</node_type>)'
             replace: '\1{% if node_type == "master" or single_node %}master{% else %}worker{% endif %}\2'
+
+        - name: Manager-config | Edit cluster configuration in wazuh-manager.conf (cluster key)
+          ansible.builtin.replace:
+            path: /var/wazuh-manager/etc/wazuh-manager.conf
+            regexp: '(<node_type>[^<]+</node_type>\s*)<key>[^<]*(</key>)'
+            replace: '\g<1><key>{{ wazuh_cluster_key }}\g<2>'
+          when: not single_node
 
         - name: Manager-config | Edit cluster configuration in wazuh-manager.conf (bind address)
           ansible.builtin.replace:


### PR DESCRIPTION
close https://github.com/wazuh/wazuh-ansible/issues/2206

## Description

- "Configure cluster authentication key" block — on first run, generates a key with openssl rand -hex 16 into {{ local_configs_path }}/wazuh-cluster-key (the same already-gitignored scratch directory used for certificates). It's guarded with creates:, so it's only generated once — whichever manager play (master or worker) runs first creates it, and later plays just reuse the same file. It's read via slurp and stored as the wazuh_cluster_key fact.

- New replace task for the <key> tag inside <cluster> in wazuh-manager.conf, injecting that shared key — right alongside the existing node_name/node_type/bind_addr replacements.
This solves the root cause: by default each node's installer generates its own random cluster key, so master and worker never match. Now every manager node in the deployment (run via wazuh-distributed.yml) reads/writes the same local key file on the Ansible controller, guaranteeing an identical <key> value across all nodes.

One thing worth flagging: the key file lives on the machine running Ansible, at deployment-config-files/wazuh-cluster-key (chmod 600, and that whole directory is already in .gitignore), so it won't get committed — but if you tear down and redeploy without removing that directory, the same key will be reused, which is actually what you want for idempotency.

## Test

- https://github.com/wazuh/wazuh-ansible/issues/2206#issuecomment-4980331212