### PR TITLE
Add optional wazuh_manager_endpoint support to wazuh-agent role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#2267](https://github.com/wazuh/wazuh-ansible/issues/2267) | Add optional wazuh_manager_endpoint support to wazuh-agent role |
 | [#2173](https://github.com/wazuh/wazuh-ansible/pull/2173) | Added bump-issue-link support for Revert Stage Bump. |
 | [#2166](https://github.com/wazuh/wazuh-ansible/pull/2166) | Add integration test module docs |
 | [#1920](https://github.com/wazuh/wazuh-ansible/issues/1920) | Implement the wazuh-ansible integration testing module |

--- a/docs/ref/variables.md
+++ b/docs/ref/variables.md
@@ -245,3 +245,21 @@ These variables are defined in `roles/wazuh-agent/defaults/main.yml`.
 **Variable:** `wazuh_agent_package_name`  
 **Description:** Base filename (without architecture suffix or extension) of the Wazuh Agent package to download and install.  
 **Default value:** `wazuh-agent-{{ wazuh_full_version }}-{{ wazuh_package_revision }}`
+
+---
+
+**Variable:** `wazuh_manager_address`  
+**Description:** Hostname or IP of the Wazuh manager the agent will connect and enroll to. Defined in `wazuh-agent.yml` (not in `defaults/main.yml`), maps to the `WAZUH_MANAGER` install-time variable.  
+**Default value:** `<Your Wazuh Manager IP>` (must be overridden)
+
+---
+
+**Variable:** `wazuh_registration_password`  
+**Description:** Password used for agent auto-enrollment. Defined in `wazuh-agent.yml` (not in `defaults/main.yml`), maps to the `WAZUH_REGISTRATION_PASSWORD` install-time variable.  
+**Default value:** `<Your Wazuh Manager Registration Password>` (must be overridden)
+
+---
+
+**Variable:** `wazuh_manager_endpoint`  
+**Description:** Optional. Full connection URL for the manager (`host[:port][/path]`), maps to the `WAZUH_MANAGER_ENDPOINT` install-time variable. Added ahead of [wazuh/wazuh#38624](https://github.com/wazuh/wazuh/issues/38624), which will replace `WAZUH_MANAGER`/`WAZUH_MANAGER_PORT` with this single variable at RC1. Empty keeps the role on the legacy `wazuh_manager_address`/`WAZUH_MANAGER` path.  
+**Default value:** `""`

--- a/roles/wazuh-agent/defaults/main.yml
+++ b/roles/wazuh-agent/defaults/main.yml
@@ -3,3 +3,8 @@
 wazuh_agent_package_download_path: "/tmp/wazuh-agent"
 wazuh_agent_win_package_download_path: "C:\\Temp\\wazuh-agent"
 wazuh_agent_package_name: "wazuh-agent-{{ wazuh_full_version }}-{{ wazuh_package_revision }}"
+
+# Optional, RC1+. Full connection URL for the manager (host[:port][/path]),
+# maps to the WAZUH_MANAGER_ENDPOINT install-time variable. Empty keeps this
+# role on the legacy wazuh_manager_address/WAZUH_MANAGER path.
+wazuh_manager_endpoint: ""

--- a/roles/wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh-agent/tasks/Linux.yml
@@ -6,6 +6,14 @@
     state: directory
     mode: '0755'
 
+- name: Linux | Build install-time environment for the Wazuh agent
+  ansible.builtin.set_fact:
+    wazuh_agent_install_env: >-
+      {{
+        {'WAZUH_MANAGER': wazuh_manager_address, 'WAZUH_REGISTRATION_PASSWORD': wazuh_registration_password}
+        | combine({'WAZUH_MANAGER_ENDPOINT': wazuh_manager_endpoint} if (wazuh_manager_endpoint | default('') | length > 0) else {})
+      }}
+
 - name: Linux CentOS/RedHat | Importing tasks for RHEL-based systems
   ansible.builtin.include_tasks:
     file: "RedHat.yml"
@@ -21,9 +29,7 @@
     name: "{{ wazuh_agent_package_download_path }}/{{ wazuh_agent_package_name }}_{{ ansible_facts.architecture }}.rpm"
     state: present
     disable_gpg_check: true
-  environment:
-    WAZUH_MANAGER: "{{ wazuh_manager_address }}"
-    WAZUH_REGISTRATION_PASSWORD: "{{ wazuh_registration_password }}"
+  environment: "{{ wazuh_agent_install_env }}"
   when:
     - ansible_facts.os_family == "RedHat"
 
@@ -31,9 +37,7 @@
   ansible.builtin.apt:
     deb: "{{ wazuh_agent_package_download_path }}/{{ wazuh_agent_package_name }}_{{ ansible_facts.architecture }}.deb"
     state: present
-  environment:
-    WAZUH_MANAGER: "{{ wazuh_manager_address }}"
-    WAZUH_REGISTRATION_PASSWORD: "{{ wazuh_registration_password }}"
+  environment: "{{ wazuh_agent_install_env }}"
   when:
     - ansible_facts.os_family == "Debian"
 

--- a/roles/wazuh-agent/tasks/Windows.yml
+++ b/roles/wazuh-agent/tasks/Windows.yml
@@ -10,10 +10,17 @@
     url: "{{ wazuh_agent_windows }}"
     dest: "{{ wazuh_agent_win_package_download_path }}\\{{ wazuh_agent_package_name }}.msi"
 
+- name: Windows | Build install-time arguments for the Wazuh agent
+  ansible.builtin.set_fact:
+    wazuh_agent_install_args: >-
+      /q WAZUH_MANAGER="{{ wazuh_manager_address }}"
+      WAZUH_REGISTRATION_PASSWORD="{{ wazuh_registration_password }}"
+      {% if wazuh_manager_endpoint | default('') | length > 0 %}WAZUH_MANAGER_ENDPOINT="{{ wazuh_manager_endpoint }}"{% endif %}
+
 - name: Windows | Install Wazuh agent
   ansible.windows.win_package:
     path: "{{ wazuh_agent_win_package_download_path }}\\{{ wazuh_agent_package_name }}.msi"
-    arguments: '/q WAZUH_MANAGER="{{ wazuh_manager_address }}" WAZUH_REGISTRATION_PASSWORD="{{ wazuh_registration_password }}"'
+    arguments: "{{ wazuh_agent_install_args }}"
     state: present
 
 - name: Windows | Stop Wazuh agent service (if already running)

--- a/roles/wazuh-agent/tasks/macOS.yml
+++ b/roles/wazuh-agent/tasks/macOS.yml
@@ -27,6 +27,9 @@
     content: |
       WAZUH_MANAGER="{{ wazuh_manager_address }}"
       WAZUH_REGISTRATION_PASSWORD="{{ wazuh_registration_password }}"
+      {% if wazuh_manager_endpoint | default('') | length > 0 %}
+      WAZUH_MANAGER_ENDPOINT="{{ wazuh_manager_endpoint }}"
+      {% endif %}
     dest: /tmp/wazuh_envs
     mode: '0644'
 


### PR DESCRIPTION
Draft, not ready to merge — adds optional wazuh_manager_endpoint support ahead of wazuh/wazuh#38624, untestable end-to-end until upstream lands; see wazuh-ansible#2267 for full analysis.