### PR TITLE
feat(indexer): add support for custom OpenSearch node roles (e.g. quorum-only nodes)

### DIFF
--- a/roles/wazuh-indexer/tasks/config_files_setup.yml
+++ b/roles/wazuh-indexer/tasks/config_files_setup.yml
@@ -304,6 +304,14 @@
               {% endif %}
               {% endfor %}
 
+    - name: OpenSearch Config | Set custom node.roles if defined in vars
+      ansible.builtin.lineinfile:
+        path: /etc/wazuh-indexer/opensearch.yml
+        regexp: '^node\.roles:'
+        line: 'node.roles: {{ instances[inventory_hostname].opensearch_roles | to_json }}'
+        insertafter: '^node\.name:'
+      when: instances[inventory_hostname].opensearch_roles is defined
+
     - name: Add single-node discovery type if needed
       ansible.builtin.lineinfile:
         path: /etc/wazuh-indexer/opensearch.yml


### PR DESCRIPTION
## Description
This PR introduces the ability to configure custom OpenSearch roles (`node.roles`) for Wazuh Indexer nodes directly from the `instances` dictionary in the playbook variables. 

## Motivation and Context
In distributed multi-datacenter environments, some datacenters may be connected via slower or highly utilized network links. In such architectures, it is crucial to have the ability to configure a specific indexer node exclusively as a `cluster_manager` (acting purely as a voting/quorum node) without assigning it the `data` role. 

Previously, all nodes were implicitly created as full data nodes. This change allows users to prevent heavy data replication over slow links while still maintaining the cluster's high availability and quorum requirements.

## How to use
Users can now simply define `opensearch_roles` for a specific node in their `instances` variable definition. For example:

```yaml
instances:
  wi3:
    name: indexer-3
    ip: "10.0.0.3"
    role: indexer
    opensearch_roles: ["cluster_manager"]