### PR TITLE
Adapt manager certificate deployment to unified layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#2255](https://github.com/wazuh/wazuh-ansible/issues/2255) | Adapt certificate deployment to the unified manager certificate layout (root:wazuh-manager 0640, dir 1770) |
 | [#2218](https://github.com/wazuh/wazuh-ansible/issues/2218) | RedHat-based agent install task does not set WAZUH_REGISTRATION_PASSWORD, breaking auto-enrollment. |
 | [#2206](https://github.com/wazuh/wazuh-ansible/issues/2206) | Wazuh-manager master and worker nodes keys do not match. |
 | [#2195](https://github.com/wazuh/wazuh-ansible/pull/2195) | Fix bumper workflow failure when bump produces no changes |

--- a/roles/wazuh-manager/tasks/main.yml
+++ b/roles/wazuh-manager/tasks/main.yml
@@ -108,28 +108,16 @@
         group: wazuh-manager
         mode: '0640'
 
-    - name: Copy the manager's indexer certificates from local to the Wazuh Manager instance
+    - name: Copy the manager's indexer certificate/key to the Wazuh Manager instance
       ansible.builtin.copy:
-        src: "{{ local_configs_path }}/wazuh-certificates/{{ item }}"
-        dest: "{{ full_cert_path | dirname }}/{{ item }}"
-        owner: root
-        group: wazuh-manager
-        mode: '0640'
-      with_items:
-        - "{{ manager_node_name }}-key.pem"
-        - "{{ manager_node_name }}.pem"
-
-    - name: Copy certificates to match default names
-      ansible.builtin.copy:
-        src: "{{ item.src }}"
+        src: "{{ local_configs_path }}/wazuh-certificates/{{ item.src }}"
         dest: "{{ item.dest }}"
-        remote_src: true
         owner: root
         group: wazuh-manager
         mode: '0640'
       with_items:
-        - { src: "{{ full_cert_path | dirname }}/{{ manager_node_name }}.pem", dest: "{{ full_cert_path }}" }
-        - { src: "{{ full_key_path | dirname }}/{{ manager_node_name }}-key.pem", dest: "{{ full_key_path }}" }
+        - { src: "{{ manager_node_name }}.pem", dest: "{{ full_cert_path }}" }
+        - { src: "{{ manager_node_name }}-key.pem", dest: "{{ full_key_path }}" }
       when: item.src != item.dest
 
     - name: Keystore | Set Indexer username

--- a/roles/wazuh-manager/tasks/main.yml
+++ b/roles/wazuh-manager/tasks/main.yml
@@ -85,62 +85,37 @@
         daemon_reload: true
       become: true
 
-    - name: Detect expected indexer SSL certificate names from wazuh-manager.conf
+    - name: Set the manager's indexer client certificate/key paths
       block:
-        - name: Read wazuh-manager.conf
-          ansible.builtin.slurp:
-            path: /var/wazuh-manager/etc/wazuh-manager.conf
-          register: wazuh_manager_conf_raw
-          changed_when: false
-
-        - name: Extract expected certificate/key
-          ansible.builtin.set_fact:
-            expected_cert_path: "{{ (certificate_paths | first | default('') | trim) }}"
-            expected_key_path: "{{ (key_paths | first | default('') | trim) }}"
-          vars:
-            conf_text: "{{ wazuh_manager_conf_raw.content | b64decode }}"
-            certificate_paths: "{{ conf_text | regex_findall('(?s)<certificate>\\s*([^<]+\\.pem)\\s*</certificate>') }}"
-            key_paths: "{{ conf_text | regex_findall('(?s)<key>\\s*([^<]+\\.pem)\\s*</key>') }}"
-
-        - name: Inspect extraction results
-          ansible.builtin.debug:
-            msg:
-              - "Cert Path Found: '{{ expected_cert_path }}'"
-              - "Key Path Found: '{{ expected_key_path }}'"
-
         - name: Set cert and key full paths
           ansible.builtin.set_fact:
-            full_cert_path: "{{ wazuh_manager_install_path }}{{ expected_cert_path }}"
-            full_key_path: "{{ wazuh_manager_install_path }}{{ expected_key_path }}"
-
-        - name: Validate expected certificate and key filenames
-          ansible.builtin.assert:
-            that:
-              - ( expected_cert_path | length > 0 ) and ( expected_key_path | length > 0 )
-              - ( expected_cert_path is match('^/?.+\\.pem$') )
-              - ( expected_key_path is match('^/?.+\\.pem$') )
-            fail_msg: >-
-              Invalid indexer SSL certificate/key filenames detected from
-              /var/wazuh-manager/etc/wazuh-manager.conf.
-          changed_when: false
+            full_cert_path: "{{ wazuh_manager_install_path }}etc/certs/indexer-connector.pem"
+            full_key_path: "{{ wazuh_manager_install_path }}etc/certs/indexer-connector-key.pem"
 
         - name: Create expected cert/key directory (if does not exist)
           ansible.builtin.file:
             path: "{{ full_cert_path | dirname }}"
             state: directory
-            owner: wazuh-manager
+            owner: root
             group: wazuh-manager
-            mode: "0700"
+            mode: "1770"
 
-    - name: Copy the certificates from local to the Wazuh Manager instance
+    - name: Copy root-ca certificate from local to the Wazuh Manager instance
+      ansible.builtin.copy:
+        src: "{{ local_configs_path }}/wazuh-certificates/root-ca.pem"
+        dest: "{{ full_cert_path | dirname }}/root-ca.pem"
+        owner: root
+        group: wazuh-manager
+        mode: '0640'
+
+    - name: Copy the manager's indexer certificates from local to the Wazuh Manager instance
       ansible.builtin.copy:
         src: "{{ local_configs_path }}/wazuh-certificates/{{ item }}"
         dest: "{{ full_cert_path | dirname }}/{{ item }}"
-        owner: wazuh-manager
+        owner: root
         group: wazuh-manager
-        mode: '0400'
+        mode: '0640'
       with_items:
-        - "root-ca.pem"
         - "{{ manager_node_name }}-key.pem"
         - "{{ manager_node_name }}.pem"
 
@@ -149,9 +124,9 @@
         src: "{{ item.src }}"
         dest: "{{ item.dest }}"
         remote_src: true
-        owner: wazuh-manager
+        owner: root
         group: wazuh-manager
-        mode: '0400'
+        mode: '0640'
       with_items:
         - { src: "{{ full_cert_path | dirname }}/{{ manager_node_name }}.pem", dest: "{{ full_cert_path }}" }
         - { src: "{{ full_key_path | dirname }}/{{ manager_node_name }}-key.pem", dest: "{{ full_key_path }}" }

--- a/roles/wazuh-manager/tasks/main.yml
+++ b/roles/wazuh-manager/tasks/main.yml
@@ -85,12 +85,39 @@
         daemon_reload: true
       become: true
 
-    - name: Set the manager's indexer client certificate/key paths
+    - name: Detect the manager's indexer client certificate/key paths from wazuh-manager.conf
       block:
+        - name: Read wazuh-manager.conf
+          ansible.builtin.slurp:
+            path: /var/wazuh-manager/etc/wazuh-manager.conf
+          register: wazuh_manager_conf_raw
+          changed_when: false
+
+        - name: Extract the indexer SSL certificate/key paths
+          ansible.builtin.set_fact:
+            expected_cert_path: "{{ (indexer_certificates | first | default('') | trim) }}"
+            expected_key_path: "{{ (indexer_keys | first | default('') | trim) }}"
+          vars:
+            conf_text: "{{ wazuh_manager_conf_raw.content | b64decode | regex_replace('(?s)<!--.*?-->', '') }}"
+            indexer_ssl_block: "{{ conf_text | regex_findall('(?s)<indexer[^>]*>.*?<ssl>(.*?)</ssl>.*?</indexer>') | first | default('') }}"
+            indexer_certificates: "{{ indexer_ssl_block | regex_findall('(?s)<certificate>\\s*([^<]+\\.pem)\\s*</certificate>') }}"
+            indexer_keys: "{{ indexer_ssl_block | regex_findall('(?s)<key>\\s*([^<]+\\.pem)\\s*</key>') }}"
+
+        - name: Validate expected certificate and key filenames
+          ansible.builtin.assert:
+            that:
+              - ( expected_cert_path | length > 0 ) and ( expected_key_path | length > 0 )
+              - ( expected_cert_path is match('^/?.+\\.pem$') )
+              - ( expected_key_path is match('^/?.+\\.pem$') )
+            fail_msg: >-
+              Could not find the indexer SSL certificate/key paths inside the <indexer><ssl>
+              block of /var/wazuh-manager/etc/wazuh-manager.conf.
+          changed_when: false
+
         - name: Set cert and key full paths
           ansible.builtin.set_fact:
-            full_cert_path: "{{ wazuh_manager_install_path }}etc/certs/indexer-connector.pem"
-            full_key_path: "{{ wazuh_manager_install_path }}etc/certs/indexer-connector-key.pem"
+            full_cert_path: "{{ wazuh_manager_install_path }}{{ expected_cert_path }}"
+            full_key_path: "{{ wazuh_manager_install_path }}{{ expected_key_path }}"
 
         - name: Create expected cert/key directory (if does not exist)
           ansible.builtin.file:


### PR DESCRIPTION
Change directory and file ownership for the manager's indexer trust material (root-ca.pem + the node's own cert/key, whatever name wazuh-manager.conf declares) from wazuh-manager:wazuh-manager to root:wazuh-manager, and bump modes from 0700/0400 to 1770/0640 respectively, matching the unified certificate layout (wazuh#38281, wazuh-installation-assistant#970).

No filename rename was needed here: this role already reads the expected certificate/key names dynamically from wazuh-manager.conf instead of hardcoding them.

Fixes #2255