### PR TITLE
Fix changelog check to accept Prior versions entries

### DIFF
--- a/.github/workflows/5_changelog_check.yml
+++ b/.github/workflows/5_changelog_check.yml
@@ -36,8 +36,12 @@ jobs:
             INVALID=$(echo "$ADDED" | grep -E '^- ' | grep -vx -- '- None' | grep -vE "$ENTRY_REGEX" | grep -vE "$PRIOR_VERSION_REGEX" || true)
             if [ -n "$INVALID" ]; then
               FORMAT="❌"
-              echo "::error::Invalid CHANGELOG.md entries. Expected format: '- Description ([#123](https://github.com/<org>/<repo>/issues/123))'. Offending lines:"
+              echo "::error::Invalid CHANGELOG.md entries. Offending lines:"
               echo "$INVALID"
+              echo "::error::Expected formats:"
+              echo "::error::  - Change entry: '- Description ([#123](https://github.com/<org>/<repo>/issues/123))'"
+              echo "::error::  - Prior versions entry: '- [vX.Y.Z](https://github.com/<org>/<repo>/blob/vX.Y.Z/CHANGELOG.md)'"
+              echo "::error::  - Prior versions placeholder (no prior version): '- []()'"
             fi
           fi
 

--- a/.github/workflows/5_changelog_check.yml
+++ b/.github/workflows/5_changelog_check.yml
@@ -31,15 +31,17 @@ jobs:
           else
             FORMAT="✅"
 
-            ENTRY_REGEX='^- .+ \(\[#[0-9]+\]\(https://github\.com/[^)]+/(issues|pull)/[0-9]+\)\)$'
+            TABLE_ENTRY_REGEX='^\| \[#[0-9]+\]\(https://github\.com/[^)]+/(issues|pull)/[0-9]+\) \| .+ \|$'
+            TABLE_HEADER_REGEX='^\| Issue \| Comment \|$|^\| - \| - \|$'
             PRIOR_VERSION_REGEX='^- \[v?[0-9]+\.[0-9]+\.[0-9]+\]\(https://github\.com/[^)]+/blob/[^)]+/CHANGELOG\.md\)$|^- \[\]\(\)$'
-            INVALID=$(echo "$ADDED" | grep -E '^- ' | grep -vx -- '- None' | grep -vE "$ENTRY_REGEX" | grep -vE "$PRIOR_VERSION_REGEX" || true)
+            INVALID=$(echo "$ADDED" | grep -E '^(\||-)' | grep -vx -- '- None' | grep -vE "$TABLE_HEADER_REGEX" | grep -vE "$TABLE_ENTRY_REGEX" | grep -vE "$PRIOR_VERSION_REGEX" || true)
+
             if [ -n "$INVALID" ]; then
               FORMAT="❌"
               echo "::error::Invalid CHANGELOG.md entries. Offending lines:"
               echo "$INVALID"
               echo "::error::Expected formats:"
-              echo "::error::  - Change entry: '- Description ([#123](https://github.com/<org>/<repo>/issues/123))'"
+              echo "::error::  - Table entry: '| [#123](https://github.com/<org>/<repo>/issues/123) | Description |'"
               echo "::error::  - Prior versions entry: '- [vX.Y.Z](https://github.com/<org>/<repo>/blob/vX.Y.Z/CHANGELOG.md)'"
               echo "::error::  - Prior versions placeholder (no prior version): '- []()'"
             fi

--- a/.github/workflows/5_changelog_check.yml
+++ b/.github/workflows/5_changelog_check.yml
@@ -32,7 +32,8 @@ jobs:
             FORMAT="✅"
 
             ENTRY_REGEX='^- .+ \(\[#[0-9]+\]\(https://github\.com/[^)]+/(issues|pull)/[0-9]+\)\)$'
-            INVALID=$(echo "$ADDED" | grep -E '^- ' | grep -vx -- '- None' | grep -vE "$ENTRY_REGEX" || true)
+            PRIOR_VERSION_REGEX='^- \[v?[0-9]+\.[0-9]+\.[0-9]+\]\(https://github\.com/[^)]+/blob/[^)]+/CHANGELOG\.md\)$|^- \[\]\(\)$'
+            INVALID=$(echo "$ADDED" | grep -E '^- ' | grep -vx -- '- None' | grep -vE "$ENTRY_REGEX" | grep -vE "$PRIOR_VERSION_REGEX" || true)
             if [ -n "$INVALID" ]; then
               FORMAT="❌"
               echo "::error::Invalid CHANGELOG.md entries. Expected format: '- Description ([#123](https://github.com/<org>/<repo>/issues/123))'. Offending lines:"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,13 +67,14 @@
 
 | Issue | Comment |
 | - | - |
+| [#3657](https://github.com/wazuh/wazuh-automation/issues/3657) | Fix changelog check to accept Prior versions entries |
 | [#2218](https://github.com/wazuh/wazuh-ansible/issues/2218) | RedHat-based agent install task does not set WAZUH_REGISTRATION_PASSWORD, breaking auto-enrollment. |
 | [#2206](https://github.com/wazuh/wazuh-ansible/issues/2206) | Wazuh-manager master and worker nodes keys do not match. |
 | [#2195](https://github.com/wazuh/wazuh-ansible/pull/2195) | Fix bumper workflow failure when bump produces no changes |
 | [#2159](https://github.com/wazuh/wazuh-ansible/issues/2159) | Bumper script issue when the tag is set to false |
 | [#2045](https://github.com/wazuh/wazuh-ansible/issues/2045) | Ansible deployment fails on needrestart task when no services require restart |
 | [#2056](https://github.com/wazuh/wazuh-ansible/issues/2056) | No idempotency for the `opensearch.yml` configurations |
-| [#3657](https://github.com/wazuh/wazuh-automation/issues/3657) | Fix changelog check to accept Prior versions entries |
+
 
 ## Prior version
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 | [#2159](https://github.com/wazuh/wazuh-ansible/issues/2159) | Bumper script issue when the tag is set to false |
 | [#2045](https://github.com/wazuh/wazuh-ansible/issues/2045) | Ansible deployment fails on needrestart task when no services require restart |
 | [#2056](https://github.com/wazuh/wazuh-ansible/issues/2056) | No idempotency for the `opensearch.yml` configurations |
+| [#3657](https://github.com/wazuh/wazuh-automation/issues/3657) | Fix changelog check to accept Prior versions entries |
 
 ## Prior version
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@
 
 | Issue | Comment |
 | - | - |
-| [#3657](https://github.com/wazuh/wazuh-automation/issues/3657) | Fix changelog check to accept Prior versions entries |
+| [#2233](https://github.com/wazuh/wazuh-automation/issues/2233) | Fix changelog check to accept Prior versions entries |
 | [#2218](https://github.com/wazuh/wazuh-ansible/issues/2218) | RedHat-based agent install task does not set WAZUH_REGISTRATION_PASSWORD, breaking auto-enrollment. |
 | [#2206](https://github.com/wazuh/wazuh-ansible/issues/2206) | Wazuh-manager master and worker nodes keys do not match. |
 | [#2195](https://github.com/wazuh/wazuh-ansible/pull/2195) | Fix bumper workflow failure when bump produces no changes |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@
 
 | Issue | Comment |
 | - | - |
-| [#2233](https://github.com/wazuh/wazuh-automation/issues/2233) | Fix changelog check to accept Prior versions entries |
+| [#2233](https://github.com/wazuh/wazuh-ansible/issues/2233) | Fix changelog check to accept Prior versions entries |
 | [#2218](https://github.com/wazuh/wazuh-ansible/issues/2218) | RedHat-based agent install task does not set WAZUH_REGISTRATION_PASSWORD, breaking auto-enrollment. |
 | [#2206](https://github.com/wazuh/wazuh-ansible/issues/2206) | Wazuh-manager master and worker nodes keys do not match. |
 | [#2195](https://github.com/wazuh/wazuh-ansible/pull/2195) | Fix bumper workflow failure when bump produces no changes |


### PR DESCRIPTION
## Changes
- Added a `PRIOR_VERSION_REGEX` pattern recognizing version changelog
  links and the empty placeholder `- []()`
- Standard PR/Issue entries continue to validate as before

## Tests
Verified with test PRs (not to be merged):

- Standard entry (valid): https://github.com/wazuh/wazuh-ansible/pull/2234 → **passed**
- Prior versions entry (valid): https://github.com/wazuh/wazuh-ansible/pull/2235 → **passed**
- Both sections combined (valid): https://github.com/wazuh/wazuh-ansible/pull/2236 → **passed**
- Invalid format entry: https://github.com/wazuh/wazuh-ansible/pull/2237 → **failed**
- Another invalid format entry: https://github.com/wazuh/wazuh-ansible/pull/2238 → **failed**

## Related issue
https://github.com/wazuh/wazuh-automation/issues/3657