### PR TITLE
Pass the manager CA to the agent install (verification_mode now enforced by default)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#2278](https://github.com/wazuh/wazuh-ansible/issues/2278) | Pass the manager CA to the agent install (verification_mode now enforced by default) |
 | [#2267](https://github.com/wazuh/wazuh-ansible/issues/2267) | Add optional wazuh_manager_endpoint support to wazuh-agent role |
 | [#2173](https://github.com/wazuh/wazuh-ansible/pull/2173) | Added bump-issue-link support for Revert Stage Bump. |
 | [#2166](https://github.com/wazuh/wazuh-ansible/pull/2166) | Add integration test module docs |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 | Issue | Comment |
 | - | - |
-| [#2278](https://github.com/wazuh/wazuh-ansible/issues/2278) | Pass the manager CA to the agent install (verification_mode now enforced by default) |
+| [#2278](https://github.com/wazuh/wazuh-ansible/issues/2278) | Provision the manager CA and TLS verification mode for the agent install, and verify the CA was applied |
 | [#2267](https://github.com/wazuh/wazuh-ansible/issues/2267) | Add optional wazuh_manager_endpoint support to wazuh-agent role |
 | [#2173](https://github.com/wazuh/wazuh-ansible/pull/2173) | Added bump-issue-link support for Revert Stage Bump. |
 | [#2166](https://github.com/wazuh/wazuh-ansible/pull/2166) | Add integration test module docs |

--- a/docs/ref/roles/wazuh-agent.md
+++ b/docs/ref/roles/wazuh-agent.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-The `wazuh-agent` role installs the Wazuh Agent on target nodes running Linux, Windows, or macOS.
+The `wazuh-agent` role installs the Wazuh Agent on target nodes running Linux, Windows, or macOS, and provisions the manager's CA certificate so the agent can verify the manager's TLS certificate.
 
 The role detects the target operating system at runtime and delegates to the appropriate platform-specific task file (`Linux.yml`, `Windows.yml`, or `macOS.yml`). On Linux, it further delegates to either `RedHat.yml` or `Debian.yml` depending on the OS family.
 
@@ -11,6 +11,7 @@ The role detects the target operating system at runtime and delegates to the app
 | Task | Description |
 |------|-------------|
 | Import variables | Loads shared variables from `vars/main.yml` and `vars/artifact_urls.yaml`. |
+| Validate variables | Imports `validate.yml`, which checks `wazuh_registration_ca` and `wazuh_ssl_verification` before anything is installed. |
 | Linux tasks | Imports `Linux.yml` when the target system is Linux, which in turn imports the appropriate distribution-specific tasks. |
 | Windows tasks | Imports `Windows.yml` when the target OS family is Windows. |
 | macOS tasks | Imports `macOS.yml` when the target system is Darwin (macOS). |
@@ -24,6 +25,28 @@ On **Linux (Debian-based)**, the role downloads and installs the `.deb` package 
 On **Windows**, the role downloads and installs the `.msi` package using the Windows package manager.
 
 On **macOS**, the role downloads and installs the `.pkg` package for either ARM64 (Apple Silicon) or Intel64 architectures.
+
+## CA provisioning
+
+When `wazuh_registration_ca` is set, the role copies that CA certificate to the target node **before** installing the package, and passes the remote path to the installer as the `WAZUH_REGISTRATION_CA` install-time variable. The installer pins the path into `<agent><ssl><certificate_authorities>` in `ossec.conf`, which governs all agent↔manager HTTPS traffic and is read on every agent start.
+
+Three properties of this flow are worth knowing before changing these tasks:
+
+- **The copy must stay ahead of the install.** The agent's installer script rejects a missing or unreadable `WAZUH_REGISTRATION_CA` path, only writes a line to its own log, and still exits `0`. A CA copied after the package install would therefore never be pinned, silently.
+- **The destination is the agent's own CA drop-in path**, not a temporary one: `/var/ossec/etc/certs/root-ca.pem` on Linux, `/Library/Ossec/etc/certs/root-ca.pem` on macOS, and `<install dir>\certs\root-ca.pem` on Windows. This is the location the agent's own upgrade path looks for, so the same file also satisfies a later WPK upgrade against a self-signed manager, and it is removed when the agent is uninstalled. The role creates the directory, since it does not exist before the package install.
+- **The result is verified.** After the install, the role reads `ossec.conf` back and asserts that `<certificate_authorities>` holds the expected path (`wazuh_agent_verify_registration_ca`, default `true`). Both ways this can fail are otherwise silent — see below.
+
+`wazuh_ssl_verification` maps to the `SSL_VERIFICATION` install-time variable and sets `<agent><ssl><verification_mode>` explicitly. Left empty, the effective mode is `certificate` when a CA is provisioned, which validates the certificate chain but does **not** check the manager's hostname; `full` adds the hostname check, and `none` disables verification for lab and CI deployments. `system` cannot be combined with `wazuh_registration_ca` — the agent refuses to start with both set — and the role rejects that combination up front.
+
+### Existing agents are not reconfigured
+
+**The role only wires the CA on a fresh install.** Adding `wazuh_registration_ca` to the inventory and re-running the playbook against agents that are already installed does not configure them: `apt`, `dnf` and `win_package` all skip an install that is already satisfied, and the macOS path is explicitly guarded on `pkgutil`, so the installer script that writes `<certificate_authorities>` never runs. The CA file is copied and the play reports success regardless.
+
+The post-install assertion is what makes this visible instead of silent. To remediate an existing agent, either remove the agent and re-run this role, or add the tag to `ossec.conf` by hand inside `<agent><ssl>` and restart the agent:
+
+```xml
+<certificate_authorities>/var/ossec/etc/certs/root-ca.pem</certificate_authorities>
+```
 
 ## Usage
 

--- a/docs/ref/variables.md
+++ b/docs/ref/variables.md
@@ -267,5 +267,29 @@ These variables are defined in `roles/wazuh-agent/defaults/main.yml`.
 ---
 
 **Variable:** `wazuh_registration_ca`  
-**Description:** Optional. Local path (Ansible control node) to a CA certificate file used to verify the manager's TLS certificate during agent enrollment. The role copies it to the target node and passes it as the `WAZUH_REGISTRATION_CA` install-time variable. Required when the manager presents a self-signed or private CA — with `verification_mode` now enforced by default (see [wazuh/wazuh#38786](https://github.com/wazuh/wazuh/pull/38786)), an agent installed without this variable against such a manager fails closed instead of connecting insecurely.  
+**Description:** Optional. **Absolute** path on the Ansible control node to the CA certificate that signed the manager's TLS certificate. Must be a CA certificate, not a bundle carrying a private key: the file is copied to the target world-readable so the agent daemons can read it. The role copies it to the target node *before* installing the package and passes the remote path as the `WAZUH_REGISTRATION_CA` install-time variable; the installer pins that path into `<agent><ssl><certificate_authorities>`, which governs **all** agent↔manager HTTPS traffic, not just enrollment, and also flips the effective `verification_mode` to `certificate` (see `wazuh_ssl_verification` below — `certificate` validates the certificate chain but does **not** check the manager's hostname). Note that `<enrollment><server_ca_path>`, which the installer also writes, is parsed but ignored by the 5.x agent. Required when the manager presents a self-signed or private CA — with `verification_mode` now enforced by default (see [wazuh/wazuh#38786](https://github.com/wazuh/wazuh/pull/38786)), an agent installed without this variable against such a manager fails closed instead of connecting insecurely. The copied file is a permanent runtime dependency: `wazuh-agentd` reads it on **every** start and refuses to start when it is missing, so it must stay on the node for the life of the install. A relative path is resolved against the role's own `files/` directory by `ansible.builtin.copy`, so the role asserts up front that the value is an absolute path to a regular file on the control node.  
 **Default value:** `""`
+
+---
+
+**Variable:** `wazuh_ssl_verification`  
+**Description:** Optional. Agent TLS verification posture, mapped to the `SSL_VERIFICATION` install-time variable ([wazuh/wazuh#38786](https://github.com/wazuh/wazuh/pull/38786)) and written to `<agent><ssl><verification_mode>`. One of `full` (verify against the CA **and** check the manager's hostname), `certificate` (verify against the CA only), `system` (trust the OS store) or `none` (no verification, for lab/CI against a self-signed manager with no CA to hand). Empty leaves the tag unset, which resolves to `certificate` when `wazuh_registration_ca` is set and `system` when it is not. Set `full` on a manager whose certificate carries proper SANs. `system` cannot be combined with `wazuh_registration_ca` — the agent refuses to start with both configured — and the role asserts this rather than letting the installer silently drop the CA.  
+**Default value:** `""`
+
+---
+
+**Variable:** `wazuh_registration_ca_remote_path` / `wazuh_registration_ca_macos_remote_path` / `wazuh_registration_ca_win_remote_path`  
+**Description:** Where the role places `wazuh_registration_ca` on the target node, per platform. These are the CA drop-in locations the agent itself documents (`pkg_installer.sh` on Linux/macOS, `do_upgrade.ps1` on Windows), so one file serves both the install-time pin and the CA a later WPK upgrade looks for, and it is removed when the agent is uninstalled. Derived from `wazuh_agent_install_path`, `wazuh_agent_macos_install_path` and `wazuh_agent_win_install_path` respectively, so overriding a non-default install prefix is enough.  
+**Default value:** `/var/ossec/etc/certs/root-ca.pem`, `/Library/Ossec/etc/certs/root-ca.pem`, `<ProgramFiles(x86)>\ossec-agent\certs\root-ca.pem`
+
+---
+
+**Variable:** `wazuh_agent_verify_registration_ca`  
+**Description:** Whether to assert, after the install, that the CA really was pinned into `ossec.conf`. Only runs when `wazuh_registration_ca` is set. The check exists because both relevant failure modes are otherwise completely silent: the installer logs its own failures to pin the CA to `ossec.log` and still exits `0`, and a package install skipped on an already-installed agent never runs the installer at all — in both cases the package manager, the service start and the whole play report success while the agent has no CA configured and can never enroll. Set to `false` to skip the check.  
+**Default value:** `true`
+
+---
+
+**Variable:** `wazuh_agent_install_path` / `wazuh_agent_macos_install_path` / `wazuh_agent_win_install_path`  
+**Description:** Agent installation directory per platform. Used to resolve the CA drop-in locations above and the `ossec.conf` the post-install check reads.  
+**Default value:** `/var/ossec`, `/Library/Ossec`, `{{ ansible_facts.env['ProgramFiles(x86)'] }}\ossec-agent`

--- a/docs/ref/variables.md
+++ b/docs/ref/variables.md
@@ -263,3 +263,9 @@ These variables are defined in `roles/wazuh-agent/defaults/main.yml`.
 **Variable:** `wazuh_manager_endpoint`  
 **Description:** Optional. Full connection URL for the manager (`host[:port][/path]`), maps to the `WAZUH_MANAGER_ENDPOINT` install-time variable. Added ahead of [wazuh/wazuh#38624](https://github.com/wazuh/wazuh/issues/38624), which will replace `WAZUH_MANAGER`/`WAZUH_MANAGER_PORT` with this single variable at RC1. Empty keeps the role on the legacy `wazuh_manager_address`/`WAZUH_MANAGER` path.  
 **Default value:** `""`
+
+---
+
+**Variable:** `wazuh_registration_ca`  
+**Description:** Optional. Local path (Ansible control node) to a CA certificate file used to verify the manager's TLS certificate during agent enrollment. The role copies it to the target node and passes it as the `WAZUH_REGISTRATION_CA` install-time variable. Required when the manager presents a self-signed or private CA — with `verification_mode` now enforced by default (see [wazuh/wazuh#38786](https://github.com/wazuh/wazuh/pull/38786)), an agent installed without this variable against such a manager fails closed instead of connecting insecurely.  
+**Default value:** `""`

--- a/roles/wazuh-agent/defaults/main.yml
+++ b/roles/wazuh-agent/defaults/main.yml
@@ -4,15 +4,58 @@ wazuh_agent_package_download_path: "/tmp/wazuh-agent"
 wazuh_agent_win_package_download_path: "C:\\Temp\\wazuh-agent"
 wazuh_agent_package_name: "wazuh-agent-{{ wazuh_full_version }}-{{ wazuh_package_revision }}"
 
+# Agent installation directory per platform. Used to resolve the CA drop-in
+# location and ossec.conf below, so overriding a non-default install prefix in
+# one place is enough. The Windows MSI is 32-bit, so on a 64-bit host it lands
+# under the x86 Program Files.
+wazuh_agent_install_path: "/var/ossec"
+wazuh_agent_macos_install_path: "/Library/Ossec"
+wazuh_agent_win_install_path: >-
+  {{ ansible_facts.env['ProgramFiles(x86)'] | default('C:\Program Files (x86)', true) }}\ossec-agent
+
 # Optional, RC1+. Full connection URL for the manager (host[:port][/path]),
 # maps to the WAZUH_MANAGER_ENDPOINT install-time variable. Empty keeps this
 # role on the legacy wazuh_manager_address/WAZUH_MANAGER path.
 wazuh_manager_endpoint: ""
 
-# Optional. Local path (Ansible control node) to a CA certificate file used to
-# verify the manager's TLS certificate during agent enrollment/registration.
-# The role copies it to the target node and passes it as the
-# WAZUH_REGISTRATION_CA install-time variable. Required when the manager
-# presents a self-signed or private CA, per verification_mode now being
-# enforced by default (wazuh/wazuh#38786). Empty skips CA provisioning.
+# Optional. Absolute path on the Ansible control node to the CA certificate
+# that signed the manager's TLS certificate (a certificate, never a bundle
+# carrying a private key: the file is copied world-readable so the agent
+# daemons can read it). The role copies it to the target node *before* the
+# package install and passes the remote path as the WAZUH_REGISTRATION_CA
+# install-time variable, which the installer pins into
+# <agent><ssl><certificate_authorities>. That tag governs all agent-to-manager
+# HTTPS traffic, not just enrollment, and is read on every agent start, so the
+# copied file must stay on the node for the life of the install.
+#
+# Required when the manager presents a self-signed or private CA: since
+# wazuh/wazuh#38786 the agent enforces certificate verification, so an agent
+# installed without this variable against such a manager fails closed. Empty
+# skips CA provisioning entirely.
 wazuh_registration_ca: ""
+
+# Optional. Agent TLS verification posture, mapped to the SSL_VERIFICATION
+# install-time variable and written to <agent><ssl><verification_mode>. One of:
+#   full        - verify against the CA *and* check the manager's hostname
+#   certificate - verify against the CA only (no hostname check)
+#   system      - trust the OS store; cannot be combined with a CA
+#   none        - no verification (lab/CI against a self-signed manager)
+# Empty leaves the tag unset, which resolves to 'certificate' when
+# wazuh_registration_ca is set and 'system' when it is not.
+wazuh_ssl_verification: ""
+
+# Where the role places wazuh_registration_ca on the target node. This is the
+# drop-in location the agent itself documents (pkg_installer.sh on Linux/macOS,
+# do_upgrade.ps1 on Windows), so the same file serves both the install-time pin
+# and the CA a later WPK upgrade looks for, and it is removed when the agent is
+# uninstalled.
+wazuh_registration_ca_remote_path: "{{ wazuh_agent_install_path }}/etc/certs/root-ca.pem"
+wazuh_registration_ca_macos_remote_path: "{{ wazuh_agent_macos_install_path }}/etc/certs/root-ca.pem"
+wazuh_registration_ca_win_remote_path: "{{ wazuh_agent_win_install_path }}\\certs\\root-ca.pem"
+
+# Assert after the install that the CA really was pinned into ossec.conf. The
+# installer only logs its own failures to pin it and still exits 0, and a
+# package install skipped on an already-installed agent never runs the
+# installer at all, so without this check both outcomes are a green play and an
+# agent that can never enroll. Only runs when wazuh_registration_ca is set.
+wazuh_agent_verify_registration_ca: true

--- a/roles/wazuh-agent/defaults/main.yml
+++ b/roles/wazuh-agent/defaults/main.yml
@@ -8,3 +8,11 @@ wazuh_agent_package_name: "wazuh-agent-{{ wazuh_full_version }}-{{ wazuh_package
 # maps to the WAZUH_MANAGER_ENDPOINT install-time variable. Empty keeps this
 # role on the legacy wazuh_manager_address/WAZUH_MANAGER path.
 wazuh_manager_endpoint: ""
+
+# Optional. Local path (Ansible control node) to a CA certificate file used to
+# verify the manager's TLS certificate during agent enrollment/registration.
+# The role copies it to the target node and passes it as the
+# WAZUH_REGISTRATION_CA install-time variable. Required when the manager
+# presents a self-signed or private CA, per verification_mode now being
+# enforced by default (wazuh/wazuh#38786). Empty skips CA provisioning.
+wazuh_registration_ca: ""

--- a/roles/wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh-agent/tasks/Linux.yml
@@ -6,12 +6,25 @@
     state: directory
     mode: '0755'
 
+- name: Linux | Set the remote path for the registration CA certificate
+  ansible.builtin.set_fact:
+    wazuh_registration_ca_remote_path: "{{ wazuh_agent_package_download_path }}/registration-ca.pem"
+  when: wazuh_registration_ca | default('') | length > 0
+
+- name: Linux | Copy registration CA certificate to the target node
+  ansible.builtin.copy:
+    src: "{{ wazuh_registration_ca }}"
+    dest: "{{ wazuh_registration_ca_remote_path }}"
+    mode: '0644'
+  when: wazuh_registration_ca | default('') | length > 0
+
 - name: Linux | Build install-time environment for the Wazuh agent
   ansible.builtin.set_fact:
     wazuh_agent_install_env: >-
       {{
         {'WAZUH_MANAGER': wazuh_manager_address, 'WAZUH_REGISTRATION_PASSWORD': wazuh_registration_password}
         | combine({'WAZUH_MANAGER_ENDPOINT': wazuh_manager_endpoint} if (wazuh_manager_endpoint | default('') | length > 0) else {})
+        | combine({'WAZUH_REGISTRATION_CA': wazuh_registration_ca_remote_path} if (wazuh_registration_ca | default('') | length > 0) else {})
       }}
 
 - name: Linux CentOS/RedHat | Importing tasks for RHEL-based systems

--- a/roles/wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh-agent/tasks/Linux.yml
@@ -8,7 +8,7 @@
 
 - name: Linux | Set the remote path for the registration CA certificate
   ansible.builtin.set_fact:
-    wazuh_registration_ca_remote_path: "{{ wazuh_agent_package_download_path }}/registration-ca.pem"
+    wazuh_registration_ca_remote_path: "/etc/wazuh-registration-ca.pem"
   when: wazuh_registration_ca | default('') | length > 0
 
 - name: Linux | Copy registration CA certificate to the target node

--- a/roles/wazuh-agent/tasks/Linux.yml
+++ b/roles/wazuh-agent/tasks/Linux.yml
@@ -6,15 +6,26 @@
     state: directory
     mode: '0755'
 
-- name: Linux | Set the remote path for the registration CA certificate
-  ansible.builtin.set_fact:
-    wazuh_registration_ca_remote_path: "/etc/wazuh-registration-ca.pem"
+# The CA must be on disk *before* the package install: the agent's installer
+# script (register_configure_agent.sh) rejects a missing or unreadable
+# WAZUH_REGISTRATION_CA path, only logs it and still exits 0, so a CA copied
+# after the install would silently never be pinned into ossec.conf. Do not move
+# these two tasks below the install tasks.
+- name: Linux | Create the certificate directory for the manager CA
+  ansible.builtin.file:
+    path: "{{ wazuh_registration_ca_remote_path | dirname }}"
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
   when: wazuh_registration_ca | default('') | length > 0
 
-- name: Linux | Copy registration CA certificate to the target node
+- name: Linux | Copy the manager CA certificate to the target node
   ansible.builtin.copy:
     src: "{{ wazuh_registration_ca }}"
     dest: "{{ wazuh_registration_ca_remote_path }}"
+    owner: root
+    group: root
     mode: '0644'
   when: wazuh_registration_ca | default('') | length > 0
 
@@ -25,6 +36,7 @@
         {'WAZUH_MANAGER': wazuh_manager_address, 'WAZUH_REGISTRATION_PASSWORD': wazuh_registration_password}
         | combine({'WAZUH_MANAGER_ENDPOINT': wazuh_manager_endpoint} if (wazuh_manager_endpoint | default('') | length > 0) else {})
         | combine({'WAZUH_REGISTRATION_CA': wazuh_registration_ca_remote_path} if (wazuh_registration_ca | default('') | length > 0) else {})
+        | combine({'SSL_VERIFICATION': wazuh_ssl_verification} if (wazuh_ssl_verification | default('') | length > 0) else {})
       }}
 
 - name: Linux CentOS/RedHat | Importing tasks for RHEL-based systems
@@ -53,6 +65,24 @@
   environment: "{{ wazuh_agent_install_env }}"
   when:
     - ansible_facts.os_family == "Debian"
+
+- name: Linux | Verify the manager CA was pinned into the agent configuration
+  when:
+    - wazuh_registration_ca | default('') | length > 0
+    - wazuh_agent_verify_registration_ca | bool
+  block:
+    - name: Linux | Read the agent configuration file
+      ansible.builtin.slurp:
+        src: "{{ wazuh_agent_install_path }}/etc/ossec.conf"
+      register: wazuh_agent_ossec_conf_raw
+
+    - name: Linux | Assert the manager CA is configured
+      ansible.builtin.include_tasks:
+        file: "verify_registration_ca.yml"
+      vars:
+        wazuh_agent_ossec_conf_path: "{{ wazuh_agent_install_path }}/etc/ossec.conf"
+        wazuh_agent_ossec_log_path: "{{ wazuh_agent_install_path }}/logs/ossec.log"
+        wazuh_agent_ca_expected_path: "{{ wazuh_registration_ca_remote_path }}"
 
 - name: Linux | Start and enable Wazuh Agent service
   block:

--- a/roles/wazuh-agent/tasks/Windows.yml
+++ b/roles/wazuh-agent/tasks/Windows.yml
@@ -7,7 +7,7 @@
 
 - name: Windows | Set the remote path for the registration CA certificate
   ansible.builtin.set_fact:
-    wazuh_registration_ca_remote_path: "{{ wazuh_agent_win_package_download_path }}\\registration-ca.pem"
+    wazuh_registration_ca_remote_path: "C:\\ProgramData\\wazuh-registration-ca.pem"
   when: wazuh_registration_ca | default('') | length > 0
 
 - name: Windows | Copy registration CA certificate to the target node

--- a/roles/wazuh-agent/tasks/Windows.yml
+++ b/roles/wazuh-agent/tasks/Windows.yml
@@ -5,15 +5,21 @@
     path: "{{ wazuh_agent_win_package_download_path }}"
     state: directory
 
-- name: Windows | Set the remote path for the registration CA certificate
-  ansible.builtin.set_fact:
-    wazuh_registration_ca_remote_path: "C:\\ProgramData\\wazuh-registration-ca.pem"
+# Copied before the install for the same reason as on Linux: InstallerScripts.vbs
+# checks the WAZUH_REGISTRATION_CA path with FileExists(), and on a miss only
+# writes a line to the install log. Placed under the agent's install directory,
+# which is both the drop-in path do_upgrade.ps1 looks for and a location the
+# uninstaller removes. Do not move below the install task.
+- name: Windows | Create the certificate directory for the manager CA
+  ansible.windows.win_file:
+    path: "{{ wazuh_registration_ca_win_remote_path | win_dirname }}"
+    state: directory
   when: wazuh_registration_ca | default('') | length > 0
 
-- name: Windows | Copy registration CA certificate to the target node
+- name: Windows | Copy the manager CA certificate to the target node
   ansible.windows.win_copy:
     src: "{{ wazuh_registration_ca }}"
-    dest: "{{ wazuh_registration_ca_remote_path }}"
+    dest: "{{ wazuh_registration_ca_win_remote_path }}"
   when: wazuh_registration_ca | default('') | length > 0
 
 - name: Windows | Download Wazuh agent installer
@@ -21,19 +27,40 @@
     url: "{{ wazuh_agent_windows }}"
     dest: "{{ wazuh_agent_win_package_download_path }}\\{{ wazuh_agent_package_name }}.msi"
 
+# Each optional property emits its own leading space inside the {%- if -%}, so an
+# unset variable adds nothing at all rather than leaving a stray separator behind.
 - name: Windows | Build install-time arguments for the Wazuh agent
   ansible.builtin.set_fact:
     wazuh_agent_install_args: >-
       /q WAZUH_MANAGER="{{ wazuh_manager_address }}"
       WAZUH_REGISTRATION_PASSWORD="{{ wazuh_registration_password }}"
-      {% if wazuh_manager_endpoint | default('') | length > 0 %}WAZUH_MANAGER_ENDPOINT="{{ wazuh_manager_endpoint }}"{% endif %}
-      {% if wazuh_registration_ca | default('') | length > 0 %}WAZUH_REGISTRATION_CA="{{ wazuh_registration_ca_remote_path }}"{% endif %}
+      {%- if wazuh_manager_endpoint | default('') | length > 0 %} WAZUH_MANAGER_ENDPOINT="{{ wazuh_manager_endpoint }}"{% endif %}
+      {%- if wazuh_registration_ca | default('') | length > 0 %} WAZUH_REGISTRATION_CA="{{ wazuh_registration_ca_win_remote_path }}"{% endif %}
+      {%- if wazuh_ssl_verification | default('') | length > 0 %} SSL_VERIFICATION="{{ wazuh_ssl_verification }}"{% endif %}
 
 - name: Windows | Install Wazuh agent
   ansible.windows.win_package:
     path: "{{ wazuh_agent_win_package_download_path }}\\{{ wazuh_agent_package_name }}.msi"
     arguments: "{{ wazuh_agent_install_args }}"
     state: present
+
+- name: Windows | Verify the manager CA was pinned into the agent configuration
+  when:
+    - wazuh_registration_ca | default('') | length > 0
+    - wazuh_agent_verify_registration_ca | bool
+  block:
+    - name: Windows | Read the agent configuration file
+      ansible.windows.slurp:
+        src: "{{ wazuh_agent_win_install_path }}\\ossec.conf"
+      register: wazuh_agent_ossec_conf_raw
+
+    - name: Windows | Assert the manager CA is configured
+      ansible.builtin.include_tasks:
+        file: "verify_registration_ca.yml"
+      vars:
+        wazuh_agent_ossec_conf_path: "{{ wazuh_agent_win_install_path }}\\ossec.conf"
+        wazuh_agent_ossec_log_path: "{{ wazuh_agent_win_install_path }}\\ossec.log"
+        wazuh_agent_ca_expected_path: "{{ wazuh_registration_ca_win_remote_path }}"
 
 - name: Windows | Stop Wazuh agent service (if already running)
   ansible.windows.win_service:

--- a/roles/wazuh-agent/tasks/Windows.yml
+++ b/roles/wazuh-agent/tasks/Windows.yml
@@ -5,6 +5,17 @@
     path: "{{ wazuh_agent_win_package_download_path }}"
     state: directory
 
+- name: Windows | Set the remote path for the registration CA certificate
+  ansible.builtin.set_fact:
+    wazuh_registration_ca_remote_path: "{{ wazuh_agent_win_package_download_path }}\\registration-ca.pem"
+  when: wazuh_registration_ca | default('') | length > 0
+
+- name: Windows | Copy registration CA certificate to the target node
+  ansible.windows.win_copy:
+    src: "{{ wazuh_registration_ca }}"
+    dest: "{{ wazuh_registration_ca_remote_path }}"
+  when: wazuh_registration_ca | default('') | length > 0
+
 - name: Windows | Download Wazuh agent installer
   ansible.windows.win_get_url:
     url: "{{ wazuh_agent_windows }}"
@@ -16,6 +27,7 @@
       /q WAZUH_MANAGER="{{ wazuh_manager_address }}"
       WAZUH_REGISTRATION_PASSWORD="{{ wazuh_registration_password }}"
       {% if wazuh_manager_endpoint | default('') | length > 0 %}WAZUH_MANAGER_ENDPOINT="{{ wazuh_manager_endpoint }}"{% endif %}
+      {% if wazuh_registration_ca | default('') | length > 0 %}WAZUH_REGISTRATION_CA="{{ wazuh_registration_ca_remote_path }}"{% endif %}
 
 - name: Windows | Install Wazuh agent
   ansible.windows.win_package:

--- a/roles/wazuh-agent/tasks/macOS.yml
+++ b/roles/wazuh-agent/tasks/macOS.yml
@@ -8,7 +8,7 @@
 
 - name: MacOS | Set the remote path for the registration CA certificate
   ansible.builtin.set_fact:
-    wazuh_registration_ca_remote_path: "{{ wazuh_agent_package_download_path }}/registration-ca.pem"
+    wazuh_registration_ca_remote_path: "/etc/wazuh-registration-ca.pem"
   when: wazuh_registration_ca | default('') | length > 0
 
 - name: MacOS | Copy registration CA certificate to the target node

--- a/roles/wazuh-agent/tasks/macOS.yml
+++ b/roles/wazuh-agent/tasks/macOS.yml
@@ -6,15 +6,25 @@
     state: directory
     mode: '0755'
 
-- name: MacOS | Set the remote path for the registration CA certificate
-  ansible.builtin.set_fact:
-    wazuh_registration_ca_remote_path: "/etc/wazuh-registration-ca.pem"
+# Copied before the install for the same reason as on Linux: the installer only
+# logs an unreadable WAZUH_REGISTRATION_CA and exits 0. Also placed at the CA
+# drop-in path the agent's own upgrade path looks for, so it keeps working for
+# later WPK upgrades. Do not move below the install block.
+- name: MacOS | Create the certificate directory for the manager CA
+  ansible.builtin.file:
+    path: "{{ wazuh_registration_ca_macos_remote_path | dirname }}"
+    state: directory
+    owner: root
+    group: wheel
+    mode: '0755'
   when: wazuh_registration_ca | default('') | length > 0
 
-- name: MacOS | Copy registration CA certificate to the target node
+- name: MacOS | Copy the manager CA certificate to the target node
   ansible.builtin.copy:
     src: "{{ wazuh_registration_ca }}"
-    dest: "{{ wazuh_registration_ca_remote_path }}"
+    dest: "{{ wazuh_registration_ca_macos_remote_path }}"
+    owner: root
+    group: wheel
     mode: '0644'
   when: wazuh_registration_ca | default('') | length > 0
 
@@ -34,20 +44,6 @@
   when:
     - ansible_facts.architecture == "arm64"
 
-- name: MacOS | Create Wazuh environment variables file
-  ansible.builtin.copy:
-    content: |
-      WAZUH_MANAGER="{{ wazuh_manager_address }}"
-      WAZUH_REGISTRATION_PASSWORD="{{ wazuh_registration_password }}"
-      {% if wazuh_manager_endpoint | default('') | length > 0 %}
-      WAZUH_MANAGER_ENDPOINT="{{ wazuh_manager_endpoint }}"
-      {% endif %}
-      {% if wazuh_registration_ca | default('') | length > 0 %}
-      WAZUH_REGISTRATION_CA="{{ wazuh_registration_ca_remote_path }}"
-      {% endif %}
-    dest: /tmp/wazuh_envs
-    mode: '0644'
-
 - name: MacOS | Check installed packages
   ansible.builtin.command: "pkgutil --pkgs"
   register: installed_packages
@@ -61,6 +57,29 @@
 - name: MacOS | Install and load Wazuh agent
   when: not wazuh_agent_already_installed
   block:
+    # Written only on the install path, since the installer is the only thing
+    # that reads it, and mode 0600 because it carries the registration
+    # password. Removed again in `always` below: the installer deletes it
+    # itself on success, so this covers the failure paths.
+    - name: MacOS | Create Wazuh environment variables file
+      ansible.builtin.copy:
+        content: |
+          WAZUH_MANAGER="{{ wazuh_manager_address }}"
+          WAZUH_REGISTRATION_PASSWORD="{{ wazuh_registration_password }}"
+          {% if wazuh_manager_endpoint | default('') | length > 0 %}
+          WAZUH_MANAGER_ENDPOINT="{{ wazuh_manager_endpoint }}"
+          {% endif %}
+          {% if wazuh_registration_ca | default('') | length > 0 %}
+          WAZUH_REGISTRATION_CA="{{ wazuh_registration_ca_macos_remote_path }}"
+          {% endif %}
+          {% if wazuh_ssl_verification | default('') | length > 0 %}
+          SSL_VERIFICATION="{{ wazuh_ssl_verification }}"
+          {% endif %}
+        dest: /tmp/wazuh_envs
+        owner: root
+        group: wheel
+        mode: '0600'
+
     - name: MacOS | Install Wazuh agent using installer
       ansible.builtin.command: "installer -pkg {{ wazuh_agent_package_download_path }}/{{ wazuh_agent_package_name }}.pkg -target /"
       register: install_pkg
@@ -90,8 +109,32 @@
       ansible.builtin.command: /bin/sleep 5
       changed_when: false
 
+  always:
+    - name: MacOS | Remove the Wazuh environment variables file
+      ansible.builtin.file:
+        path: /tmp/wazuh_envs
+        state: absent
+
 - name: MacOS | Verify Wazuh agent service is running
   ansible.builtin.command: "launchctl print system/com.wazuh.agent"
   register: wazuh_agent_service_status
   failed_when: "'state = running' not in wazuh_agent_service_status.stdout"
   changed_when: false
+
+- name: MacOS | Verify the manager CA was pinned into the agent configuration
+  when:
+    - wazuh_registration_ca | default('') | length > 0
+    - wazuh_agent_verify_registration_ca | bool
+  block:
+    - name: MacOS | Read the agent configuration file
+      ansible.builtin.slurp:
+        src: "{{ wazuh_agent_macos_install_path }}/etc/ossec.conf"
+      register: wazuh_agent_ossec_conf_raw
+
+    - name: MacOS | Assert the manager CA is configured
+      ansible.builtin.include_tasks:
+        file: "verify_registration_ca.yml"
+      vars:
+        wazuh_agent_ossec_conf_path: "{{ wazuh_agent_macos_install_path }}/etc/ossec.conf"
+        wazuh_agent_ossec_log_path: "{{ wazuh_agent_macos_install_path }}/logs/ossec.log"
+        wazuh_agent_ca_expected_path: "{{ wazuh_registration_ca_macos_remote_path }}"

--- a/roles/wazuh-agent/tasks/macOS.yml
+++ b/roles/wazuh-agent/tasks/macOS.yml
@@ -6,6 +6,18 @@
     state: directory
     mode: '0755'
 
+- name: MacOS | Set the remote path for the registration CA certificate
+  ansible.builtin.set_fact:
+    wazuh_registration_ca_remote_path: "{{ wazuh_agent_package_download_path }}/registration-ca.pem"
+  when: wazuh_registration_ca | default('') | length > 0
+
+- name: MacOS | Copy registration CA certificate to the target node
+  ansible.builtin.copy:
+    src: "{{ wazuh_registration_ca }}"
+    dest: "{{ wazuh_registration_ca_remote_path }}"
+    mode: '0644'
+  when: wazuh_registration_ca | default('') | length > 0
+
 - name: MacOS (Intel) | Download Wazuh agent package
   ansible.builtin.get_url:
     url: "{{ wazuh_agent_macos_intel64 }}"
@@ -29,6 +41,9 @@
       WAZUH_REGISTRATION_PASSWORD="{{ wazuh_registration_password }}"
       {% if wazuh_manager_endpoint | default('') | length > 0 %}
       WAZUH_MANAGER_ENDPOINT="{{ wazuh_manager_endpoint }}"
+      {% endif %}
+      {% if wazuh_registration_ca | default('') | length > 0 %}
+      WAZUH_REGISTRATION_CA="{{ wazuh_registration_ca_remote_path }}"
       {% endif %}
     dest: /tmp/wazuh_envs
     mode: '0644'

--- a/roles/wazuh-agent/tasks/main.yml
+++ b/roles/wazuh-agent/tasks/main.yml
@@ -8,6 +8,10 @@
   ansible.builtin.include_vars:
     file: ../../vars/{{ urls_file }}
 
+- name: Validating the manager CA and TLS verification variables
+  ansible.builtin.include_tasks:
+    file: "validate.yml"
+
 - name: Linux | Importing tasks for Linux systems
   ansible.builtin.include_tasks:
     file: "Linux.yml"

--- a/roles/wazuh-agent/tasks/validate.yml
+++ b/roles/wazuh-agent/tasks/validate.yml
@@ -1,0 +1,46 @@
+---
+
+- name: Validate | Check the manager CA and TLS verification variables
+  when: (wazuh_registration_ca | default('') | length > 0) or (wazuh_ssl_verification | default('') | length > 0)
+  block:
+    - name: Validate | Assert wazuh_ssl_verification is a mode the agent accepts
+      ansible.builtin.assert:
+        that:
+          - wazuh_ssl_verification | default('') in ['', 'full', 'certificate', 'system', 'none']
+        fail_msg: >-
+          wazuh_ssl_verification must be exactly one of 'full', 'certificate', 'system' or 'none'
+          (got '{{ wazuh_ssl_verification }}'). The installer discards any other value and leaves
+          <verification_mode> unset instead of failing, so this is checked here.
+
+    - name: Validate | Assert a manager CA is not combined with 'system' verification
+      ansible.builtin.assert:
+        that:
+          - not ((wazuh_registration_ca | default('') | length > 0) and (wazuh_ssl_verification | default('') == 'system'))
+        fail_msg: >-
+          wazuh_ssl_verification is 'system' and wazuh_registration_ca is set. 'system' trusts the
+          OS trust store, not a configured CA, and the agent refuses to start with both set, so the
+          installer silently drops the CA. Either unset wazuh_registration_ca and import the CA into
+          the target's OS trust store, or use 'certificate' or 'full'.
+
+    - name: Validate | Stat the manager CA on the Ansible control node
+      ansible.builtin.stat:
+        path: "{{ wazuh_registration_ca }}"
+      delegate_to: localhost
+      become: false
+      register: wazuh_registration_ca_local
+      changed_when: false
+      when: wazuh_registration_ca | default('') | length > 0
+
+    - name: Validate | Assert the manager CA is a regular file on the control node
+      ansible.builtin.assert:
+        that:
+          - wazuh_registration_ca is match('/')
+          - wazuh_registration_ca_local.stat.exists
+          - wazuh_registration_ca_local.stat.isreg
+        fail_msg: >-
+          wazuh_registration_ca ('{{ wazuh_registration_ca }}') must be an absolute path to a CA
+          certificate file on the Ansible control node. A relative path is resolved against the
+          role's own files/ directory by ansible.builtin.copy, and a directory is copied
+          recursively, either of which leaves the agent with a <certificate_authorities> path the
+          installer cannot read.
+      when: wazuh_registration_ca | default('') | length > 0

--- a/roles/wazuh-agent/tasks/verify_registration_ca.yml
+++ b/roles/wazuh-agent/tasks/verify_registration_ca.yml
@@ -1,0 +1,33 @@
+---
+
+# Shared assert for all three platforms. The caller reads ossec.conf into
+# wazuh_agent_ossec_conf_raw and passes the paths it expects, because the module
+# that reads the file differs per platform.
+
+- name: Verify CA | Assert the manager CA was pinned into the agent configuration
+  ansible.builtin.assert:
+    that:
+      - wazuh_agent_ca_expected_path in configured_ca_paths
+    fail_msg: >-
+      The Wazuh agent installed, but <certificate_authorities> in
+      {{ wazuh_agent_ossec_conf_path }} is not set to {{ wazuh_agent_ca_expected_path }}
+      ({{ ('found ' ~ (configured_ca_paths | join(', '))) if (configured_ca_paths | length > 0) else 'the tag is absent' }}).
+      The agent therefore falls back to verification_mode 'system', which does not trust a private
+      CA, and will never enroll -- while the package install, the service start and this play all
+      still report success, which is why this is asserted. Two known causes:
+      (1) the agent was already installed, so the package manager skipped the install and the
+      installer script that writes the tag never ran. This role only wires the CA on a fresh
+      install: on an existing agent, either remove the agent and re-run this role, or add
+      <certificate_authorities>{{ wazuh_agent_ca_expected_path }}</certificate_authorities> inside
+      <agent><ssl> in ossec.conf by hand and restart the agent.
+      (2) the installer ran but discarded the CA. It logs the reason and exits 0 -- check
+      {{ wazuh_agent_ossec_log_path }} for the WAZUH_REGISTRATION_CA line (verification_mode
+      already explicitly 'system', the CA path unreadable at install time, or an existing <ssl>
+      block it could not edit).
+      Set wazuh_agent_verify_registration_ca to false to skip this check.
+    success_msg: >-
+      <certificate_authorities> is set to {{ wazuh_agent_ca_expected_path }} in
+      {{ wazuh_agent_ossec_conf_path }}.
+  vars:
+    ossec_conf_text: "{{ wazuh_agent_ossec_conf_raw.content | b64decode }}"
+    configured_ca_paths: "{{ ossec_conf_text | regex_findall('<certificate_authorities>\\s*(.*?)\\s*</certificate_authorities>') }}"

--- a/wazuh-agent.yml
+++ b/wazuh-agent.yml
@@ -6,6 +6,19 @@
   vars:
     wazuh_manager_address: "<Your Wazuh Manager IP>"
     wazuh_registration_password: "<Your Wazuh Manager Registration Password>"
+    # Absolute path on this control node to the CA that signed the manager's TLS
+    # certificate. Required whenever the manager uses a self-signed or private
+    # CA: the agent enforces certificate verification, so without it enrollment
+    # fails closed. The role copies it to the agent's own certs directory before
+    # installing the package, and asserts afterwards that the agent picked it up.
+    # Leave empty only for a manager whose certificate the target's OS trust
+    # store already verifies.
+    wazuh_registration_ca: ""
+    # Verification posture: full (CA + hostname), certificate (CA only), system
+    # (OS trust store, cannot be combined with wazuh_registration_ca) or none.
+    # Empty resolves to certificate when wazuh_registration_ca is set -- which
+    # does not check the manager's hostname -- and to system when it is not.
+    wazuh_ssl_verification: ""
   roles:
     - role: package-urls
   tasks:


### PR DESCRIPTION
Adds `wazuh_registration_ca` support to the `wazuh-agent` role so a manager with a self-signed/private CA can still enroll agents now that `verification_mode` is enforced by default (wazuh/wazuh#38786).

Draft — validated end-to-end twice against a real manager+agent pair, see comments on #2278 for evidence.

Closes #2278