### PR TITLE
Reported skipped bumps in the repository bumper workflow instead of failing

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -179,12 +179,15 @@ jobs:
           PR_NUMBER=$(gh pr list --head "$BUMP_BRANCH" --base "${{ github.ref_name }}" --state merged --json number --jq '.[0].number')
 
           if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
-            echo "Error: The original PR for the bump was not found"
+            echo "The original PR for the bump was not found"
             echo "Searching merged PR from: $BUMP_BRANCH to ${{ github.ref_name }}"
-            exit 1
+            echo "pr_found=false" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
 
           echo "Original PR found: #$PR_NUMBER"
+          echo "pr_found=true" >> $GITHUB_OUTPUT
 
           MERGE_COMMIT=$(gh pr view $PR_NUMBER --json mergeCommit --jq '.mergeCommit.oid')
 
@@ -202,6 +205,17 @@ jobs:
             git commit -m "feat: revert ${{ github.ref_name }} references"
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
+
+      - name: "Result: original bump pull request not found"
+        if: inputs.revert == true && steps.revert_step.outputs.pr_found == 'false'
+        run: echo "There is no original bump pull request to revert, nothing to do."
+
+      - name: "Result: no changes to commit"
+        if: >-
+          (inputs.revert != true && steps.bump_commit.outputs.has_changes == 'false') ||
+          (inputs.revert == true && steps.revert_step.outputs.pr_found == 'true' &&
+          steps.revert_step.outputs.has_changes == 'false')
+        run: echo "The bump produced no changes, no pull request was created."
 
       - name: Push changes
         if: (inputs.revert != true && steps.bump_commit.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#2246](https://github.com/wazuh/wazuh-ansible/issues/2246) | Report skipped bumps in the repository bumper workflow |
 | [#2233](https://github.com/wazuh/wazuh-ansible/issues/2233) | Fix changelog check to accept Prior versions entries |
 | [#2218](https://github.com/wazuh/wazuh-ansible/issues/2218) | RedHat-based agent install task does not set WAZUH_REGISTRATION_PASSWORD, breaking auto-enrollment. |
 | [#2206](https://github.com/wazuh/wazuh-ansible/issues/2206) | Wazuh-manager master and worker nodes keys do not match. |


### PR DESCRIPTION
## Related Issue #2246 

## Description

`.github/workflows/5_bumper_repository.yml` ended with the `failure` conclusion in a harmless situation: when reverting a bump whose original pull request doesn't exist (because that bump introduced no changes),
the `Revert references (Revert)` step ran `exit 1`. The release orchestrator in `wazuh-qa-automation` (wazuh-qa-automation#8027) can now tell apart a real failure from a no-op bump/revert, but only by reading
the **names of the steps** that ran in the workflow — so this workflow needed to stop failing in that case and explicitly report it.

The other harmless case described in the parent issue — a bump run producing no changes — was already handled correctly in this repo via the existing `Commit changes (Bump)` step, which already guards the commit with `git diff --staged --quiet` and reports `has_changes=false` instead of failing. No changes were needed there.

## Changes

- **`Revert references (Revert)`**: replaced the `exit 1` on "original  PR not found" with `pr_found=false` / `has_changes=false` outputs and  `exit 0`. Also added `pr_found=true` on the success path, needed by
  the new result step below.
- Added two new steps, with names kept **exactly** as specified in the issue (matched by the orchestrator, trimmed and case-insensitive):
  - `"Result: original bump pull request not found"`
  - `"Result: no changes to commit"`
- `Push changes` / `Create pull request` / `Merge pull request` already  had the correct combined conditions on `has_changes` for both bump and  revert paths — left untouched.

## Validation

Ran the workflow 4 times against a disposable branch (`test/2246-validation`, since deleted), using `Use workflow from:
fix/2246-report-skipped-bumps` so the fixed code was exercised, with a throwaway version (`9.9.9-alpha0`) to avoid touching anything real.

| # | Scenario | Result | Run |
|---|---|---|---|
| 1 | Normal bump | ✅ Success — PR created & merged, neither result step ran | [Run](https://github.com/wazuh/wazuh-ansible/actions/runs/32473502751) |
| 2 | Bump with no changes | ✅ Success — `Result: no changes to commit` ran, Push/Create PR/Merge PR skipped | [Run](https://github.com/wazuh/wazuh-ansible/actions/runs/32473699025) |
| 3 | Revert with no original PR | ✅ Success — `Result: original bump pull request not found` ran, no PR created | [Run](https://github.com/wazuh/wazuh-ansible/actions/runs/32473898347) |
| 4 | Normal revert | ✅ Success — found the original PR, reverted it, PR created & merged, neither result step ran | [Run](https://github.com/wazuh/wazuh-ansible/actions/runs/32475184311) |

All four scenarios match the behaviour required by the issue. Test branch and its bump/revert branches were deleted after validation (PR merges auto-deleted the bump/revert branches; the disposable base branch was deleted manually).