### PR TITLE
[TEST - DO NOT MERGE] Validate changelog_check correctly rejects invalid entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 
 | Issue | Comment |
 | - | - |
+| This is not a valid entry format | Missing issue link |
 | [#2233](https://github.com/wazuh/wazuh-ansible/issues/2233) | Fix changelog check to accept Prior versions entries |
 | [#2218](https://github.com/wazuh/wazuh-ansible/issues/2218) | RedHat-based agent install task does not set WAZUH_REGISTRATION_PASSWORD, breaking auto-enrollment. |
 | [#2206](https://github.com/wazuh/wazuh-ansible/issues/2206) | Wazuh-manager master and worker nodes keys do not match. |
@@ -78,4 +79,4 @@
 
 ## Prior version
 
-- []()
+- [](


### PR DESCRIPTION
## Purpose
Test PR to confirm that, after the changelog_check fix, the workflow still correctly **fails** on malformed entries.

## Related pull request
https://github.com/wazuh/wazuh-ansible/pull/2233