### PR TITLE
Adapt Allocator install and invocation to new Python package

### DIFF
--- a/.github/workflows/5_check_integration_tools.yaml
+++ b/.github/workflows/5_check_integration_tools.yaml
@@ -345,7 +345,7 @@ jobs:
         run: |
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
-          pip install -r wazuh-automation/deployability/deps/requirements.txt
+          pip install ./wazuh-automation/deployability/modules/allocation
           pip install ansible-core==2.16
           ansible-galaxy collection install -r wazuh-ansible/requirements.yml
 
@@ -367,7 +367,7 @@ jobs:
       - name: Allocate AIO EC2 instance
         if: matrix.deployment_type == 'aio'
         run: |
-          python3 wazuh-automation/deployability/modules/allocation/main.py \
+          wazuh-allocator \
             --action create \
             --provider aws \
             --size medium \
@@ -412,7 +412,7 @@ jobs:
           for i in ${!instance_names[@]}; do
             instance_name=${instance_names[$i]}
             (
-              python3 wazuh-automation/deployability/modules/allocation/main.py \
+              wazuh-allocator \
                 --action create \
                 --provider aws \
                 --size medium \
@@ -899,7 +899,7 @@ jobs:
               mkdir -p "$instance_dir"
               date > "$instance_dir/date.txt"
             fi
-            python3 wazuh-automation/deployability/modules/allocation/main.py \
+            wazuh-allocator \
               --action delete --track-output "$TRACK_FILE"
           fi
 
@@ -919,7 +919,7 @@ jobs:
               date > "$instance_dir/date.txt"
             fi
             (
-              python3 wazuh-automation/deployability/modules/allocation/main.py \
+              wazuh-allocator \
                 --action delete --track-output "$TRACK_FILE"
             ) &
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#2256](https://github.com/wazuh/wazuh-ansible/pull/2256) | Adapt Allocator install and invocation to the new installable Python package |
 | [#2248](https://github.com/wazuh/wazuh-ansible/issues/2248) | Change Codebuild runners to Github runners. |
 | [#2213](https://github.com/wazuh/wazuh-ansible/issues/2213) | Change upload and download methods. |
 | [#2203](https://github.com/wazuh/wazuh-ansible/issues/2203) | Update deployment for Wazuh Indexer 5.0.0 RBAC. |

--- a/docs/ref/integration_test/ansible_integration_tests.md
+++ b/docs/ref/integration_test/ansible_integration_tests.md
@@ -164,7 +164,7 @@ The private key is saved locally and used for all SSH connections in this matrix
 **AIO — 1 instance:**
 
 ```bash
-python3 wazuh-automation/deployability/modules/allocation/main.py \
+wazuh-allocator \
   --action create \
   --provider aws \
   --size medium \


### PR DESCRIPTION
Updates this workflow to use the Allocator's new package interface: installs it via `pip install ./wazuh-automation/deployability/modules/allocation` instead of the removed `requirements.txt`, and switches all four Allocator invocations (AIO create, per-instance create loop, single delete, parallel delete loop) from direct `main.py` execution to the `wazuh-allocator` console entry point. 

## Related to:
https://github.com/wazuh/internal-devel-requests/issues/5888

