### PR TITLE
Document default password change procedure for AIO and Distributed deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#2279](https://github.com/wazuh/wazuh-ansible/issues/2279) | Add documentation for the default password change procedure in AIO and Distributed deployments |
 | [#2267](https://github.com/wazuh/wazuh-ansible/issues/2267) | Add optional wazuh_manager_endpoint support to wazuh-agent role |
 | [#2173](https://github.com/wazuh/wazuh-ansible/pull/2173) | Added bump-issue-link support for Revert Stage Bump. |
 | [#2166](https://github.com/wazuh/wazuh-ansible/pull/2166) | Add integration test module docs |

--- a/docs/ref/deployment.md
+++ b/docs/ref/deployment.md
@@ -75,7 +75,7 @@ All components (Wazuh Indexer, Wazuh Manager, and Wazuh Dashboard) live on the s
 
 ```bash
   ssh <aio-node>
-  sudo bash wazuh-passwords-tool-5.0.0.sh -a -au wazuh -ap <current-wazuh-api-password>
+  sudo bash wazuh-passwords-tool.sh -a -au wazuh -ap <current-wazuh-api-password>
 ```
 
 - `-a` (`--change-all`) rotates every reserved Wazuh Indexer user with a random password.
@@ -90,7 +90,7 @@ In a distributed deployment, the Wazuh Indexer, Wazuh Manager, and Wazuh Dashboa
 
    ```bash
      ssh <indexer-node-1>
-     sudo bash wazuh-passwords-tool-5.0.0.sh -a
+     sudo bash wazuh-passwords-tool.sh -a
    ```
 
    Save every printed password, in particular the ones for `admin` and `kibanaserver`.
@@ -114,7 +114,7 @@ In a distributed deployment, the Wazuh Indexer, Wazuh Manager, and Wazuh Dashboa
 4. To also rotate the Wazuh server API users (`wazuh`, `wazuh-wui`), run the tool a second time on any node where the Wazuh Manager service is reachable, providing the current API admin credentials. `-a` is required together with `-au`/`-ap` — the tool rejects `-au`/`-ap` on their own — but on a node with no Wazuh Indexer installed it only rotates the API users:
 
    ```bash
-     sudo bash wazuh-passwords-tool-5.0.0.sh -a -au wazuh -ap <current-wazuh-api-password>
+     sudo bash wazuh-passwords-tool.sh -a -au wazuh -ap <current-wazuh-api-password>
    ```
 
 > This is a manual, one-time post-deployment step. It is not run automatically by the `wazuh-aio.yml` or `wazuh-distributed.yml` playbooks.

--- a/docs/ref/deployment.md
+++ b/docs/ref/deployment.md
@@ -62,3 +62,59 @@ For installing Wazuh Agents on one or more hosts, use the `wazuh-agent.yml` play
 ## Post-Deployment Steps
 
 After deployment, access the Wazuh Dashboard by navigating to `https://<WAZUH_DASHBOARD_IP_ADDRESS>` in your web browser. Use the [default credentials](https://documentation.wazuh.com/current/installation-guide/wazuh-dashboard/step-by-step.html#starting-the-wazuh-dashboard-service) to log in.
+
+### Change the default passwords
+
+The installation assistant sets default passwords for several Wazuh Indexer internal users (some equal to the username) and for the Wazuh server API users (`wazuh`, `wazuh-wui`). Change them right after deployment, using the `wazuh-passwords-tool.sh` script provided by the [Wazuh installation assistant](https://github.com/wazuh/wazuh-installation-assistant).
+
+> **Save every password printed by the tool.** They cannot be recovered afterwards. Use the new `admin` password to log in to the dashboard.
+
+#### AIO deployment
+
+All components (Wazuh Indexer, Wazuh Manager, and Wazuh Dashboard) live on the same node, so a single run of the passwords tool on that node rotates and propagates every password automatically:
+
+```bash
+  ssh <aio-node>
+  sudo bash wazuh-passwords-tool-5.0.0.sh -a -au wazuh -ap <current-wazuh-api-password>
+```
+
+- `-a` (`--change-all`) rotates every reserved Wazuh Indexer user with a random password.
+- `-au`/`-ap` additionally rotates the Wazuh server API users `wazuh` and `wazuh-wui` in the same run.
+- The tool updates the Wazuh Manager and Wazuh Dashboard keystores and restarts the affected services automatically — no manual step is needed on an AIO node.
+
+#### Distributed deployment
+
+In a distributed deployment, the Wazuh Indexer, Wazuh Manager, and Wazuh Dashboard nodes are separate hosts, so a single `--change-all` run cannot push the new passwords to the Manager/Dashboard keystores automatically — that update only happens for services installed locally on the node running the tool. Complete these steps instead:
+
+1. Run the tool on **one** Wazuh Indexer node to rotate every Wazuh Indexer user:
+
+   ```bash
+     ssh <indexer-node-1>
+     sudo bash wazuh-passwords-tool-5.0.0.sh -a
+   ```
+
+   Save every printed password, in particular the ones for `admin` and `kibanaserver`.
+
+2. On **each** Wazuh Manager node, update the indexer connection password in the keystore with the new value generated for the `wazuh-manager` user, then restart the service:
+
+   ```bash
+     ssh <manager-node>
+     sudo /var/wazuh-manager/bin/wazuh-manager-keystore -f indexer -k password -v '<new-wazuh-manager-password>'
+     sudo systemctl restart wazuh-manager
+   ```
+
+3. On the Wazuh Dashboard node, update the `opensearch.password` keystore entry with the new `kibanaserver` password, then restart the service:
+
+   ```bash
+     ssh <dashboard-node>
+     echo '<new-kibanaserver-password>' | sudo /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root add -f --stdin opensearch.password
+     sudo systemctl restart wazuh-dashboard
+   ```
+
+4. To also rotate the Wazuh server API users (`wazuh`, `wazuh-wui`), run the tool a second time on any node where the Wazuh Manager service is reachable, providing the current API admin credentials. `-a` is required together with `-au`/`-ap` — the tool rejects `-au`/`-ap` on their own — but on a node with no Wazuh Indexer installed it only rotates the API users:
+
+   ```bash
+     sudo bash wazuh-passwords-tool-5.0.0.sh -a -au wazuh -ap <current-wazuh-api-password>
+   ```
+
+> This is a manual, one-time post-deployment step. It is not run automatically by the `wazuh-aio.yml` or `wazuh-distributed.yml` playbooks.


### PR DESCRIPTION
Documents the post-deployment password change procedure for AIO and Distributed deployments, validated end-to-end against a real distributed cluster (see #2279 for the testing evidence). Closes #2279