### PR TITLE
Fixed 'Prior version' heading to 'Prior versions' in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,6 @@
 | [#2056](https://github.com/wazuh/wazuh-ansible/issues/2056) | No idempotency for the `opensearch.yml` configurations |
 
 
-## Prior version
+## Prior versions
 
 - []()


### PR DESCRIPTION
## Related issue #2272 

## Description 

Audited CHANGELOG.md's `[v5.0.0]` section after the version was bumped
to `beta5` (VERSION.json already updated by the separate bump task).
Found the "Prior versions" heading was still singular ("Prior version").

Rest of the `[v5.0.0]` section (Added/Changed/Removed/Fixed) reviewed
and found complete and correctly formatted — no other changes needed.